### PR TITLE
feat: implement HTTP server (internal/server)

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"runtime/debug"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -111,7 +112,11 @@ func (s *Server) RegisterRoutes(opts RouteOptions) {
 		if opts.WebhookHandler == nil {
 			panic("server: RegisterRoutes requires WebhookHandler when sync strategy is webhook")
 		}
-		s.mux.HandleFunc("POST "+s.config.Sync.Webhook.Path, opts.WebhookHandler)
+		webhookPath := s.config.Sync.Webhook.Path
+		if strings.ContainsAny(webhookPath, " \t") {
+			panic(fmt.Sprintf("server: webhook path %q contains spaces", webhookPath))
+		}
+		s.mux.HandleFunc("POST "+webhookPath, opts.WebhookHandler)
 	}
 }
 
@@ -156,7 +161,7 @@ func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
 		next.ServeHTTP(wrapped, r)
 		s.logger.Info("request",
 			"method", r.Method,
-			"path", r.URL.Path,
+			"path", r.URL.RequestURI(),
 			"status", wrapped.statusCode,
 			"duration", time.Since(start),
 			"remote", r.RemoteAddr,
@@ -193,6 +198,10 @@ func (s *Server) recoveryMiddleware(next http.Handler) http.Handler {
 					"path", r.URL.Path,
 					"stack", string(debug.Stack()),
 				)
+				if rw, ok := w.(*responseWriter); ok && rw.headerWritten {
+					// Headers already sent — can't send 500; close connection
+					return
+				}
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			}
 		}()
@@ -202,6 +211,7 @@ func (s *Server) recoveryMiddleware(next http.Handler) http.Handler {
 
 func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, "ok")
 }
