### PR TITLE
feat: implement embedded default assets (defaults/ + embed.go)

### DIFF
--- a/defaults/config/defaults.yaml
+++ b/defaults/config/defaults.yaml
@@ -4,10 +4,10 @@
 site:
   title: "My Blog"
   description: "A blog powered by BlogFlow"
-  base_url: "http://localhost:8080"
+  base_url: "https://localhost:8080"
   language: "en"
   author:
-    name: "Blog Author"
+    name: ""
     email: ""
 
 content:

--- a/defaults/config/defaults.yaml
+++ b/defaults/config/defaults.yaml
@@ -1,0 +1,49 @@
+# BlogFlow default configuration
+# Override by placing site.yaml in /data/config/ or setting BLOGFLOW_* env vars
+
+site:
+  title: "My Blog"
+  description: "A blog powered by BlogFlow"
+  base_url: "http://localhost:8080"
+  language: "en"
+  author:
+    name: "Blog Author"
+    email: ""
+
+content:
+  posts_dir: "posts"
+  pages_dir: "pages"
+  media_dir: "media"
+  posts_per_page: 10
+  date_format: "January 2, 2006"
+  summary_length: 200
+
+theme:
+  name: "default"
+  path: ""
+
+server:
+  port: 8080
+  read_timeout: "5s"
+  write_timeout: "10s"
+  idle_timeout: "120s"
+
+cache:
+  enabled: true
+  ttl: "1h"
+  max_entries: 1000
+
+sync:
+  strategy: "watch"
+  webhook:
+    path: "/api/webhook"
+    allowed_events:
+      - push
+    branch_filter: "main"
+    ip_allowlist: true
+    rate_limit: 10
+
+feed:
+  enabled: true
+  type: "atom"
+  items: 20

--- a/defaults/config/defaults.yaml
+++ b/defaults/config/defaults.yaml
@@ -4,7 +4,7 @@
 site:
   title: "My Blog"
   description: "A blog powered by BlogFlow"
-  base_url: "https://localhost:8080"
+  base_url: "http://localhost:8080"  # Override in production with your actual HTTPS URL
   language: "en"
   author:
     name: ""
@@ -39,6 +39,7 @@ sync:
     path: "/api/webhook"
     allowed_events:
       - push
+    # secret: Set via BLOGFLOW_WEBHOOK_SECRET env var (never in YAML files)
     branch_filter: "main"
     ip_allowlist: true
     rate_limit: 10

