### PR TITLE
feat: implement content scanner and in-memory index

### DIFF
--- a/internal/content/scanner.go
+++ b/internal/content/scanner.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"html/template"
 	"io/fs"
-	"path/filepath"
+	"path"
 	"sort"
 	"strings"
 )
@@ -77,13 +77,15 @@ func (s *Scanner) Scan(contentFS fs.FS) (*Index, error) {
 	}
 
 	// Sort posts by date descending
-	sort.Slice(idx.Posts, func(i, j int) bool {
+	sort.SliceStable(idx.Posts, func(i, j int) bool {
 		return idx.Posts[i].Date.After(idx.Posts[j].Date)
 	})
 
 	return idx, nil
 }
 
+// scanDir aborts on the first file error (fail-fast). Validate content
+// before deployment to avoid partial index builds.
 func (s *Scanner) scanDir(contentFS fs.FS, dir string, idx *Index, isPage bool) error {
 	return fs.WalkDir(contentFS, dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -110,6 +112,10 @@ func (s *Scanner) scanDir(contentFS fs.FS, dir string, idx *Index, isPage bool) 
 		}
 		if fm.Draft {
 			return nil // skip drafts
+		}
+
+		if !isPage && fm.Date.IsZero() {
+			return fmt.Errorf("parsing %s: post requires a 'date' field", path)
 		}
 
 		// Render markdown
@@ -143,13 +149,22 @@ func (s *Scanner) scanDir(contentFS fs.FS, dir string, idx *Index, isPage bool) 
 		}
 
 		if isPage {
+			if existing, ok := idx.PageBySlug[slug]; ok {
+				return fmt.Errorf("duplicate page slug %q: %s conflicts with %s", slug, path, existing.Path)
+			}
 			idx.Pages = append(idx.Pages, post)
 			idx.PageBySlug[slug] = post
 		} else {
+			if existing, ok := idx.BySlug[slug]; ok {
+				return fmt.Errorf("duplicate post slug %q: %s conflicts with %s", slug, path, existing.Path)
+			}
 			idx.Posts = append(idx.Posts, post)
 			idx.BySlug[slug] = post
 			for _, tag := range fm.Tags {
 				tag = strings.ToLower(strings.TrimSpace(tag))
+				if tag == "" {
+					continue
+				}
 				idx.ByTag[tag] = append(idx.ByTag[tag], post)
 			}
 			idx.ByYear[fm.Date.Year()] = append(idx.ByYear[fm.Date.Year()], post)
@@ -160,9 +175,9 @@ func (s *Scanner) scanDir(contentFS fs.FS, dir string, idx *Index, isPage bool) 
 }
 
 // slugFromPath generates a slug from a file path by stripping directory and extension.
-func slugFromPath(path string) string {
-	base := filepath.Base(path)
-	return strings.TrimSuffix(base, filepath.Ext(base))
+func slugFromPath(p string) string {
+	base := path.Base(p)
+	return strings.TrimSuffix(base, path.Ext(base))
 }
 
 // stripHTML removes HTML tags using a simple state-machine approach.
@@ -185,13 +200,14 @@ func stripHTML(s string) string {
 	return b.String()
 }
 
-// truncateText shortens text to n characters at a word boundary.
+// truncateText shortens text to n runes at a word boundary.
 func truncateText(s string, n int) string {
-	s = strings.Join(strings.Fields(s), " ") // normalize whitespace
-	if len(s) <= n {
+	s = strings.Join(strings.Fields(s), " ")
+	runes := []rune(s)
+	if len(runes) <= n {
 		return s
 	}
-	truncated := s[:n]
+	truncated := string(runes[:n])
 	if idx := strings.LastIndex(truncated, " "); idx > 0 {
 		truncated = truncated[:idx]
 	}

--- a/internal/content/scanner.go
+++ b/internal/content/scanner.go
@@ -1,0 +1,199 @@
+package content
+
+import (
+	"errors"
+	"fmt"
+	"html/template"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Post represents a fully processed blog post.
+type Post struct {
+	FrontMatter
+	Slug        string
+	Content     template.HTML // rendered HTML from markdown
+	Summary     string        // truncated plain text
+	ReadingTime int           // minutes
+	Path        string        // original .md file path relative to content root
+}
+
+// Index is the in-memory content index, built by scanning the content directory.
+type Index struct {
+	Posts      []*Post            // sorted by date descending
+	BySlug     map[string]*Post   // O(1) slug lookup
+	ByTag      map[string][]*Post // posts by tag
+	ByYear     map[int][]*Post    // posts by year
+	Pages      []*Post            // static pages (from pages/ dir)
+	PageBySlug map[string]*Post   // O(1) page slug lookup
+}
+
+// Scanner walks a content filesystem and builds an Index.
+type Scanner struct {
+	renderer   *Renderer
+	postsDir   string // default: "posts"
+	pagesDir   string // default: "pages"
+	summaryLen int    // default: 200
+}
+
+// NewScanner creates a content scanner.
+func NewScanner(renderer *Renderer, postsDir, pagesDir string, summaryLen int) *Scanner {
+	if postsDir == "" {
+		postsDir = "posts"
+	}
+	if pagesDir == "" {
+		pagesDir = "pages"
+	}
+	if summaryLen <= 0 {
+		summaryLen = 200
+	}
+	return &Scanner{renderer: renderer, postsDir: postsDir, pagesDir: pagesDir, summaryLen: summaryLen}
+}
+
+// Scan walks the given fs.FS and builds a content Index.
+// Only processes .md files. Skips drafts. Skips files without front matter.
+func (s *Scanner) Scan(contentFS fs.FS) (*Index, error) {
+	idx := &Index{
+		BySlug:     make(map[string]*Post),
+		ByTag:      make(map[string][]*Post),
+		ByYear:     make(map[int][]*Post),
+		PageBySlug: make(map[string]*Post),
+	}
+
+	// Scan posts
+	if err := s.scanDir(contentFS, s.postsDir, idx, false); err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("scanning posts: %w", err)
+		}
+	}
+
+	// Scan pages
+	if err := s.scanDir(contentFS, s.pagesDir, idx, true); err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("scanning pages: %w", err)
+		}
+	}
+
+	// Sort posts by date descending
+	sort.Slice(idx.Posts, func(i, j int) bool {
+		return idx.Posts[i].Date.After(idx.Posts[j].Date)
+	})
+
+	return idx, nil
+}
+
+func (s *Scanner) scanDir(contentFS fs.FS, dir string, idx *Index, isPage bool) error {
+	return fs.WalkDir(contentFS, dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+
+		data, err := fs.ReadFile(contentFS, path)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", path, err)
+		}
+
+		fm, body, err := ParseFrontMatter(data)
+		if err != nil {
+			return fmt.Errorf("parsing %s: %w", path, err)
+		}
+		if fm == nil {
+			return nil // no front matter, skip
+		}
+		if fm.Draft {
+			return nil // skip drafts
+		}
+
+		// Render markdown
+		html, err := s.renderer.Render(body)
+		if err != nil {
+			return fmt.Errorf("rendering %s: %w", path, err)
+		}
+
+		// Build slug from front matter or filename
+		slug := fm.Slug
+		if slug == "" {
+			slug = slugFromPath(path)
+		}
+
+		// Build summary (strip HTML, truncate)
+		summary := truncateText(stripHTML(string(html)), s.summaryLen)
+
+		// Calculate reading time
+		readingTime := fm.ReadingTime
+		if readingTime == 0 {
+			readingTime = ReadingTimeMinutes(string(body))
+		}
+
+		post := &Post{
+			FrontMatter: *fm,
+			Slug:        slug,
+			Content:     template.HTML(html),
+			Summary:     summary,
+			ReadingTime: readingTime,
+			Path:        path,
+		}
+
+		if isPage {
+			idx.Pages = append(idx.Pages, post)
+			idx.PageBySlug[slug] = post
+		} else {
+			idx.Posts = append(idx.Posts, post)
+			idx.BySlug[slug] = post
+			for _, tag := range fm.Tags {
+				tag = strings.ToLower(strings.TrimSpace(tag))
+				idx.ByTag[tag] = append(idx.ByTag[tag], post)
+			}
+			idx.ByYear[fm.Date.Year()] = append(idx.ByYear[fm.Date.Year()], post)
+		}
+
+		return nil
+	})
+}
+
+// slugFromPath generates a slug from a file path by stripping directory and extension.
+func slugFromPath(path string) string {
+	base := filepath.Base(path)
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}
+
+// stripHTML removes HTML tags using a simple state-machine approach.
+func stripHTML(s string) string {
+	var b strings.Builder
+	inTag := false
+	for _, r := range s {
+		if r == '<' {
+			inTag = true
+			continue
+		}
+		if r == '>' {
+			inTag = false
+			continue
+		}
+		if !inTag {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// truncateText shortens text to n characters at a word boundary.
+func truncateText(s string, n int) string {
+	s = strings.Join(strings.Fields(s), " ") // normalize whitespace
+	if len(s) <= n {
+		return s
+	}
+	truncated := s[:n]
+	if idx := strings.LastIndex(truncated, " "); idx > 0 {
+		truncated = truncated[:idx]
+	}
+	return truncated + "…"
+}

--- a/internal/content/scanner.go
+++ b/internal/content/scanner.go
@@ -166,7 +166,7 @@ func (s *Scanner) scanDir(contentFS fs.FS, dir string, idx *Index, isPage bool) 
 		post := &Post{
 			FrontMatter: *fm,
 			Slug:        slug,
-			Content:     template.HTML(rendered),
+			Content:     template.HTML(rendered), //nolint:gosec // G203: content is sanitized by goldmark (raw HTML stripped by default)
 			Summary:     summary,
 			ReadingTime: readingTime,
 			Path:        filePath,

--- a/internal/content/scanner.go
+++ b/internal/content/scanner.go
@@ -3,6 +3,7 @@ package content
 import (
 	"errors"
 	"fmt"
+	"html"
 	"html/template"
 	"io/fs"
 	"path"
@@ -76,10 +77,30 @@ func (s *Scanner) Scan(contentFS fs.FS) (*Index, error) {
 		}
 	}
 
+	// Detect post/page cross-namespace slug collisions
+	for slug, page := range idx.PageBySlug {
+		if post, ok := idx.BySlug[slug]; ok {
+			return nil, fmt.Errorf("slug conflict: page %s and post %s share slug %q", page.Path, post.Path, slug)
+		}
+	}
+
 	// Sort posts by date descending
 	sort.SliceStable(idx.Posts, func(i, j int) bool {
 		return idx.Posts[i].Date.After(idx.Posts[j].Date)
 	})
+
+	// Rebuild secondary indexes from sorted Posts for deterministic ordering
+	idx.ByTag = make(map[string][]*Post)
+	idx.ByYear = make(map[int][]*Post)
+	for _, post := range idx.Posts {
+		for _, tag := range post.Tags {
+			tag = strings.ToLower(strings.TrimSpace(tag))
+			if tag != "" {
+				idx.ByTag[tag] = append(idx.ByTag[tag], post)
+			}
+		}
+		idx.ByYear[post.Date.Year()] = append(idx.ByYear[post.Date.Year()], post)
+	}
 
 	return idx, nil
 }
@@ -87,25 +108,25 @@ func (s *Scanner) Scan(contentFS fs.FS) (*Index, error) {
 // scanDir aborts on the first file error (fail-fast). Validate content
 // before deployment to avoid partial index builds.
 func (s *Scanner) scanDir(contentFS fs.FS, dir string, idx *Index, isPage bool) error {
-	return fs.WalkDir(contentFS, dir, func(path string, d fs.DirEntry, err error) error {
+	return fs.WalkDir(contentFS, dir, func(filePath string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if d.IsDir() {
 			return nil
 		}
-		if !strings.HasSuffix(path, ".md") {
+		if !strings.HasSuffix(filePath, ".md") {
 			return nil
 		}
 
-		data, err := fs.ReadFile(contentFS, path)
+		data, err := fs.ReadFile(contentFS, filePath)
 		if err != nil {
-			return fmt.Errorf("reading %s: %w", path, err)
+			return fmt.Errorf("reading %s: %w", filePath, err)
 		}
 
 		fm, body, err := ParseFrontMatter(data)
 		if err != nil {
-			return fmt.Errorf("parsing %s: %w", path, err)
+			return fmt.Errorf("parsing %s: %w", filePath, err)
 		}
 		if fm == nil {
 			return nil // no front matter, skip
@@ -115,23 +136,26 @@ func (s *Scanner) scanDir(contentFS fs.FS, dir string, idx *Index, isPage bool) 
 		}
 
 		if !isPage && fm.Date.IsZero() {
-			return fmt.Errorf("parsing %s: post requires a 'date' field", path)
+			return fmt.Errorf("parsing %s: post requires a 'date' field", filePath)
 		}
 
 		// Render markdown
-		html, err := s.renderer.Render(body)
+		rendered, err := s.renderer.Render(body)
 		if err != nil {
-			return fmt.Errorf("rendering %s: %w", path, err)
+			return fmt.Errorf("rendering %s: %w", filePath, err)
 		}
 
 		// Build slug from front matter or filename
 		slug := fm.Slug
 		if slug == "" {
-			slug = slugFromPath(path)
+			slug = slugFromPath(filePath)
+			if strings.Contains(slug, "/") || strings.Contains(slug, "\\") || strings.Contains(slug, "..") || strings.Contains(slug, "\x00") || strings.ContainsAny(slug, " \t") {
+				return fmt.Errorf("scanning %s: generated slug %q contains invalid characters", filePath, slug)
+			}
 		}
 
 		// Build summary (strip HTML, truncate)
-		summary := truncateText(stripHTML(string(html)), s.summaryLen)
+		summary := truncateText(stripHTML(string(rendered)), s.summaryLen)
 
 		// Calculate reading time
 		readingTime := fm.ReadingTime
@@ -142,32 +166,24 @@ func (s *Scanner) scanDir(contentFS fs.FS, dir string, idx *Index, isPage bool) 
 		post := &Post{
 			FrontMatter: *fm,
 			Slug:        slug,
-			Content:     template.HTML(html),
+			Content:     template.HTML(rendered),
 			Summary:     summary,
 			ReadingTime: readingTime,
-			Path:        path,
+			Path:        filePath,
 		}
 
 		if isPage {
 			if existing, ok := idx.PageBySlug[slug]; ok {
-				return fmt.Errorf("duplicate page slug %q: %s conflicts with %s", slug, path, existing.Path)
+				return fmt.Errorf("duplicate page slug %q: %s conflicts with %s", slug, filePath, existing.Path)
 			}
 			idx.Pages = append(idx.Pages, post)
 			idx.PageBySlug[slug] = post
 		} else {
 			if existing, ok := idx.BySlug[slug]; ok {
-				return fmt.Errorf("duplicate post slug %q: %s conflicts with %s", slug, path, existing.Path)
+				return fmt.Errorf("duplicate post slug %q: %s conflicts with %s", slug, filePath, existing.Path)
 			}
 			idx.Posts = append(idx.Posts, post)
 			idx.BySlug[slug] = post
-			for _, tag := range fm.Tags {
-				tag = strings.ToLower(strings.TrimSpace(tag))
-				if tag == "" {
-					continue
-				}
-				idx.ByTag[tag] = append(idx.ByTag[tag], post)
-			}
-			idx.ByYear[fm.Date.Year()] = append(idx.ByYear[fm.Date.Year()], post)
 		}
 
 		return nil
@@ -197,7 +213,7 @@ func stripHTML(s string) string {
 			b.WriteRune(r)
 		}
 	}
-	return b.String()
+	return html.UnescapeString(b.String())
 }
 
 // truncateText shortens text to n runes at a word boundary.

--- a/internal/content/scanner_test.go
+++ b/internal/content/scanner_test.go
@@ -371,6 +371,7 @@ func TestTruncateText(t *testing.T) {
 		{"truncate at word boundary", "the quick brown fox jumps over the lazy dog", 20, "the quick brown fox…"},
 		{"whitespace normalization", "  hello   world  ", 200, "hello world"},
 		{"empty string", "", 200, ""},
+		{"unicode rune boundary", "こんにちは世界のテスト", 5, "こんにちは…"},
 	}
 
 	for _, tt := range tests {
@@ -380,5 +381,94 @@ func TestTruncateText(t *testing.T) {
 				t.Errorf("truncateText(%q, %d) = %q, want %q", tt.text, tt.n, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestScan_DuplicateSlug(t *testing.T) {
+	fs := fstest.MapFS{
+		"posts/first.md": &fstest.MapFile{
+			Data: []byte(mkPost("First", "dupe", "2025-06-01", nil, false, "First.\n")),
+		},
+		"posts/second.md": &fstest.MapFile{
+			Data: []byte(mkPost("Second", "dupe", "2025-06-02", nil, false, "Second.\n")),
+		},
+	}
+
+	_, err := newTestScanner().Scan(fs)
+	if err == nil {
+		t.Fatal("expected error for duplicate slug, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate post slug") {
+		t.Errorf("error = %q, want it to mention duplicate post slug", err)
+	}
+}
+
+func TestScan_DuplicatePageSlug(t *testing.T) {
+	fs := fstest.MapFS{
+		"pages/first.md": &fstest.MapFile{
+			Data: []byte(mkPost("First", "dupe", "2025-06-01", nil, false, "First.\n")),
+		},
+		"pages/second.md": &fstest.MapFile{
+			Data: []byte(mkPost("Second", "dupe", "2025-06-02", nil, false, "Second.\n")),
+		},
+	}
+
+	_, err := newTestScanner().Scan(fs)
+	if err == nil {
+		t.Fatal("expected error for duplicate page slug, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate page slug") {
+		t.Errorf("error = %q, want it to mention duplicate page slug", err)
+	}
+}
+
+func TestScan_MissingDate(t *testing.T) {
+	fs := fstest.MapFS{
+		"posts/no-date.md": &fstest.MapFile{
+			Data: []byte("---\ntitle: \"No Date\"\nslug: \"no-date\"\n---\nContent.\n"),
+		},
+	}
+
+	_, err := newTestScanner().Scan(fs)
+	if err == nil {
+		t.Fatal("expected error for missing date, got nil")
+	}
+	if !strings.Contains(err.Error(), "requires a 'date' field") {
+		t.Errorf("error = %q, want it to mention date requirement", err)
+	}
+}
+
+func TestScan_PageAllowedWithoutDate(t *testing.T) {
+	fs := fstest.MapFS{
+		"pages/about.md": &fstest.MapFile{
+			Data: []byte("---\ntitle: \"About\"\nslug: \"about\"\n---\nAbout page.\n"),
+		},
+	}
+
+	idx, err := newTestScanner().Scan(fs)
+	if err != nil {
+		t.Fatalf("pages should allow missing date, got error: %v", err)
+	}
+	if len(idx.Pages) != 1 {
+		t.Fatalf("expected 1 page, got %d", len(idx.Pages))
+	}
+}
+
+func TestScan_EmptyTagSkipped(t *testing.T) {
+	fs := fstest.MapFS{
+		"posts/post.md": &fstest.MapFile{
+			Data: []byte(mkPost("Post", "post", "2025-06-01", []string{"go", " ", ""}, false, "Content.\n")),
+		},
+	}
+
+	idx, err := newTestScanner().Scan(fs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := idx.ByTag[""]; ok {
+		t.Error("empty string tag should not be indexed")
+	}
+	if len(idx.ByTag["go"]) != 1 {
+		t.Errorf("expected 1 post tagged 'go', got %d", len(idx.ByTag["go"]))
 	}
 }

--- a/internal/content/scanner_test.go
+++ b/internal/content/scanner_test.go
@@ -1,0 +1,384 @@
+package content
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func mkPost(title, slug, date string, tags []string, draft bool, body string) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.WriteString("title: \"" + title + "\"\n")
+	if slug != "" {
+		b.WriteString("slug: \"" + slug + "\"\n")
+	}
+	b.WriteString("date: " + date + "\n")
+	if draft {
+		b.WriteString("draft: true\n")
+	}
+	if len(tags) > 0 {
+		b.WriteString("tags: [\"" + strings.Join(tags, "\", \"") + "\"]\n")
+	}
+	b.WriteString("---\n")
+	b.WriteString(body)
+	return b.String()
+}
+
+func newTestScanner() *Scanner {
+	return NewScanner(NewRenderer(), "", "", 200)
+}
+
+func TestScan_BasicPost(t *testing.T) {
+	fs := fstest.MapFS{
+		"posts/hello.md": &fstest.MapFile{
+			Data: []byte(mkPost("Hello World", "hello-world", "2025-06-01", []string{"go"}, false, "This is **bold** text.\n")),
+		},
+	}
+
+	idx, err := newTestScanner().Scan(fs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(idx.Posts) != 1 {
+		t.Fatalf("expected 1 post, got %d", len(idx.Posts))
+	}
+
+	post := idx.Posts[0]
+	if post.Slug != "hello-world" {
+		t.Errorf("slug = %q, want %q", post.Slug, "hello-world")
+	}
+	if post.Title != "Hello World" {
+		t.Errorf("title = %q, want %q", post.Title, "Hello World")
+	}
+	if !strings.Contains(string(post.Content), "<strong>bold</strong>") {
+		t.Errorf("content missing rendered bold: %s", post.Content)
+	}
+	if post.Summary == "" {
+		t.Error("summary should not be empty")
+	}
+	if post.ReadingTime < 1 {
+		t.Errorf("reading time = %d, want >= 1", post.ReadingTime)
+	}
+	if post.Path != "posts/hello.md" {
+		t.Errorf("path = %q, want %q", post.Path, "posts/hello.md")
+	}
+
+	// Verify index lookups
+	if idx.BySlug["hello-world"] != post {
+		t.Error("BySlug lookup failed")
+	}
+}
+
+func TestScan_MultiplePosts(t *testing.T) {
+	fs := fstest.MapFS{
+		"posts/old.md": &fstest.MapFile{
+			Data: []byte(mkPost("Old Post", "old", "2024-01-01", nil, false, "Old content.\n")),
+		},
+		"posts/mid.md": &fstest.MapFile{
+			Data: []byte(mkPost("Mid Post", "mid", "2025-03-15", nil, false, "Mid content.\n")),
+		},
+		"posts/new.md": &fstest.MapFile{
+			Data: []byte(mkPost("New Post", "new", "2025-06-01", nil, false, "New content.\n")),
+		},
+	}
+
+	idx, err := newTestScanner().Scan(fs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(idx.Posts) != 3 {
+		t.Fatalf("expected 3 posts, got %d", len(idx.Posts))
+	}
+
+	// Verify date descending order
+	if idx.Posts[0].Slug != "new" {
+		t.Errorf("first post slug = %q, want %q", idx.Posts[0].Slug, "new")
+	}
+	if idx.Posts[1].Slug != "mid" {
+		t.Errorf("second post slug = %q, want %q", idx.Posts[1].Slug, "mid")
+	}
+	if idx.Posts[2].Slug != "old" {
+		t.Errorf("third post slug = %q, want %q", idx.Posts[2].Slug, "old")
+	}
+}
+
+func TestScan_SkipDrafts(t *testing.T) {
+	fs := fstest.MapFS{
+		"posts/published.md": &fstest.MapFile{
+			Data: []byte(mkPost("Published", "pub", "2025-06-01", nil, false, "Content.\n")),
+		},
+		"posts/draft.md": &fstest.MapFile{
+			Data: []byte(mkPost("Draft", "draft", "2025-06-02", nil, true, "Draft content.\n")),
+		},
+	}
+
+	idx, err := newTestScanner().Scan(fs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(idx.Posts) != 1 {
+		t.Fatalf("expected 1 post (draft skipped), got %d", len(idx.Posts))
+	}
+	if idx.Posts[0].Slug != "pub" {
+		t.Errorf("expected published post, got slug %q", idx.Posts[0].Slug)
+	}
+}
+
+func TestScan_SkipNonMarkdown(t *testing.T) {
+	fs := fstest.MapFS{
+		"posts/good.md": &fstest.MapFile{
+			Data: []byte(mkPost("Good", "good", "2025-06-01", nil, false, "Content.\n")),
+		},
+		"posts/readme.txt": &fstest.MapFile{
+			Data: []byte("This is a text file"),
+		},
+		"posts/data.json": &fstest.MapFile{
+			Data: []byte(`{"key": "value"}`),
+		},
+	}
+
+	idx, err := newTestScanner().Scan(fs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(idx.Posts) != 1 {
+		t.Fatalf("expected 1 post (non-md skipped), got %d", len(idx.Posts))
+	}
+}
+
+func TestScan_NoFrontMatter(t *testing.T) {
+	fs := fstest.MapFS{
+		"posts/with-fm.md": &fstest.MapFile{
+			Data: []byte(mkPost("With FM", "with-fm", "2025-06-01", nil, false, "Content.\n")),
+		},
+		"posts/no-fm.md": &fstest.MapFile{
+			Data: []byte("# Just Markdown\n\nNo front matter here.\n"),
+		},
+	}
+
+	idx, err := newTestScanner().Scan(fs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(idx.Posts) != 1 {
+		t.Fatalf("expected 1 post (no-fm skipped), got %d", len(idx.Posts))
+	}
+	if idx.Posts[0].Slug != "with-fm" {
+		t.Errorf("expected with-fm post, got slug %q", idx.Posts[0].Slug)
+	}
+}
+
+func TestScan_Pages(t *testing.T) {
+	fs := fstest.MapFS{
+		"posts/blog.md": &fstest.MapFile{
+			Data: []byte(mkPost("Blog Post", "blog", "2025-06-01", nil, false, "Blog.\n")),
+		},
+		"pages/about.md": &fstest.MapFile{
+			Data: []byte(mkPost("About", "about", "2025-01-01", nil, false, "About page.\n")),
+		},
+		"pages/contact.md": &fstest.MapFile{
+			Data: []byte(mkPost("Contact", "contact", "2025-01-01", nil, false, "Contact page.\n")),
+		},
+	}
+
+	idx, err := newTestScanner().Scan(fs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(idx.Posts) != 1 {
+		t.Fatalf("expected 1 post, got %d", len(idx.Posts))
+	}
+	if len(idx.Pages) != 2 {
+		t.Fatalf("expected 2 pages, got %d", len(idx.Pages))
+	}
+
+	if idx.PageBySlug["about"] == nil {
+		t.Error("PageBySlug missing 'about'")
+	}
+	if idx.PageBySlug["contact"] == nil {
+		t.Error("PageBySlug missing 'contact'")
+	}
+
+	// Pages should not appear in BySlug (post-only index)
+	if idx.BySlug["about"] != nil {
+		t.Error("pages should not appear in BySlug")
+	}
+}
+
+func TestScan_TagIndex(t *testing.T) {
+	fs := fstest.MapFS{
+		"posts/go-post.md": &fstest.MapFile{
+			Data: []byte(mkPost("Go Post", "go-post", "2025-06-01", []string{"Go", "Programming"}, false, "Go.\n")),
+		},
+		"posts/rust-post.md": &fstest.MapFile{
+			Data: []byte(mkPost("Rust Post", "rust-post", "2025-06-02", []string{"Rust", "Programming"}, false, "Rust.\n")),
+		},
+	}
+
+	idx, err := newTestScanner().Scan(fs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Tags are lowercased
+	if len(idx.ByTag["go"]) != 1 {
+		t.Errorf("expected 1 post tagged 'go', got %d", len(idx.ByTag["go"]))
+	}
+	if len(idx.ByTag["rust"]) != 1 {
+		t.Errorf("expected 1 post tagged 'rust', got %d", len(idx.ByTag["rust"]))
+	}
+	if len(idx.ByTag["programming"]) != 2 {
+		t.Errorf("expected 2 posts tagged 'programming', got %d", len(idx.ByTag["programming"]))
+	}
+}
+
+func TestScan_YearIndex(t *testing.T) {
+	fs := fstest.MapFS{
+		"posts/post2024.md": &fstest.MapFile{
+			Data: []byte(mkPost("2024 Post", "post-2024", "2024-05-10", nil, false, "Old.\n")),
+		},
+		"posts/post2025a.md": &fstest.MapFile{
+			Data: []byte(mkPost("2025 Post A", "post-2025a", "2025-03-01", nil, false, "New A.\n")),
+		},
+		"posts/post2025b.md": &fstest.MapFile{
+			Data: []byte(mkPost("2025 Post B", "post-2025b", "2025-06-15", nil, false, "New B.\n")),
+		},
+	}
+
+	idx, err := newTestScanner().Scan(fs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(idx.ByYear[2024]) != 1 {
+		t.Errorf("expected 1 post in 2024, got %d", len(idx.ByYear[2024]))
+	}
+	if len(idx.ByYear[2025]) != 2 {
+		t.Errorf("expected 2 posts in 2025, got %d", len(idx.ByYear[2025]))
+	}
+}
+
+func TestScan_SlugFromFilename(t *testing.T) {
+	// Post without slug in front matter should derive slug from filename
+	fs := fstest.MapFS{
+		"posts/my-great-post.md": &fstest.MapFile{
+			Data: []byte(mkPost("My Great Post", "", "2025-06-01", nil, false, "Content.\n")),
+		},
+	}
+
+	idx, err := newTestScanner().Scan(fs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(idx.Posts) != 1 {
+		t.Fatalf("expected 1 post, got %d", len(idx.Posts))
+	}
+	if idx.Posts[0].Slug != "my-great-post" {
+		t.Errorf("slug = %q, want %q", idx.Posts[0].Slug, "my-great-post")
+	}
+	if idx.BySlug["my-great-post"] == nil {
+		t.Error("BySlug lookup by filename-derived slug failed")
+	}
+}
+
+func TestScan_EmptyDir(t *testing.T) {
+	// posts directory exists but is empty
+	fs := fstest.MapFS{
+		"posts/.gitkeep": &fstest.MapFile{Data: []byte{}},
+	}
+
+	idx, err := newTestScanner().Scan(fs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(idx.Posts) != 0 {
+		t.Errorf("expected 0 posts, got %d", len(idx.Posts))
+	}
+}
+
+func TestScan_MissingDir(t *testing.T) {
+	// Completely empty FS — no posts or pages dirs
+	fs := fstest.MapFS{}
+
+	idx, err := newTestScanner().Scan(fs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(idx.Posts) != 0 {
+		t.Errorf("expected 0 posts, got %d", len(idx.Posts))
+	}
+	if len(idx.Pages) != 0 {
+		t.Errorf("expected 0 pages, got %d", len(idx.Pages))
+	}
+}
+
+func TestSlugFromPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"posts/hello-world.md", "hello-world"},
+		{"posts/sub/nested.md", "nested"},
+		{"my-page.md", "my-page"},
+		{"posts/2025-01-01-post.md", "2025-01-01-post"},
+		{"file.markdown", "file"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := slugFromPath(tt.path)
+			if got != tt.want {
+				t.Errorf("slugFromPath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStripHTML(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain text", "hello world", "hello world"},
+		{"simple tags", "<p>hello</p>", "hello"},
+		{"nested tags", "<div><p><strong>bold</strong> text</p></div>", "bold text"},
+		{"empty tags", "<br/><hr/>", ""},
+		{"mixed content", "before <em>mid</em> after", "before mid after"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripHTML(tt.input)
+			if got != tt.want {
+				t.Errorf("stripHTML(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTruncateText(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		n    int
+		want string
+	}{
+		{"short text", "hello world", 200, "hello world"},
+		{"exact length", "hello", 5, "hello"},
+		{"truncate at word boundary", "the quick brown fox jumps over the lazy dog", 20, "the quick brown fox…"},
+		{"whitespace normalization", "  hello   world  ", 200, "hello world"},
+		{"empty string", "", 200, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateText(tt.text, tt.n)
+			if got != tt.want {
+				t.Errorf("truncateText(%q, %d) = %q, want %q", tt.text, tt.n, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/content/scanner_test.go
+++ b/internal/content/scanner_test.go
@@ -232,6 +232,13 @@ func TestScan_TagIndex(t *testing.T) {
 	if len(idx.ByTag["programming"]) != 2 {
 		t.Errorf("expected 2 posts tagged 'programming', got %d", len(idx.ByTag["programming"]))
 	}
+
+	// Verify ByTag ordering matches sorted Posts (date descending)
+	progPosts := idx.ByTag["programming"]
+	if len(progPosts) == 2 && !progPosts[0].Date.After(progPosts[1].Date) {
+		t.Errorf("ByTag[programming] not sorted by date descending: %s (%s) should be after %s (%s)",
+			progPosts[0].Slug, progPosts[0].Date, progPosts[1].Slug, progPosts[1].Date)
+	}
 }
 
 func TestScan_YearIndex(t *testing.T) {
@@ -451,6 +458,25 @@ func TestScan_PageAllowedWithoutDate(t *testing.T) {
 	}
 	if len(idx.Pages) != 1 {
 		t.Fatalf("expected 1 page, got %d", len(idx.Pages))
+	}
+}
+
+func TestScan_PostPageSlugConflict(t *testing.T) {
+	fs := fstest.MapFS{
+		"posts/about.md": &fstest.MapFile{
+			Data: []byte(mkPost("About Blog", "about", "2025-06-01", nil, false, "Blog about.\n")),
+		},
+		"pages/about.md": &fstest.MapFile{
+			Data: []byte(mkPost("About Page", "about", "2025-01-01", nil, false, "About page.\n")),
+		},
+	}
+
+	_, err := newTestScanner().Scan(fs)
+	if err == nil {
+		t.Fatal("expected error for post/page slug conflict, got nil")
+	}
+	if !strings.Contains(err.Error(), "slug conflict") {
+		t.Errorf("error = %q, want it to mention slug conflict", err)
 	}
 }
 


### PR DESCRIPTION
Content pipeline: walks fs.FS, discovers .md files, parses front matter, renders markdown, builds in-memory index (by slug, tag, year). 14 tests, -race clean.