@@ -211,6 +221,7 @@ func (s *Server) SetReady(v bool) { s.ready.Store(v) }
 
 func (s *Server) readyHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set("Cache-Control", "no-store")
 	if !s.ready.Load() {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		fmt.Fprint(w, "not ready")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"net"
 	"net/http"
+	"runtime/debug"
+	"sync/atomic"
 	"time"
 
 	"github.com/kenhaines/blogflow/internal/config"
@@ -17,6 +20,7 @@ type Server struct {
 	mux        *http.ServeMux
 	config     *config.Config
 	logger     *slog.Logger
+	ready      atomic.Bool
 }
 
 // New creates a new BlogFlow server.
@@ -33,11 +37,12 @@ func New(cfg *config.Config, logger *slog.Logger) *Server {
 	}
 
 	s.httpServer = &http.Server{
-		Addr:         fmt.Sprintf(":%d", cfg.Server.Port),
-		Handler:      s.middleware(mux),
-		ReadTimeout:  cfg.Server.ReadTimeout,
-		WriteTimeout: cfg.Server.WriteTimeout,
-		IdleTimeout:  cfg.Server.IdleTimeout,
+		Addr:              fmt.Sprintf(":%d", cfg.Server.Port),
+		Handler:           s.middleware(mux),
+		ReadTimeout:       cfg.Server.ReadTimeout,
+		ReadHeaderTimeout: 5 * time.Second,
+		WriteTimeout:      cfg.Server.WriteTimeout,
+		IdleTimeout:       cfg.Server.IdleTimeout,
 	}
 
 	return s
@@ -58,14 +63,34 @@ type RouteOptions struct {
 // RegisterRoutes sets up all HTTP routes. Call this after content and theme are loaded.
 // contentHandler, pageHandler, etc. are injected as http.HandlerFunc.
 func (s *Server) RegisterRoutes(opts RouteOptions) {
+	// Nil-handler guards for required routes.
+	if opts.ListHandler == nil {
+		panic("server: RegisterRoutes requires ListHandler")
+	}
+	if opts.PostHandler == nil {
+		panic("server: RegisterRoutes requires PostHandler")
+	}
+	if opts.PageHandler == nil {
+		panic("server: RegisterRoutes requires PageHandler")
+	}
+	if opts.TagHandler == nil {
+		panic("server: RegisterRoutes requires TagHandler")
+	}
+	if opts.SitemapHandler == nil {
+		panic("server: RegisterRoutes requires SitemapHandler")
+	}
+
 	// Content routes
-	s.mux.HandleFunc("GET /", opts.ListHandler)
+	s.mux.HandleFunc("GET /{$}", opts.ListHandler)
 	s.mux.HandleFunc("GET /posts/{slug}", opts.PostHandler)
 	s.mux.HandleFunc("GET /pages/{slug}", opts.PageHandler)
 	s.mux.HandleFunc("GET /tags/{tag}", opts.TagHandler)
 
 	// Feed
 	if s.config.Feed.Enabled {
+		if opts.FeedHandler == nil {
+			panic("server: RegisterRoutes requires FeedHandler when feed is enabled")
+		}
 		s.mux.HandleFunc("GET /feed.xml", opts.FeedHandler)
 	}
 
@@ -83,7 +108,10 @@ func (s *Server) RegisterRoutes(opts RouteOptions) {
 
 	// Webhook (if configured)
 	if s.config.Sync.Strategy == "webhook" {
-		s.mux.HandleFunc("POST /api/webhook", opts.WebhookHandler)
+		if opts.WebhookHandler == nil {
+			panic("server: RegisterRoutes requires WebhookHandler when sync strategy is webhook")
+		}
+		s.mux.HandleFunc("POST "+s.config.Sync.Webhook.Path, opts.WebhookHandler)
 	}
 }
 
@@ -91,6 +119,15 @@ func (s *Server) RegisterRoutes(opts RouteOptions) {
 func (s *Server) Start() error {
 	s.logger.Info("server starting", "addr", s.httpServer.Addr)
 	if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("server: %w", err)
+	}
+	return nil
+}
+
+// Serve begins serving HTTP on the given listener. Blocks until the server stops.
+func (s *Server) Serve(ln net.Listener) error {
+	s.logger.Info("server starting", "addr", ln.Addr().String())
+	if err := s.httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
 		return fmt.Errorf("server: %w", err)
 	}
 	return nil
@@ -104,9 +141,10 @@ func (s *Server) Shutdown(ctx context.Context) error {
 
 // middleware chains standard middleware: logging, security headers, recovery.
 func (s *Server) middleware(next http.Handler) http.Handler {
-	return s.recoveryMiddleware(
-		s.securityHeadersMiddleware(
-			s.loggingMiddleware(next),
+	// Order: logging (outermost) → recovery → security headers → handler
+	return s.loggingMiddleware(
+		s.recoveryMiddleware(
+			s.securityHeadersMiddleware(next),
 		),
 	)
 }
@@ -144,7 +182,17 @@ func (s *Server) recoveryMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if rec := recover(); rec != nil {
-				s.logger.Error("panic recovered", "panic", rec, "path", r.URL.Path)
+				panicStr := fmt.Sprintf("%v", rec)
+				if len(panicStr) > 256 {
+					panicStr = panicStr[:256] + "...[truncated]"
+				}
+				s.logger.Error("panic recovered",
+					"panic_type", fmt.Sprintf("%T", rec),
+					"panic", panicStr,
+					"method", r.Method,
+					"path", r.URL.Path,
+					"stack", string(debug.Stack()),
+				)
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			}
 		}()
@@ -158,9 +206,16 @@ func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "ok")
 }
 
+// SetReady marks the server as ready (or not) for traffic.
+func (s *Server) SetReady(v bool) { s.ready.Store(v) }
+
 func (s *Server) readyHandler(w http.ResponseWriter, r *http.Request) {
-	// TODO: check that content index is loaded and templates are parsed
 	w.Header().Set("Content-Type", "text/plain")
+	if !s.ready.Load() {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprint(w, "not ready")
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, "ready")
 }
@@ -168,10 +223,26 @@ func (s *Server) readyHandler(w http.ResponseWriter, r *http.Request) {
 // responseWriter wraps http.ResponseWriter to capture the status code.
 type responseWriter struct {
 	http.ResponseWriter
-	statusCode int
+	statusCode    int
+	headerWritten bool
 }
 
 func (rw *responseWriter) WriteHeader(code int) {
-	rw.statusCode = code
-	rw.ResponseWriter.WriteHeader(code)
+	if !rw.headerWritten {
+		rw.statusCode = code
+		rw.headerWritten = true
+		rw.ResponseWriter.WriteHeader(code)
+	}
+}
+
+func (rw *responseWriter) Write(b []byte) (int, error) {
+	if !rw.headerWritten {
+		rw.WriteHeader(http.StatusOK)
+	}
+	return rw.ResponseWriter.Write(b)
+}
+
+// Unwrap returns the underlying ResponseWriter for middleware that need it.
+func (rw *responseWriter) Unwrap() http.ResponseWriter {
+	return rw.ResponseWriter
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,3 +1,5 @@
+// Package server provides BlogFlow's HTTP server with middleware,
+// routing, health checks, and graceful shutdown.
 package server
 
 import (
@@ -213,7 +215,7 @@ func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain")
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprint(w, "ok")
+	_, _ = fmt.Fprint(w, "ok")
 }
 
 // SetReady marks the server as ready (or not) for traffic.
@@ -224,11 +226,11 @@ func (s *Server) readyHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-store")
 	if !s.ready.Load() {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		fmt.Fprint(w, "not ready")
+		_, _ = fmt.Fprint(w, "not ready")
 		return
 	}
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprint(w, "ready")
+	_, _ = fmt.Fprint(w, "ready")
 }
 
 // responseWriter wraps http.ResponseWriter to capture the status code.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,177 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/kenhaines/blogflow/internal/config"
+)
+
+// Server is the BlogFlow HTTP server.
+type Server struct {
+	httpServer *http.Server
+	mux        *http.ServeMux
+	config     *config.Config
+	logger     *slog.Logger
+}
+
+// New creates a new BlogFlow server.
+func New(cfg *config.Config, logger *slog.Logger) *Server {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	mux := http.NewServeMux()
+	s := &Server{
+		mux:    mux,
+		config: cfg,
+		logger: logger,
+	}
+
+	s.httpServer = &http.Server{
+		Addr:         fmt.Sprintf(":%d", cfg.Server.Port),
+		Handler:      s.middleware(mux),
+		ReadTimeout:  cfg.Server.ReadTimeout,
+		WriteTimeout: cfg.Server.WriteTimeout,
+		IdleTimeout:  cfg.Server.IdleTimeout,
+	}
+
+	return s
+}
+
+// RouteOptions holds the handler functions injected into the server.
+type RouteOptions struct {
+	ListHandler    http.HandlerFunc
+	PostHandler    http.HandlerFunc
+	PageHandler    http.HandlerFunc
+	TagHandler     http.HandlerFunc
+	FeedHandler    http.HandlerFunc
+	SitemapHandler http.HandlerFunc
+	WebhookHandler http.HandlerFunc
+	StaticFS       fs.FS
+}
+
+// RegisterRoutes sets up all HTTP routes. Call this after content and theme are loaded.
+// contentHandler, pageHandler, etc. are injected as http.HandlerFunc.
+func (s *Server) RegisterRoutes(opts RouteOptions) {
+	// Content routes
+	s.mux.HandleFunc("GET /", opts.ListHandler)
+	s.mux.HandleFunc("GET /posts/{slug}", opts.PostHandler)
+	s.mux.HandleFunc("GET /pages/{slug}", opts.PageHandler)
+	s.mux.HandleFunc("GET /tags/{tag}", opts.TagHandler)
+
+	// Feed
+	if s.config.Feed.Enabled {
+		s.mux.HandleFunc("GET /feed.xml", opts.FeedHandler)
+	}
+
+	// Sitemap
+	s.mux.HandleFunc("GET /sitemap.xml", opts.SitemapHandler)
+
+	// Health checks
+	s.mux.HandleFunc("GET /healthz", s.healthHandler)
+	s.mux.HandleFunc("GET /readyz", s.readyHandler)
+
+	// Static assets
+	if opts.StaticFS != nil {
+		s.mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServerFS(opts.StaticFS)))
+	}
+
+	// Webhook (if configured)
+	if s.config.Sync.Strategy == "webhook" {
+		s.mux.HandleFunc("POST /api/webhook", opts.WebhookHandler)
+	}
+}
+
+// Start begins serving HTTP. Blocks until the server stops.
+func (s *Server) Start() error {
+	s.logger.Info("server starting", "addr", s.httpServer.Addr)
+	if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("server: %w", err)
+	}
+	return nil
+}
+
+// Shutdown gracefully stops the server with the given context deadline.
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.logger.Info("server shutting down")
+	return s.httpServer.Shutdown(ctx)
+}
+
+// middleware chains standard middleware: logging, security headers, recovery.
+func (s *Server) middleware(next http.Handler) http.Handler {
+	return s.recoveryMiddleware(
+		s.securityHeadersMiddleware(
+			s.loggingMiddleware(next),
+		),
+	)
+}
+
+func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		wrapped := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+		next.ServeHTTP(wrapped, r)
+		s.logger.Info("request",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", wrapped.statusCode,
+			"duration", time.Since(start),
+			"remote", r.RemoteAddr,
+		)
+	})
+}
+
+func (s *Server) securityHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		w.Header().Set("Content-Security-Policy",
+			"default-src 'none'; script-src 'none'; object-src 'none'; "+
+				"connect-src 'none'; style-src 'self'; img-src 'self' https: data:; "+
+				"font-src 'self' https:; base-uri 'self'; form-action 'self'; "+
+				"frame-ancestors 'self'")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) recoveryMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				s.logger.Error("panic recovered", "panic", rec, "path", r.URL.Path)
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, "ok")
+}
+
+func (s *Server) readyHandler(w http.ResponseWriter, r *http.Request) {
+	// TODO: check that content index is loaded and templates are parsed
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, "ready")
+}
+
+// responseWriter wraps http.ResponseWriter to capture the status code.
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -26,7 +26,7 @@ func defaultTestConfig() *config.Config {
 
 func stubHandler(body string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, body)
+		_, _ = fmt.Fprint(w, body)
 	}
 }
 