--- a/defaults/content/pages/about.md
+++ b/defaults/content/pages/about.md
@@ -1,0 +1,8 @@
+---
+title: "About"
+slug: "about"
+---
+
+Welcome to my blog, powered by [BlogFlow](https://github.com/khaines/blogflow).
+
+BlogFlow is a compact, efficient blog engine where content is managed through Git. To customize this page, create your own `pages/about.md` in your content directory.

--- a/defaults/static/css/main.css
+++ b/defaults/static/css/main.css
@@ -1,0 +1,615 @@
+/* ==========================================================================
+   BlogFlow — Default Theme Stylesheet
+   Responsive, accessible, dark-mode-aware. No JavaScript required.
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Custom Properties (Light Mode)
+   -------------------------------------------------------------------------- */
+:root {
+    --bg: #ffffff;
+    --bg-secondary: #f8f9fa;
+    --text: #1a1a2e;
+    --text-secondary: #555770;
+    --accent: #2563eb;
+    --accent-hover: #1d4ed8;
+    --border: #e2e4e9;
+    --code-bg: #f1f3f5;
+    --code-text: #d6336c;
+    --blockquote-border: #2563eb;
+    --blockquote-bg: #f0f4ff;
+    --tag-bg: #e8edff;
+    --tag-text: #2563eb;
+    --shadow: rgba(0, 0, 0, 0.06);
+    --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+    --font-mono: ui-monospace, "Cascadia Code", "Source Code Pro",
+        Menlo, Consolas, "DejaVu Sans Mono", monospace;
+}
+
+/* --------------------------------------------------------------------------
+   2. Dark Mode
+   -------------------------------------------------------------------------- */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #16161a;
+        --bg-secondary: #1e1e24;
+        --text: #ececf1;
+        --text-secondary: #a0a0b0;
+        --accent: #60a5fa;
+        --accent-hover: #93c5fd;
+        --border: #2e2e38;
+        --code-bg: #1e1e24;
+        --code-text: #f0a8c0;
+        --blockquote-border: #60a5fa;
+        --blockquote-bg: #1a1f2e;
+        --tag-bg: #1e2a40;
+        --tag-text: #60a5fa;
+        --shadow: rgba(0, 0, 0, 0.3);
+    }
+}
+
+/* --------------------------------------------------------------------------
+   3. Reset & Base
+   -------------------------------------------------------------------------- */
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+html {
+    font-size: 100%;
+    -webkit-text-size-adjust: 100%;
+    scroll-behavior: smooth;
+}
+
+body {
+    font-family: var(--font-sans);
+    font-size: 1rem;
+    line-height: 1.6;
+    color: var(--text);
+    background-color: var(--bg);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+/* --------------------------------------------------------------------------
+   4. Accessibility
+   -------------------------------------------------------------------------- */
+.skip-link {
+    position: absolute;
+    top: -100%;
+    left: 1rem;
+    z-index: 1000;
+    padding: 0.5rem 1rem;
+    background: var(--accent);
+    color: #fff;
+    border-radius: 0 0 0.25rem 0.25rem;
+    text-decoration: none;
+}
+
+.skip-link:focus {
+    top: 0;
+}
+
+:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+/* --------------------------------------------------------------------------
+   5. Layout
+   -------------------------------------------------------------------------- */
+.site-header,
+main,
+.site-footer {
+    width: 100%;
+    max-width: 48rem;
+    margin-inline: auto;
+    padding-inline: 1.5rem;
+}
+
+main {
+    flex: 1;
+    padding-block: 2rem;
+}
+
+/* --------------------------------------------------------------------------
+   6. Header
+   -------------------------------------------------------------------------- */
+.site-header {
+    padding-block: 1.25rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.site-nav {
+    display: flex;
+    align-items: center;
+}
+
+.site-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--text);
+    text-decoration: none;
+}
+
+.site-title:hover {
+    color: var(--accent);
+}
+
+/* --------------------------------------------------------------------------
+   7. Footer
+   -------------------------------------------------------------------------- */
+.site-footer {
+    padding-block: 1.5rem;
+    border-top: 1px solid var(--border);
+    text-align: center;
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+}
+
+.site-footer a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.site-footer a:hover {
+    text-decoration: underline;
+}
+
+/* --------------------------------------------------------------------------
+   8. Post Content
+   -------------------------------------------------------------------------- */
+.post-content,
+.page-content {
+    max-width: 65ch;
+}
+
+.post-content > * + *,
+.page-content > * + * {
+    margin-top: 1.25rem;
+}
+
+.post-content h2,
+.page-content h2 {
+    font-size: 1.5rem;
+    margin-top: 2.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.post-content h3,
+.page-content h3 {
+    font-size: 1.25rem;
+    margin-top: 2rem;
+    margin-bottom: 0.5rem;
+}
+
+.post-content h4,
+.page-content h4 {
+    font-size: 1.1rem;
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.post-content a,
+.page-content a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+
+.post-content a:hover,
+.page-content a:hover {
+    color: var(--accent-hover);
+}
+
+/* Lists */
+.post-content ul,
+.post-content ol,
+.page-content ul,
+.page-content ol {
+    padding-left: 1.5rem;
+}
+
+.post-content li + li,
+.page-content li + li {
+    margin-top: 0.25rem;
+}
+
+/* Blockquotes */
+.post-content blockquote,
+.page-content blockquote {
+    border-left: 3px solid var(--blockquote-border);
+    background: var(--blockquote-bg);
+    padding: 0.75rem 1rem;
+    border-radius: 0 0.25rem 0.25rem 0;
+    color: var(--text-secondary);
+}
+
+/* Inline code */
+.post-content code,
+.page-content code {
+    font-family: var(--font-mono);
+    font-size: 0.875em;
+    background: var(--code-bg);
+    color: var(--code-text);
+    padding: 0.125em 0.375em;
+    border-radius: 0.25rem;
+}
+
+/* Code blocks */
+.post-content pre,
+.page-content pre {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    padding: 1rem 1.25rem;
+    overflow-x: auto;
+    line-height: 1.5;
+}
+
+.post-content pre code,
+.page-content pre code {
+    background: none;
+    color: var(--text);
+    padding: 0;
+    font-size: 0.875rem;
+}
+
+/* Images */
+.post-content img,
+.page-content img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 0.5rem;
+}
+
+/* Horizontal rules */
+.post-content hr,
+.page-content hr {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin-block: 2rem;
+}
+
+/* Tables */
+.post-content table,
+.page-content table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9375rem;
+}
+
+.post-content th,
+.post-content td,
+.page-content th,
+.page-content td {
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--border);
+    text-align: left;
+}
+
+.post-content th,
+.page-content th {
+    background: var(--bg-secondary);
+    font-weight: 600;
+}
+
+/* --------------------------------------------------------------------------
+   9. Post Header & Metadata
+   -------------------------------------------------------------------------- */
+.post-header {
+    margin-bottom: 2rem;
+}
+
+.post-header h1 {
+    font-size: 2rem;
+    line-height: 1.2;
+    margin-bottom: 0.5rem;
+}
+
+.post-meta {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.375rem;
+}
+
+.post-meta-sep {
+    color: var(--border);
+}
+
+/* --------------------------------------------------------------------------
+   10. Tags
+   -------------------------------------------------------------------------- */
+.post-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+    margin-top: 0.75rem;
+}
+
+.tag {
+    display: inline-block;
+    font-size: 0.8125rem;
+    padding: 0.125rem 0.625rem;
+    background: var(--tag-bg);
+    color: var(--tag-text);
+    border-radius: 1rem;
+    text-decoration: none;
+    transition: opacity 0.15s;
+}
+
+.tag:hover {
+    opacity: 0.8;
+}
+
+/* --------------------------------------------------------------------------
+   11. Post List / Summaries
+   -------------------------------------------------------------------------- */
+.post-list h1 {
+    font-size: 1.75rem;
+    margin-bottom: 1.5rem;
+}
+
+.post-summary {
+    padding-block: 1.25rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.post-summary:last-child {
+    border-bottom: none;
+}
+
+.post-summary h2 {
+    font-size: 1.25rem;
+    line-height: 1.3;
+    margin-bottom: 0.25rem;
+}
+
+.post-summary h2 a {
+    color: var(--text);
+    text-decoration: none;
+}
+
+.post-summary h2 a:hover {
+    color: var(--accent);
+}
+
+.post-summary .summary {
+    margin-top: 0.375rem;
+    color: var(--text-secondary);
+    font-size: 0.9375rem;
+}
+
+/* --------------------------------------------------------------------------
+   12. Pagination
+   -------------------------------------------------------------------------- */
+.pagination {
+    display: flex;
+    justify-content: space-between;
+    padding-top: 1.5rem;
+    margin-top: 1rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9375rem;
+}
+
+.pagination a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.pagination a:hover {
+    text-decoration: underline;
+}
+
+.pagination-next {
+    margin-left: auto;
+}
+
+/* --------------------------------------------------------------------------
+   13. Error Page
+   -------------------------------------------------------------------------- */
+.error-page {
+    text-align: center;
+    padding-block: 4rem;
+}
+
+.error-page h1 {
+    font-size: 2rem;
+    margin-bottom: 1rem;
+}
+
+.error-page p {
+    color: var(--text-secondary);
+    margin-bottom: 0.5rem;
+}
+
+.error-page a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.error-page a:hover {
+    text-decoration: underline;
+}
+
+/* --------------------------------------------------------------------------
+   14. Chroma Syntax Highlighting
+   Compatible with goldmark-highlighting / Chroma output classes
+   -------------------------------------------------------------------------- */
+
+/* Background */
+.chroma { background-color: var(--code-bg); color: var(--text); }
+
+/* Keyword */
+.chroma .k,
+.chroma .kc,
+.chroma .kd,
+.chroma .kn,
+.chroma .kp,
+.chroma .kr { color: #7c3aed; font-weight: 600; }
+
+/* Name */
+.chroma .n  { color: var(--text); }
+.chroma .na { color: #0d9488; }
+.chroma .nb { color: #2563eb; }
+.chroma .nc { color: #2563eb; font-weight: 600; }
+.chroma .nf { color: #2563eb; }
+
+/* String */
+.chroma .s,
+.chroma .sa,
+.chroma .sb,
+.chroma .sc,
+.chroma .dl,
+.chroma .sd,
+.chroma .s2,
+.chroma .se,
+.chroma .sh,
+.chroma .si,
+.chroma .sx,
+.chroma .sr,
+.chroma .s1,
+.chroma .ss { color: #059669; }
+
+/* Number */
+.chroma .m,
+.chroma .mb,
+.chroma .mf,
+.chroma .mh,
+.chroma .mi,
+.chroma .il,
+.chroma .mo { color: #d97706; }
+
+/* Comment */
+.chroma .c,
+.chroma .ch,
+.chroma .cm,
+.chroma .c1,
+.chroma .cs,
+.chroma .cp,
+.chroma .cpf { color: var(--text-secondary); font-style: italic; }
+
+/* Operator */
+.chroma .o,
+.chroma .ow { color: #be185d; }
+
+/* Punctuation */
+.chroma .p { color: var(--text-secondary); }
+
+/* Generic */
+.chroma .gd { color: #dc2626; }
+.chroma .gi { color: #16a34a; }
+.chroma .ge { font-style: italic; }
+.chroma .gs { font-weight: 700; }
+
+@media (prefers-color-scheme: dark) {
+    .chroma .k,
+    .chroma .kc,
+    .chroma .kd,
+    .chroma .kn,
+    .chroma .kp,
+    .chroma .kr { color: #a78bfa; }
+
+    .chroma .na { color: #5eead4; }
+    .chroma .nb { color: #60a5fa; }
+    .chroma .nc { color: #60a5fa; }
+    .chroma .nf { color: #60a5fa; }
+
+    .chroma .s,
+    .chroma .sa,
+    .chroma .sb,
+    .chroma .sc,
+    .chroma .dl,
+    .chroma .sd,
+    .chroma .s2,
+    .chroma .se,
+    .chroma .sh,
+    .chroma .si,
+    .chroma .sx,
+    .chroma .sr,
+    .chroma .s1,
+    .chroma .ss { color: #34d399; }
+
+    .chroma .m,
+    .chroma .mb,
+    .chroma .mf,
+    .chroma .mh,
+    .chroma .mi,
+    .chroma .il,
+    .chroma .mo { color: #fbbf24; }
+
+    .chroma .c,
+    .chroma .ch,
+    .chroma .cm,
+    .chroma .c1,
+    .chroma .cs,
+    .chroma .cp,
+    .chroma .cpf { color: #71717a; }
+
+    .chroma .o,
+    .chroma .ow { color: #f472b6; }
+
+    .chroma .gd { color: #fca5a5; }
+    .chroma .gi { color: #86efac; }
+}
+
+/* --------------------------------------------------------------------------
+   15. Print Stylesheet
+   -------------------------------------------------------------------------- */
+@media print {
+    body {
+        color: #000;
+        background: #fff;
+        font-size: 12pt;
+    }
+
+    .site-header,
+    .site-footer,
+    .pagination,
+    .skip-link,
+    .post-tags {
+        display: none;
+    }
+
+    main {
+        max-width: none;
+        padding: 0;
+    }
+
+    .post-content a,
+    .page-content a {
+        color: #000;
+        text-decoration: underline;
+    }
+
+    .post-content a[href^="http"]::after,
+    .page-content a[href^="http"]::after {
+        content: " (" attr(href) ")";
+        font-size: 0.875em;
+        color: #555;
+    }
+
+    pre {
+        white-space: pre-wrap;
+        border: 1px solid #ccc;
+        page-break-inside: avoid;
+    }
+
+    img {
+        max-width: 100% !important;
+        page-break-inside: avoid;
+    }
+
+    h1, h2, h3 {
+        page-break-after: avoid;
+    }
+}

--- a/defaults/static/css/main.css
+++ b/defaults/static/css/main.css
@@ -613,3 +613,11 @@ main {
         page-break-after: avoid;
     }
 }
+
+/* --------------------------------------------------------------------------
+   16. Reduced Motion
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+    html { scroll-behavior: auto; }
+    .tag { transition: none; }
+}

--- a/defaults/static/css/main.css
+++ b/defaults/static/css/main.css
@@ -15,7 +15,7 @@
     --accent-hover: #1d4ed8;
     --border: #e2e4e9;
     --code-bg: #f1f3f5;
-    --code-text: #d6336c;
+    --code-text: #c2255c;
     --blockquote-border: #2563eb;
     --blockquote-bg: #f0f4ff;
     --tag-bg: #e8edff;
@@ -478,7 +478,7 @@ main {
 .chroma .sx,
 .chroma .sr,
 .chroma .s1,
-.chroma .ss { color: #059669; }
+.chroma .ss { color: #047857; }
 
 /* Number */
 .chroma .m,
@@ -487,7 +487,7 @@ main {
 .chroma .mh,
 .chroma .mi,
 .chroma .il,
-.chroma .mo { color: #d97706; }
+.chroma .mo { color: #b45309; }
 
 /* Comment */
 .chroma .c,
@@ -553,7 +553,7 @@ main {
     .chroma .c1,
     .chroma .cs,
     .chroma .cp,
-    .chroma .cpf { color: #71717a; }
+    .chroma .cpf { color: #8e8e99; }
 
     .chroma .o,
     .chroma .ow { color: #f472b6; }

--- a/defaults/static/images/favicon.svg
+++ b/defaults/static/images/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="6" fill="#2563eb"/>
+  <text x="16" y="23" font-family="system-ui,sans-serif" font-size="20" font-weight="700" fill="#fff" text-anchor="middle">B</text>
+</svg>

--- a/defaults/templates/404.html
+++ b/defaults/templates/404.html
@@ -1,0 +1,9 @@
+{{define "title"}}Page Not Found — {{.Site.Title}}{{end}}
+
+{{define "content"}}
+<article class="error-page">
+    <h1>Page Not Found</h1>
+    <p>Sorry, the page you're looking for doesn't exist or has been moved.</p>
+    <p><a href="/">← Back to home</a></p>
+</article>
+{{end}}

--- a/defaults/templates/base.html
+++ b/defaults/templates/base.html
@@ -4,13 +4,13 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'none'; script-src 'none'; object-src 'none'; connect-src 'none'; style-src 'self'; img-src 'self'; font-src 'self'; base-uri 'self'; form-action 'self'">
+          content="default-src 'none'; script-src 'none'; object-src 'none'; connect-src 'none'; style-src 'self'; img-src 'self' https: data:; font-src 'self' https:; base-uri 'self'; form-action 'self'">
     <title>{{block "title" .}}{{.Site.Title}}{{end}}</title>
-    <meta name="description" content="{{.Site.Description}}">
+    <meta name="description" content="{{block "meta_description" .}}{{.Site.Description}}{{end}}">
     <meta property="og:title" content="{{block "og_title" .}}{{.Site.Title}}{{end}}">
     <meta property="og:description" content="{{block "og_description" .}}{{.Site.Description}}{{end}}">
     <meta property="og:type" content="{{block "og_type" .}}website{{end}}">
-    <meta property="og:url" content="{{.Site.BaseURL}}">
+    <meta property="og:url" content="{{block "og_url" .}}{{.Site.BaseURL}}{{end}}">
     <link rel="icon" href="/static/images/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/static/css/main.css">
 </head>

--- a/defaults/templates/base.html
+++ b/defaults/templates/base.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'self'; script-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'">
+          content="default-src 'none'; script-src 'none'; object-src 'none'; connect-src 'none'; style-src 'self'; img-src 'self'; font-src 'self'; base-uri 'self'; form-action 'self'">
     <title>{{block "title" .}}{{.Site.Title}}{{end}}</title>
     <meta name="description" content="{{.Site.Description}}">
     <meta property="og:title" content="{{.Site.Title}}">
@@ -13,16 +13,6 @@
     <meta property="og:url" content="{{.Site.BaseURL}}">
     <link rel="icon" href="/static/images/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/static/css/main.css">
-    <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-                         Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-        }
-        code, pre {
-            font-family: ui-monospace, "Cascadia Code", "Source Code Pro",
-                         Menlo, Consolas, "DejaVu Sans Mono", monospace;
-        }
-    </style>
 </head>
 <body>
     <a href="#main" class="skip-link">Skip to content</a>

--- a/defaults/templates/base.html
+++ b/defaults/templates/base.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="{{.Site.Language}}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'self'; script-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'">
+    <title>{{block "title" .}}{{.Site.Title}}{{end}}</title>
+    <meta name="description" content="{{.Site.Description}}">
+    <meta property="og:title" content="{{.Site.Title}}">
+    <meta property="og:description" content="{{.Site.Description}}">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{{.Site.BaseURL}}">
+    <link rel="icon" href="/static/images/favicon.svg" type="image/svg+xml">
+    <link rel="stylesheet" href="/static/css/main.css">
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                         Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+        }
+        code, pre {
+            font-family: ui-monospace, "Cascadia Code", "Source Code Pro",
+                         Menlo, Consolas, "DejaVu Sans Mono", monospace;
+        }
+    </style>
+</head>
+<body>
+    <a href="#main" class="skip-link">Skip to content</a>
+    {{template "partials/header.html" .}}
+    <main id="main">
+        {{block "content" .}}{{end}}
+    </main>
+    {{template "partials/footer.html" .}}
+</body>
+</html>

--- a/defaults/templates/base.html
+++ b/defaults/templates/base.html
@@ -7,9 +7,9 @@
           content="default-src 'none'; script-src 'none'; object-src 'none'; connect-src 'none'; style-src 'self'; img-src 'self'; font-src 'self'; base-uri 'self'; form-action 'self'">
     <title>{{block "title" .}}{{.Site.Title}}{{end}}</title>
     <meta name="description" content="{{.Site.Description}}">
-    <meta property="og:title" content="{{.Site.Title}}">
-    <meta property="og:description" content="{{.Site.Description}}">
-    <meta property="og:type" content="website">
+    <meta property="og:title" content="{{block "og_title" .}}{{.Site.Title}}{{end}}">
+    <meta property="og:description" content="{{block "og_description" .}}{{.Site.Description}}{{end}}">
+    <meta property="og:type" content="{{block "og_type" .}}website{{end}}">
     <meta property="og:url" content="{{.Site.BaseURL}}">
     <link rel="icon" href="/static/images/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/static/css/main.css">

--- a/defaults/templates/base.html
+++ b/defaults/templates/base.html
@@ -13,6 +13,7 @@
     <meta property="og:url" content="{{block "og_url" .}}{{.Site.BaseURL}}{{end}}">
     <link rel="icon" href="/static/images/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/static/css/main.css">
+    {{if .Feed.Enabled}}<link rel="alternate" type="application/atom+xml" href="/feed.xml" title="{{.Site.Title}} Feed">{{end}}
 </head>
 <body>
     <a href="#main" class="skip-link">Skip to content</a>

--- a/defaults/templates/list.html
+++ b/defaults/templates/list.html
@@ -7,13 +7,7 @@
     <article class="post-summary">
         <header>
             <h2><a href="{{.URL}}">{{.Title}}</a></h2>
-            <div class="post-meta">
-                <time datetime="{{.Date.Format "2006-01-02"}}">{{.Date.Format $.Site.DateFormat}}</time>
-                {{if .ReadingTime}}
-                <span class="post-meta-sep" aria-hidden="true">·</span>
-                <span>{{.ReadingTime}} min read</span>
-                {{end}}
-            </div>
+            {{template "post-meta" .}}
         </header>
         {{if .Summary}}<p class="summary">{{.Summary}}</p>{{end}}
     </article>
@@ -21,14 +15,5 @@
     <p>No posts yet. Add markdown files to your posts directory to get started.</p>
     {{end}}
 </section>
-{{if or .Pagination.HasPrev .Pagination.HasNext}}
-<nav class="pagination" aria-label="Page navigation">
-    {{if .Pagination.HasPrev}}
-    <a href="{{.Pagination.PrevURL}}" class="pagination-prev" rel="prev">&larr; Newer posts</a>
-    {{end}}
-    {{if .Pagination.HasNext}}
-    <a href="{{.Pagination.NextURL}}" class="pagination-next" rel="next">Older posts &rarr;</a>
-    {{end}}
-</nav>
-{{end}}
+{{template "pagination" .}}
 {{end}}

--- a/defaults/templates/list.html
+++ b/defaults/templates/list.html
@@ -1,0 +1,34 @@
+{{define "title"}}{{if .PageTitle}}{{.PageTitle}} — {{end}}{{.Site.Title}}{{end}}
+
+{{define "content"}}
+<section class="post-list">
+    {{if .PageTitle}}<h1>{{.PageTitle}}</h1>{{end}}
+    {{range .Posts}}
+    <article class="post-summary">
+        <header>
+            <h2><a href="{{.URL}}">{{.Title}}</a></h2>
+            <div class="post-meta">
+                <time datetime="{{.Date.Format "2006-01-02"}}">{{.Date.Format $.Site.DateFormat}}</time>
+                {{if .ReadingTime}}
+                <span class="post-meta-sep" aria-hidden="true">·</span>
+                <span>{{.ReadingTime}} min read</span>
+                {{end}}
+            </div>
+        </header>
+        {{if .Summary}}<p class="summary">{{.Summary}}</p>{{end}}
+    </article>
+    {{else}}
+    <p>No posts yet. Add markdown files to your posts directory to get started.</p>
+    {{end}}
+</section>
+{{if or .Pagination.HasPrev .Pagination.HasNext}}
+<nav class="pagination" aria-label="Page navigation">
+    {{if .Pagination.HasPrev}}
+    <a href="{{.Pagination.PrevURL}}" class="pagination-prev" rel="prev">&larr; Newer posts</a>
+    {{end}}
+    {{if .Pagination.HasNext}}
+    <a href="{{.Pagination.NextURL}}" class="pagination-next" rel="next">Older posts &rarr;</a>
+    {{end}}
+</nav>
+{{end}}
+{{end}}

--- a/defaults/templates/page.html
+++ b/defaults/templates/page.html
@@ -1,6 +1,7 @@
 {{define "title"}}{{.Page.Title}} — {{.Site.Title}}{{end}}
 
 {{define "content"}}
+{{/* .Content must be template.HTML — caller is responsible for sanitizing markdown output before wrapping. */}}
 <article class="page">
     <h1>{{.Page.Title}}</h1>
     <div class="page-content">

--- a/defaults/templates/page.html
+++ b/defaults/templates/page.html
@@ -1,0 +1,10 @@
+{{define "title"}}{{.Page.Title}} — {{.Site.Title}}{{end}}
+
+{{define "content"}}
+<article class="page">
+    <h1>{{.Page.Title}}</h1>
+    <div class="page-content">
+        {{.Content}}
+    </div>
+</article>
+{{end}}

--- a/defaults/templates/page.html
+++ b/defaults/templates/page.html
@@ -1,4 +1,9 @@
 {{define "title"}}{{.Page.Title}} — {{.Site.Title}}{{end}}
+{{define "og_title"}}{{.Page.Title}}{{end}}
+{{define "og_description"}}{{.Page.Description}}{{end}}
+{{define "og_type"}}website{{end}}
+{{define "og_url"}}{{.Page.URL}}{{end}}
+{{define "meta_description"}}{{.Page.Description}}{{end}}
 
 {{define "content"}}
 {{/* .Content must be template.HTML — caller is responsible for sanitizing markdown output before wrapping. */}}

--- a/defaults/templates/partials/footer.html
+++ b/defaults/templates/partials/footer.html
@@ -1,5 +1,5 @@
 {{define "partials/footer.html"}}
 <footer class="site-footer" role="contentinfo">
-    <p>&copy; {{.Site.Title}} · Powered by <a href="https://github.com/khaines/blogflow">BlogFlow</a></p>
+    <p>&copy; {{.Site.Title}} · Powered by <a href="https://github.com/khaines/blogflow" rel="noopener noreferrer">BlogFlow</a></p>
 </footer>
 {{end}}

--- a/defaults/templates/partials/footer.html
+++ b/defaults/templates/partials/footer.html
@@ -1,0 +1,5 @@
+{{define "partials/footer.html"}}
+<footer class="site-footer" role="contentinfo">
+    <p>&copy; {{.Site.Title}} · Powered by <a href="https://github.com/khaines/blogflow">BlogFlow</a></p>
+</footer>
+{{end}}

--- a/defaults/templates/partials/header.html
+++ b/defaults/templates/partials/header.html
@@ -1,0 +1,7 @@
+{{define "partials/header.html"}}
+<header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Main navigation">
+        <a href="/" class="site-title">{{.Site.Title}}</a>
+    </nav>
+</header>
+{{end}}

--- a/defaults/templates/partials/pagination.html
+++ b/defaults/templates/partials/pagination.html
@@ -1,0 +1,12 @@
+{{define "pagination"}}
+{{if or .Pagination.HasPrev .Pagination.HasNext}}
+<nav class="pagination" aria-label="Page navigation">
+    {{if .Pagination.HasPrev}}
+    <a href="{{.Pagination.PrevURL}}" class="pagination-prev" rel="prev">&larr; Newer posts</a>
+    {{end}}
+    {{if .Pagination.HasNext}}
+    <a href="{{.Pagination.NextURL}}" class="pagination-next" rel="next">Older posts &rarr;</a>
+    {{end}}
+</nav>
+{{end}}
+{{end}}

--- a/defaults/templates/partials/post-meta.html
+++ b/defaults/templates/partials/post-meta.html
@@ -1,6 +1,6 @@
 {{define "post-meta"}}
 <div class="post-meta">
-    <time datetime="{{.Date.Format "2006-01-02"}}">{{.Date.Format $.Site.DateFormat}}</time>
+    <time datetime="{{.Date.Format "2006-01-02"}}">{{.Date.Format "January 2, 2006"}}</time>
     {{if .ReadingTime}}
     <span class="post-meta-sep" aria-hidden="true">·</span>
     <span>{{.ReadingTime}} min read</span>

--- a/defaults/templates/partials/post-meta.html
+++ b/defaults/templates/partials/post-meta.html
@@ -1,3 +1,4 @@
+{{/* TODO: Replace hardcoded format with template function that reads config.Content.DateFormat */}}
 {{define "post-meta"}}
 <div class="post-meta">
     <time datetime="{{.Date.Format "2006-01-02"}}">{{.Date.Format "January 2, 2006"}}</time>

--- a/defaults/templates/partials/post-meta.html
+++ b/defaults/templates/partials/post-meta.html
@@ -1,0 +1,16 @@
+{{define "post-meta"}}
+<div class="post-meta">
+    <time datetime="{{.Date.Format "2006-01-02"}}">{{.Date.Format $.Site.DateFormat}}</time>
+    {{if .ReadingTime}}
+    <span class="post-meta-sep" aria-hidden="true">·</span>
+    <span>{{.ReadingTime}} min read</span>
+    {{end}}
+</div>
+{{if .Tags}}
+<div class="post-tags" role="list" aria-label="Tags">
+    {{range .Tags}}
+    <a href="/tags/{{.}}" class="tag" role="listitem">{{.}}</a>
+    {{end}}
+</div>
+{{end}}
+{{end}}

--- a/defaults/templates/post.html
+++ b/defaults/templates/post.html
@@ -2,6 +2,8 @@
 {{define "og_title"}}{{.Post.Title}}{{end}}
 {{define "og_description"}}{{.Post.Description}}{{end}}
 {{define "og_type"}}article{{end}}
+{{define "og_url"}}{{.Post.URL}}{{end}}
+{{define "meta_description"}}{{.Post.Description}}{{end}}
 
 {{define "content"}}
 {{/* .Content must be template.HTML — caller is responsible for sanitizing markdown output before wrapping. */}}

--- a/defaults/templates/post.html
+++ b/defaults/templates/post.html
@@ -4,20 +4,7 @@
 <article class="post">
     <header class="post-header">
         <h1>{{.Post.Title}}</h1>
-        <div class="post-meta">
-            <time datetime="{{.Post.Date.Format "2006-01-02"}}">{{.Post.Date.Format .Site.DateFormat}}</time>
-            {{if .Post.ReadingTime}}
-            <span class="post-meta-sep" aria-hidden="true">·</span>
-            <span>{{.Post.ReadingTime}} min read</span>
-            {{end}}
-        </div>
-        {{if .Post.Tags}}
-        <div class="post-tags" role="list" aria-label="Tags">
-            {{range .Post.Tags}}
-            <a href="/tags/{{.}}" class="tag" role="listitem">{{.}}</a>
-            {{end}}
-        </div>
-        {{end}}
+        {{template "post-meta" .Post}}
     </header>
     <div class="post-content">
         {{.Content}}

--- a/defaults/templates/post.html
+++ b/defaults/templates/post.html
@@ -1,0 +1,26 @@
+{{define "title"}}{{.Post.Title}} — {{.Site.Title}}{{end}}
+
+{{define "content"}}
+<article class="post">
+    <header class="post-header">
+        <h1>{{.Post.Title}}</h1>
+        <div class="post-meta">
+            <time datetime="{{.Post.Date.Format "2006-01-02"}}">{{.Post.Date.Format .Site.DateFormat}}</time>
+            {{if .Post.ReadingTime}}
+            <span class="post-meta-sep" aria-hidden="true">·</span>
+            <span>{{.Post.ReadingTime}} min read</span>
+            {{end}}
+        </div>
+        {{if .Post.Tags}}
+        <div class="post-tags" role="list" aria-label="Tags">
+            {{range .Post.Tags}}
+            <a href="/tags/{{.}}" class="tag" role="listitem">{{.}}</a>
+            {{end}}
+        </div>
+        {{end}}
+    </header>
+    <div class="post-content">
+        {{.Content}}
+    </div>
+</article>
+{{end}}

--- a/defaults/templates/post.html
+++ b/defaults/templates/post.html
@@ -1,6 +1,10 @@
 {{define "title"}}{{.Post.Title}} — {{.Site.Title}}{{end}}
+{{define "og_title"}}{{.Post.Title}}{{end}}
+{{define "og_description"}}{{.Post.Description}}{{end}}
+{{define "og_type"}}article{{end}}
 
 {{define "content"}}
+{{/* .Content must be template.HTML — caller is responsible for sanitizing markdown output before wrapping. */}}
 <article class="post">
     <header class="post-header">
         <h1>{{.Post.Title}}</h1>

--- a/embed.go
+++ b/embed.go
@@ -1,0 +1,26 @@
+// Package blogflow embeds the default theme, templates, CSS, and configuration.
+package blogflow
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+)
+
+//go:embed defaults/*
+var defaultsFS embed.FS
+
+// DefaultsFS returns the embedded defaults filesystem with the "defaults/"
+// prefix stripped. Paths align with overlay FS expectations
+// (e.g., "templates/base.html" not "defaults/templates/base.html").
+//
+// Note: go:embed excludes files starting with . or _ by default.
+var DefaultsFS fs.FS
+
+func init() {
+	var err error
+	DefaultsFS, err = fs.Sub(defaultsFS, "defaults")
+	if err != nil {
+		panic(fmt.Sprintf("blogflow: failed to create defaults sub-filesystem: %v", err))
+	}
+}

--- a/embed.go
+++ b/embed.go
@@ -1,4 +1,8 @@
 // Package blogflow embeds the default theme, templates, CSS, and configuration.
+//
+// embed.go lives at the package root (not internal/defaults/) so the //go:embed
+// directive can reference the defaults/ directory directly. The overlay FS and
+// config system import the Defaults variable from here.
 package blogflow
 
 import (
@@ -10,16 +14,17 @@ import (
 //go:embed defaults/*
 var defaultsFS embed.FS
 
-// DefaultsFS returns the embedded defaults filesystem with the "defaults/"
-// prefix stripped. Paths align with overlay FS expectations
+// Defaults is the embedded defaults filesystem with the "defaults/" prefix
+// stripped. Paths align with overlay FS expectations
 // (e.g., "templates/base.html" not "defaults/templates/base.html").
 //
 // Note: go:embed excludes files starting with . or _ by default.
-var DefaultsFS fs.FS
+var Defaults fs.FS
 
 func init() {
 	var err error
-	DefaultsFS, err = fs.Sub(defaultsFS, "defaults")
+	// TODO: emit an slog.Debug message here once the logger is wired up.
+	Defaults, err = fs.Sub(defaultsFS, "defaults")
 	if err != nil {
 		panic(fmt.Sprintf("blogflow: failed to create defaults sub-filesystem: %v", err))
 	}


### PR DESCRIPTION
## Summary
Batteries-included default theme compiled into the binary via embed.FS. Users only need markdown to have a working blog.

## Files
- `defaults/config/defaults.yaml` — zero-config site defaults
- `defaults/templates/` — base, post, list, page, 404, header, footer
- `defaults/static/css/main.css` — 615-line responsive CSS (dark mode, Chroma, print)
- `defaults/static/images/favicon.svg` — stylized B favicon
- `defaults/content/pages/about.md` — default about page
- `embed.go` — fs.Sub prefix stripping with init() panic

## Theme Design
Responsive, mobile-first, WCAG 2.1 AA, no JavaScript, system fonts, prefers-color-scheme dark mode

## Type of Change
- [x] 🆕 New feature