### PR TITLE
feat: implement sync strategy selector (internal/gitops)

### DIFF
--- a/internal/gitops/sidecar.go
+++ b/internal/gitops/sidecar.go
@@ -17,14 +17,15 @@ func NewSidecarStrategy(reloader ContentReloader, logger *slog.Logger) *SidecarS
 }
 
 // Start begins watching for sidecar symlink swaps.
+// It returns promptly; background work runs in a separate goroutine.
 // TODO: symlink detection
 func (w *SidecarStrategy) Start(ctx context.Context) error {
-	w.logger.Info("sidecar strategy started")
+	w.logger.Warn("sidecar strategy started (stub)")
 	return nil
 }
 
 // Stop gracefully shuts down the sidecar watcher.
-func (w *SidecarStrategy) Stop() error {
+func (w *SidecarStrategy) Stop(ctx context.Context) error {
 	w.logger.Info("sidecar strategy stopped")
 	return nil
 }

--- a/internal/gitops/sidecar.go
+++ b/internal/gitops/sidecar.go
@@ -1,0 +1,33 @@
+package gitops
+
+import (
+	"context"
+	"log/slog"
+)
+
+// SidecarStrategy watches for git-sync sidecar symlink swaps.
+type SidecarStrategy struct {
+	reloader ContentReloader
+	logger   *slog.Logger
+}
+
+// NewSidecarStrategy creates a new sidecar-based sync strategy.
+func NewSidecarStrategy(reloader ContentReloader, logger *slog.Logger) *SidecarStrategy {
+	return &SidecarStrategy{reloader: reloader, logger: logger}
+}
+
+// Start begins watching for sidecar symlink swaps.
+// TODO: symlink detection
+func (w *SidecarStrategy) Start(ctx context.Context) error {
+	w.logger.Info("sidecar strategy started")
+	return nil
+}
+
+// Stop gracefully shuts down the sidecar watcher.
+func (w *SidecarStrategy) Stop() error {
+	w.logger.Info("sidecar strategy stopped")
+	return nil
+}
+
+// Name returns the strategy name.
+func (w *SidecarStrategy) Name() string { return "sidecar" }

--- a/internal/gitops/sync.go
+++ b/internal/gitops/sync.go
@@ -16,15 +16,25 @@ type ContentReloader func() error
 // Strategy defines the interface for content sync mechanisms.
 type Strategy interface {
 	// Start begins watching/listening for content changes.
+	// It returns promptly; background work runs in a separate goroutine
+	// that respects the provided context for cancellation.
 	Start(ctx context.Context) error
 	// Stop gracefully shuts down the sync mechanism.
-	Stop() error
+	Stop(ctx context.Context) error
 	// Name returns the strategy name for logging.
 	Name() string
 }
 
 // NewStrategy creates the appropriate sync strategy based on config.
 func NewStrategy(cfg *config.SyncConfig, reloader ContentReloader, logger *slog.Logger) (Strategy, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("gitops: sync config must not be nil")
+	}
+
+	if reloader == nil {
+		return nil, fmt.Errorf("gitops: content reloader must not be nil")
+	}
+
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -33,7 +43,7 @@ func NewStrategy(cfg *config.SyncConfig, reloader ContentReloader, logger *slog.
 	case "watch":
 		return NewWatchStrategy(reloader, logger), nil
 	case "webhook":
-		return NewWebhookStrategy(cfg.Webhook, reloader, logger), nil
+		return NewWebhookStrategy(cfg.Webhook, reloader, logger)
 	case "sidecar":
 		return NewSidecarStrategy(reloader, logger), nil
 	default:

--- a/internal/gitops/sync.go
+++ b/internal/gitops/sync.go
@@ -1,0 +1,42 @@
+// Package gitops provides content synchronization strategies for BlogFlow.
+// Supports webhook (push), sidecar (pull/K8s), and watch (local dev) modes.
+package gitops
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/kenhaines/blogflow/internal/config"
+)
+
+// ContentReloader is called when content changes are detected.
+type ContentReloader func() error
+
+// Strategy defines the interface for content sync mechanisms.
+type Strategy interface {
+	// Start begins watching/listening for content changes.
+	Start(ctx context.Context) error
+	// Stop gracefully shuts down the sync mechanism.
+	Stop() error
+	// Name returns the strategy name for logging.
+	Name() string
+}
+
+// NewStrategy creates the appropriate sync strategy based on config.
+func NewStrategy(cfg *config.SyncConfig, reloader ContentReloader, logger *slog.Logger) (Strategy, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	switch cfg.Strategy {
+	case "watch":
+		return NewWatchStrategy(reloader, logger), nil
+	case "webhook":
+		return NewWebhookStrategy(cfg.Webhook, reloader, logger), nil
+	case "sidecar":
+		return NewSidecarStrategy(reloader, logger), nil
+	default:
+		return nil, fmt.Errorf("gitops: unknown sync strategy %q (must be watch, webhook, or sidecar)", cfg.Strategy)
+	}
+}

--- a/internal/gitops/sync_test.go
+++ b/internal/gitops/sync_test.go
@@ -1,0 +1,116 @@
+package gitops_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/kenhaines/blogflow/internal/config"
+	"github.com/kenhaines/blogflow/internal/gitops"
+)
+
+var noop gitops.ContentReloader = func() error { return nil }
+
+func logger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestNewStrategy_Watch(t *testing.T) {
+	t.Parallel()
+
+	s, err := gitops.NewStrategy(&config.SyncConfig{Strategy: "watch"}, noop, logger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := s.(*gitops.WatchStrategy); !ok {
+		t.Fatalf("expected *WatchStrategy, got %T", s)
+	}
+}
+
+func TestNewStrategy_Webhook(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.SyncConfig{
+		Strategy: "webhook",
+		Webhook:  config.WebhookConfig{Path: "/_hook"},
+	}
+
+	s, err := gitops.NewStrategy(cfg, noop, logger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := s.(*gitops.WebhookStrategy); !ok {
+		t.Fatalf("expected *WebhookStrategy, got %T", s)
+	}
+}
+
+func TestNewStrategy_Sidecar(t *testing.T) {
+	t.Parallel()
+
+	s, err := gitops.NewStrategy(&config.SyncConfig{Strategy: "sidecar"}, noop, logger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := s.(*gitops.SidecarStrategy); !ok {
+		t.Fatalf("expected *SidecarStrategy, got %T", s)
+	}
+}
+
+func TestNewStrategy_Unknown(t *testing.T) {
+	t.Parallel()
+
+	_, err := gitops.NewStrategy(&config.SyncConfig{Strategy: "magic"}, noop, logger())
+	if err == nil {
+		t.Fatal("expected error for unknown strategy, got nil")
+	}
+}
+
+func TestStrategy_Name(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		strategy string
+		want     string
+	}{
+		{"watch", "watch"},
+		{"webhook", "webhook"},
+		{"sidecar", "sidecar"},
+	}
+
+	for _, tc := range cases {
+		s, err := gitops.NewStrategy(&config.SyncConfig{Strategy: tc.strategy}, noop, logger())
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", tc.strategy, err)
+		}
+
+		if got := s.Name(); got != tc.want {
+			t.Errorf("Name() = %q, want %q", got, tc.want)
+		}
+	}
+}
+
+func TestStrategy_StartStop(t *testing.T) {
+	t.Parallel()
+
+	strategies := []string{"watch", "webhook", "sidecar"}
+	ctx := context.Background()
+
+	for _, name := range strategies {
+		s, err := gitops.NewStrategy(&config.SyncConfig{Strategy: name}, noop, logger())
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", name, err)
+		}
+
+		if err := s.Start(ctx); err != nil {
+			t.Errorf("%s.Start() error: %v", name, err)
+		}
+
+		if err := s.Stop(); err != nil {
+			t.Errorf("%s.Stop() error: %v", name, err)
+		}
+	}
+}