@@ -218,7 +218,7 @@ func TestRecoveryMiddleware_HeadersAlreadySent(t *testing.T) {
 	panicOpts := testRouteOptions()
 	panicOpts.ListHandler = func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "partial")
+		_, _ = fmt.Fprint(w, "partial")
 		panic("late panic after headers sent")
 	}
 	s.RegisterRoutes(panicOpts)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -211,6 +211,31 @@ func TestRecoveryMiddleware(t *testing.T) {
 	}
 }
 
+func TestRecoveryMiddleware_HeadersAlreadySent(t *testing.T) {
+	cfg := defaultTestConfig()
+	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	panicOpts := testRouteOptions()
+	panicOpts.ListHandler = func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "partial")
+		panic("late panic after headers sent")
+	}
+	s.RegisterRoutes(panicOpts)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	// Must not panic even when headers were already sent.
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	// Status should be the original 200 since headers were already flushed;
+	// the recovery middleware must not attempt http.Error.
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d (headers already sent)", rec.Code, http.StatusOK)
+	}
+}
+
 func TestGracefulShutdown(t *testing.T) {
 	cfg := defaultTestConfig()
 	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
@@ -266,5 +291,68 @@ func TestStaticFileServing(t *testing.T) {
 	}
 	if body := rec.Body.String(); !strings.Contains(body, "color: red") {
 		t.Errorf("body = %q, want CSS content", body)
+	}
+}
+
+func TestWebhookPathWithSpaces_Panics(t *testing.T) {
+	cfg := defaultTestConfig()
+	cfg.Sync.Strategy = "webhook"
+	cfg.Sync.Webhook.Path = "/web hook"
+
+	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for webhook path with spaces")
+		}
+		msg := fmt.Sprintf("%v", r)
+		if !strings.Contains(msg, "contains spaces") {
+			t.Errorf("panic message = %q, want containing %q", msg, "contains spaces")
+		}
+	}()
+
+	s.RegisterRoutes(testRouteOptions())
+}
+
+func TestLoggingMiddleware_RequestURI(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	cfg := defaultTestConfig()
+	s := New(cfg, logger)
+	s.RegisterRoutes(testRouteOptions())
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz?foo=bar", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	logged := buf.String()
+	if !strings.Contains(logged, "/healthz?foo=bar") {
+		t.Errorf("log should contain full RequestURI, got: %s", logged)
+	}
+}
+
+func TestHealthEndpoint_CacheControl(t *testing.T) {
+	s := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q, want %q", got, "no-store")
+	}
+}
+
+func TestReadyEndpoint_CacheControl(t *testing.T) {
+	s := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q, want %q", got, "no-store")
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -79,6 +80,9 @@ func TestNew_CreatesServer(t *testing.T) {
 	if s.httpServer.IdleTimeout != cfg.Server.IdleTimeout {
 		t.Errorf("IdleTimeout = %v, want %v", s.httpServer.IdleTimeout, cfg.Server.IdleTimeout)
 	}
+	if s.httpServer.ReadHeaderTimeout != 5*time.Second {
+		t.Errorf("ReadHeaderTimeout = %v, want %v", s.httpServer.ReadHeaderTimeout, 5*time.Second)
+	}
 }
 
 func TestHealthEndpoint(t *testing.T) {
@@ -99,15 +103,29 @@ func TestHealthEndpoint(t *testing.T) {
 func TestReadyEndpoint(t *testing.T) {
 	s := newTestServer(t)
 
+	// Before SetReady(true), should return 503.
 	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
 	rec := httptest.NewRecorder()
 	s.httpServer.Handler.ServeHTTP(rec, req)
 
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("before SetReady: status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "not ready") {
+		t.Errorf("before SetReady: body = %q, want containing %q", body, "not ready")
+	}
+
+	// After SetReady(true), should return 200.
+	s.SetReady(true)
+	req = httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec = httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
 	if rec.Code != http.StatusOK {
-		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+		t.Errorf("after SetReady: status = %d, want %d", rec.Code, http.StatusOK)
 	}
 	if body := rec.Body.String(); body != "ready" {
-		t.Errorf("body = %q, want %q", body, "ready")
+		t.Errorf("after SetReady: body = %q, want %q", body, "ready")
 	}
 }
 
@@ -195,18 +213,19 @@ func TestRecoveryMiddleware(t *testing.T) {
 
 func TestGracefulShutdown(t *testing.T) {
 	cfg := defaultTestConfig()
-	cfg.Server.Port = 0 // let OS pick a port
 	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	s.RegisterRoutes(testRouteOptions())
 
-	// Start server in background.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+
+	// Start server on the already-open listener (no sleep needed).
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- s.Start()
+		errCh <- s.Serve(ln)
 	}()
-
-	// Give the server a moment to start listening.
-	time.Sleep(50 * time.Millisecond)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -217,7 +236,7 @@ func TestGracefulShutdown(t *testing.T) {
 	select {
 	case err := <-errCh:
 		if err != nil {
-			t.Fatalf("Start returned unexpected error: %v", err)
+			t.Fatalf("Serve returned unexpected error: %v", err)
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("server did not stop within timeout")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,251 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/kenhaines/blogflow/internal/config"
+)
+
+func defaultTestConfig() *config.Config {
+	cfg := config.Default()
+	cfg.Feed.Enabled = true
+	cfg.Sync.Strategy = "webhook"
+	return cfg
+}
+
+func stubHandler(body string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, body)
+	}
+}
+
+func testRouteOptions() RouteOptions {
+	return RouteOptions{
+		ListHandler:    stubHandler("list"),
+		PostHandler:    stubHandler("post"),
+		PageHandler:    stubHandler("page"),
+		TagHandler:     stubHandler("tags"),
+		FeedHandler:    stubHandler("feed"),
+		SitemapHandler: stubHandler("sitemap"),
+		WebhookHandler: stubHandler("webhook"),
+	}
+}
+
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+	cfg := defaultTestConfig()
+	s := New(cfg, slog.Default())
+	s.RegisterRoutes(testRouteOptions())
+	return s
+}
+
+func TestNew_CreatesServer(t *testing.T) {
+	cfg := defaultTestConfig()
+	s := New(cfg, nil)
+
+	if s.httpServer == nil {
+		t.Fatal("httpServer is nil")
+	}
+	if s.mux == nil {
+		t.Fatal("mux is nil")
+	}
+	if s.config != cfg {
+		t.Fatal("config not stored")
+	}
+	if s.logger == nil {
+		t.Fatal("logger is nil — should fall back to slog.Default()")
+	}
+
+	wantAddr := fmt.Sprintf(":%d", cfg.Server.Port)
+	if s.httpServer.Addr != wantAddr {
+		t.Errorf("Addr = %q, want %q", s.httpServer.Addr, wantAddr)
+	}
+	if s.httpServer.ReadTimeout != cfg.Server.ReadTimeout {
+		t.Errorf("ReadTimeout = %v, want %v", s.httpServer.ReadTimeout, cfg.Server.ReadTimeout)
+	}
+	if s.httpServer.WriteTimeout != cfg.Server.WriteTimeout {
+		t.Errorf("WriteTimeout = %v, want %v", s.httpServer.WriteTimeout, cfg.Server.WriteTimeout)
+	}
+	if s.httpServer.IdleTimeout != cfg.Server.IdleTimeout {
+		t.Errorf("IdleTimeout = %v, want %v", s.httpServer.IdleTimeout, cfg.Server.IdleTimeout)
+	}
+}
+
+func TestHealthEndpoint(t *testing.T) {
+	s := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != "ok" {
+		t.Errorf("body = %q, want %q", body, "ok")
+	}
+}
+
+func TestReadyEndpoint(t *testing.T) {
+	s := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != "ready" {
+		t.Errorf("body = %q, want %q", body, "ready")
+	}
+}
+
+func TestSecurityHeaders(t *testing.T) {
+	s := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	headers := map[string]string{
+		"X-Content-Type-Options": "nosniff",
+		"X-Frame-Options":        "SAMEORIGIN",
+		"Referrer-Policy":        "strict-origin-when-cross-origin",
+	}
+	for key, want := range headers {
+		got := rec.Header().Get(key)
+		if got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+
+	csp := rec.Header().Get("Content-Security-Policy")
+	if csp == "" {
+		t.Fatal("Content-Security-Policy header missing")
+	}
+}
+
+func TestCSPHeader(t *testing.T) {
+	s := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	csp := rec.Header().Get("Content-Security-Policy")
+	if !strings.Contains(csp, "frame-ancestors") {
+		t.Errorf("CSP missing frame-ancestors directive: %s", csp)
+	}
+	if !strings.Contains(csp, "default-src 'none'") {
+		t.Errorf("CSP missing default-src 'none': %s", csp)
+	}
+}
+
+func TestLoggingMiddleware(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	cfg := defaultTestConfig()
+	s := New(cfg, logger)
+	s.RegisterRoutes(testRouteOptions())
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	logged := buf.String()
+	for _, want := range []string{"method", "path", "status", "duration"} {
+		if !strings.Contains(logged, want) {
+			t.Errorf("log output missing %q: %s", want, logged)
+		}
+	}
+}
+
+func TestRecoveryMiddleware(t *testing.T) {
+	cfg := defaultTestConfig()
+	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	panicOpts := testRouteOptions()
+	panicOpts.ListHandler = func(w http.ResponseWriter, r *http.Request) {
+		panic("test panic")
+	}
+	s.RegisterRoutes(panicOpts)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	// Must not panic — recovery middleware catches it.
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestGracefulShutdown(t *testing.T) {
+	cfg := defaultTestConfig()
+	cfg.Server.Port = 0 // let OS pick a port
+	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	s.RegisterRoutes(testRouteOptions())
+
+	// Start server in background.
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.Start()
+	}()
+
+	// Give the server a moment to start listening.
+	time.Sleep(50 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := s.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown error: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Start returned unexpected error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("server did not stop within timeout")
+	}
+}
+
+func TestStaticFileServing(t *testing.T) {
+	cfg := defaultTestConfig()
+	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	staticFS := fstest.MapFS{
+		"css/style.css": &fstest.MapFile{
+			Data: []byte("body { color: red; }"),
+		},
+	}
+
+	opts := testRouteOptions()
+	opts.StaticFS = staticFS
+	s.RegisterRoutes(opts)
+
+	req := httptest.NewRequest(http.MethodGet, "/static/css/style.css", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "color: red") {
+		t.Errorf("body = %q, want CSS content", body)
+	}
+}


### PR DESCRIPTION
Go 1.22+ ServeMux with route registration, middleware chain (recovery→security headers→logging), health/ready endpoints, static file serving, graceful shutdown. 9 tests, -race clean.