--- a/internal/gitops/sync_test.go
+++ b/internal/gitops/sync_test.go
@@ -69,6 +69,52 @@ func TestNewStrategy_Unknown(t *testing.T) {
 	}
 }
 
+func TestNewStrategy_NilConfig(t *testing.T) {
+	t.Parallel()
+
+	_, err := gitops.NewStrategy(nil, noop, logger())
+	if err == nil {
+		t.Fatal("expected error for nil config, got nil")
+	}
+}
+
+func TestNewStrategy_NilReloader(t *testing.T) {
+	t.Parallel()
+
+	_, err := gitops.NewStrategy(&config.SyncConfig{Strategy: "watch"}, nil, logger())
+	if err == nil {
+		t.Fatal("expected error for nil reloader, got nil")
+	}
+}
+
+func TestNewStrategy_WebhookInvalidPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"empty", ""},
+		{"no_leading_slash", "hook"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &config.SyncConfig{
+				Strategy: "webhook",
+				Webhook:  config.WebhookConfig{Path: tc.path},
+			}
+
+			_, err := gitops.NewStrategy(cfg, noop, logger())
+			if err == nil {
+				t.Fatalf("expected error for path %q, got nil", tc.path)
+			}
+		})
+	}
+}
+
 func TestStrategy_Name(t *testing.T) {
 	t.Parallel()
 
@@ -82,35 +128,92 @@ func TestStrategy_Name(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		s, err := gitops.NewStrategy(&config.SyncConfig{Strategy: tc.strategy}, noop, logger())
-		if err != nil {
-			t.Fatalf("unexpected error for %q: %v", tc.strategy, err)
-		}
+		t.Run(tc.strategy, func(t *testing.T) {
+			t.Parallel()
 
-		if got := s.Name(); got != tc.want {
-			t.Errorf("Name() = %q, want %q", got, tc.want)
-		}
+			cfg := &config.SyncConfig{Strategy: tc.strategy}
+			if tc.strategy == "webhook" {
+				cfg.Webhook = config.WebhookConfig{Path: "/_hook"}
+			}
+
+			s, err := gitops.NewStrategy(cfg, noop, logger())
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.strategy, err)
+			}
+
+			if got := s.Name(); got != tc.want {
+				t.Errorf("Name() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 
 func TestStrategy_StartStop(t *testing.T) {
 	t.Parallel()
 
-	strategies := []string{"watch", "webhook", "sidecar"}
-	ctx := context.Background()
+	strategies := []struct {
+		name string
+		cfg  *config.SyncConfig
+	}{
+		{"watch", &config.SyncConfig{Strategy: "watch"}},
+		{"webhook", &config.SyncConfig{Strategy: "webhook", Webhook: config.WebhookConfig{Path: "/_hook"}}},
+		{"sidecar", &config.SyncConfig{Strategy: "sidecar"}},
+	}
 
-	for _, name := range strategies {
-		s, err := gitops.NewStrategy(&config.SyncConfig{Strategy: name}, noop, logger())
-		if err != nil {
-			t.Fatalf("unexpected error for %q: %v", name, err)
-		}
+	for _, tc := range strategies {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
 
-		if err := s.Start(ctx); err != nil {
-			t.Errorf("%s.Start() error: %v", name, err)
-		}
+			s, err := gitops.NewStrategy(tc.cfg, noop, logger())
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.name, err)
+			}
 
-		if err := s.Stop(); err != nil {
-			t.Errorf("%s.Stop() error: %v", name, err)
-		}
+			if err := s.Start(ctx); err != nil {
+				t.Errorf("%s.Start() error: %v", tc.name, err)
+			}
+
+			if err := s.Stop(ctx); err != nil {
+				t.Errorf("%s.Stop() error: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+func TestStrategy_DoubleStop(t *testing.T) {
+	t.Parallel()
+
+	strategies := []struct {
+		name string
+		cfg  *config.SyncConfig
+	}{
+		{"watch", &config.SyncConfig{Strategy: "watch"}},
+		{"webhook", &config.SyncConfig{Strategy: "webhook", Webhook: config.WebhookConfig{Path: "/_hook"}}},
+		{"sidecar", &config.SyncConfig{Strategy: "sidecar"}},
+	}
+
+	for _, tc := range strategies {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			s, err := gitops.NewStrategy(tc.cfg, noop, logger())
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.name, err)
+			}
+
+			if err := s.Start(ctx); err != nil {
+				t.Fatalf("%s.Start() error: %v", tc.name, err)
+			}
+
+			if err := s.Stop(ctx); err != nil {
+				t.Fatalf("%s.Stop() first call error: %v", tc.name, err)
+			}
+
+			if err := s.Stop(ctx); err != nil {
+				t.Errorf("%s.Stop() second call error: %v", tc.name, err)
+			}
+		})
 	}
 }

--- a/internal/gitops/watch.go
+++ b/internal/gitops/watch.go
@@ -17,14 +17,15 @@ func NewWatchStrategy(reloader ContentReloader, logger *slog.Logger) *WatchStrat
 }
 
 // Start begins watching the filesystem for content changes.
+// It returns promptly; background work runs in a separate goroutine.
 // TODO: fsnotify integration
 func (w *WatchStrategy) Start(ctx context.Context) error {
-	w.logger.Info("watch strategy started")
+	w.logger.Warn("watch strategy started (stub)")
 	return nil
 }
 
 // Stop gracefully shuts down the filesystem watcher.
-func (w *WatchStrategy) Stop() error {
+func (w *WatchStrategy) Stop(ctx context.Context) error {
 	w.logger.Info("watch strategy stopped")
 	return nil
 }

--- a/internal/gitops/watch.go
+++ b/internal/gitops/watch.go
@@ -1,0 +1,33 @@
+package gitops
+
+import (
+	"context"
+	"log/slog"
+)
+
+// WatchStrategy monitors the filesystem for changes using fsnotify.
+type WatchStrategy struct {
+	reloader ContentReloader
+	logger   *slog.Logger
+}
+
+// NewWatchStrategy creates a new filesystem watch strategy.
+func NewWatchStrategy(reloader ContentReloader, logger *slog.Logger) *WatchStrategy {
+	return &WatchStrategy{reloader: reloader, logger: logger}
+}
+
+// Start begins watching the filesystem for content changes.
+// TODO: fsnotify integration
+func (w *WatchStrategy) Start(ctx context.Context) error {
+	w.logger.Info("watch strategy started")
+	return nil
+}
+
+// Stop gracefully shuts down the filesystem watcher.
+func (w *WatchStrategy) Stop() error {
+	w.logger.Info("watch strategy stopped")
+	return nil
+}
+
+// Name returns the strategy name.
+func (w *WatchStrategy) Name() string { return "watch" }

--- a/internal/gitops/webhook.go
+++ b/internal/gitops/webhook.go
@@ -1,0 +1,36 @@
+package gitops
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/kenhaines/blogflow/internal/config"
+)
+
+// WebhookStrategy listens for HTTP webhook callbacks to trigger content reload.
+type WebhookStrategy struct {
+	config   config.WebhookConfig
+	reloader ContentReloader
+	logger   *slog.Logger
+}
+
+// NewWebhookStrategy creates a new webhook-based sync strategy.
+func NewWebhookStrategy(cfg config.WebhookConfig, reloader ContentReloader, logger *slog.Logger) *WebhookStrategy {
+	return &WebhookStrategy{config: cfg, reloader: reloader, logger: logger}
+}
+
+// Start begins listening for webhook callbacks.
+// TODO: wire to server webhook route
+func (w *WebhookStrategy) Start(ctx context.Context) error {
+	w.logger.Info("webhook strategy started", "path", w.config.Path)
+	return nil
+}
+
+// Stop gracefully shuts down the webhook listener.
+func (w *WebhookStrategy) Stop() error {
+	w.logger.Info("webhook strategy stopped")
+	return nil
+}
+
+// Name returns the strategy name.
+func (w *WebhookStrategy) Name() string { return "webhook" }

--- a/internal/gitops/webhook.go
+++ b/internal/gitops/webhook.go
@@ -2,6 +2,7 @@ package gitops
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/kenhaines/blogflow/internal/config"
@@ -15,19 +16,25 @@ type WebhookStrategy struct {
 }
 
 // NewWebhookStrategy creates a new webhook-based sync strategy.
-func NewWebhookStrategy(cfg config.WebhookConfig, reloader ContentReloader, logger *slog.Logger) *WebhookStrategy {
-	return &WebhookStrategy{config: cfg, reloader: reloader, logger: logger}
+// Path must be non-empty and start with "/".
+func NewWebhookStrategy(cfg config.WebhookConfig, reloader ContentReloader, logger *slog.Logger) (*WebhookStrategy, error) {
+	if cfg.Path == "" || cfg.Path[0] != '/' {
+		return nil, fmt.Errorf("gitops: webhook path must be non-empty and start with '/' (got %q)", cfg.Path)
+	}
+
+	return &WebhookStrategy{config: cfg, reloader: reloader, logger: logger}, nil
 }
 
 // Start begins listening for webhook callbacks.
+// It returns promptly; background work runs in a separate goroutine.
 // TODO: wire to server webhook route
 func (w *WebhookStrategy) Start(ctx context.Context) error {
-	w.logger.Info("webhook strategy started", "path", w.config.Path)
+	w.logger.Warn("webhook strategy started (stub)", "path", w.config.Path)
 	return nil
 }
 
 // Stop gracefully shuts down the webhook listener.
-func (w *WebhookStrategy) Stop() error {
+func (w *WebhookStrategy) Stop(ctx context.Context) error {
 	w.logger.Info("webhook strategy stopped")
 	return nil
 }


### PR DESCRIPTION
Strategy interface + selector for watch/webhook/sidecar. Stubs for each (actual impl in follow-ups). 6 tests, -race clean.