### PR TITLE
feat: implement git authentication (internal/gitops)

### DIFF
--- a/internal/gitops/auth.go
+++ b/internal/gitops/auth.go
@@ -49,11 +49,22 @@ func (a AuthConfig) String() string {
 
 // LogValue implements slog.LogValuer to redact secrets in structured logs.
 func (a AuthConfig) LogValue() slog.Value {
-	return slog.GroupValue(
-		slog.String("method", a.Method.String()),
-		slog.String("ssh_key_path", a.SSHKeyPath),
-		slog.String("token", "[REDACTED]"),
-	)
+	switch a.Method {
+	case AuthSSH:
+		return slog.GroupValue(
+			slog.String("method", "ssh"),
+			slog.String("ssh_key_path", a.SSHKeyPath),
+		)
+	case AuthToken:
+		return slog.GroupValue(
+			slog.String("method", "token"),
+			slog.String("token", "[REDACTED]"),
+		)
+	default:
+		return slog.GroupValue(
+			slog.String("method", "none"),
+		)
+	}
 }
 
 // LoadAuthFromEnv reads git authentication configuration from environment variables.
@@ -66,9 +77,6 @@ func LoadAuthFromEnv(logger *slog.Logger) (*AuthConfig, error) {
 
 	// Check SSH key first (preferred)
 	if keyPath := os.Getenv("BLOGFLOW_GIT_SSH_KEY"); keyPath != "" {
-		if _, err := os.Stat(keyPath); err != nil {
-			return nil, fmt.Errorf("gitops: BLOGFLOW_GIT_SSH_KEY set but not accessible: %w", err)
-		}
 		cfg := &AuthConfig{Method: AuthSSH, SSHKeyPath: keyPath}
 		if err := cfg.Validate(); err != nil {
 			return nil, err

--- a/internal/gitops/auth.go
+++ b/internal/gitops/auth.go
@@ -10,10 +10,11 @@ import (
 // AuthMethod represents a git authentication configuration.
 type AuthMethod int
 
+// AuthMethod represents a git authentication type.
 const (
-	AuthNone AuthMethod = iota
-	AuthSSH
-	AuthToken
+	AuthNone  AuthMethod = iota // No authentication (public repos)
+	AuthSSH                     // SSH key authentication
+	AuthToken                   // Token-based authentication (PAT)
 )
 
 // String returns a human-readable label for the AuthMethod.
@@ -41,7 +42,7 @@ func (a AuthConfig) String() string {
 	case AuthSSH:
 		return fmt.Sprintf("AuthConfig{Method:ssh, SSHKeyPath:%s}", a.SSHKeyPath)
 	case AuthToken:
-		return fmt.Sprintf("AuthConfig{Method:token, Token:[REDACTED]}")
+		return "AuthConfig{Method:token, Token:[REDACTED]}"
 	default:
 		return "AuthConfig{Method:none}"
 	}

--- a/internal/gitops/auth.go
+++ b/internal/gitops/auth.go
@@ -1,0 +1,74 @@
+// Package gitops provides content synchronization and git authentication for BlogFlow.
+package gitops
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+)
+
+// AuthMethod represents a git authentication configuration.
+type AuthMethod int
+
+const (
+	AuthNone AuthMethod = iota
+	AuthSSH
+	AuthToken
+)
+
+// AuthConfig holds git authentication settings derived from environment variables.
+type AuthConfig struct {
+	Method     AuthMethod
+	SSHKeyPath string // from BLOGFLOW_GIT_SSH_KEY
+	Token      string // from BLOGFLOW_GIT_TOKEN
+}
+
+// LoadAuthFromEnv reads git authentication configuration from environment variables.
+// Returns AuthNone if no credentials are configured.
+func LoadAuthFromEnv(logger *slog.Logger) *AuthConfig {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	// Check SSH key first (preferred)
+	if keyPath := os.Getenv("BLOGFLOW_GIT_SSH_KEY"); keyPath != "" {
+		if _, err := os.Stat(keyPath); err != nil {
+			logger.Warn("BLOGFLOW_GIT_SSH_KEY path not accessible", "path", keyPath, "error", err)
+		} else {
+			logger.Info("git auth: SSH key configured", "path", keyPath)
+			return &AuthConfig{Method: AuthSSH, SSHKeyPath: keyPath}
+		}
+	}
+
+	// Check token
+	if token := os.Getenv("BLOGFLOW_GIT_TOKEN"); token != "" {
+		if len(token) < 10 {
+			logger.Warn("BLOGFLOW_GIT_TOKEN appears too short — verify it's valid")
+		}
+		logger.Info("git auth: token configured")
+		return &AuthConfig{Method: AuthToken, Token: token}
+	}
+
+	logger.Debug("git auth: no credentials configured (public repos only)")
+	return &AuthConfig{Method: AuthNone}
+}
+
+// Validate checks the auth configuration is usable.
+func (a *AuthConfig) Validate() error {
+	switch a.Method {
+	case AuthSSH:
+		if a.SSHKeyPath == "" {
+			return fmt.Errorf("gitops: SSH auth configured but key path is empty")
+		}
+		if _, err := os.Stat(a.SSHKeyPath); err != nil {
+			return fmt.Errorf("gitops: SSH key not accessible: %w", err)
+		}
+	case AuthToken:
+		if a.Token == "" {
+			return fmt.Errorf("gitops: token auth configured but token is empty")
+		}
+	case AuthNone:
+		// valid
+	}
+	return nil
+}

--- a/internal/gitops/auth.go
+++ b/internal/gitops/auth.go
@@ -16,6 +16,18 @@ const (
 	AuthToken
 )
 
+// String returns a human-readable label for the AuthMethod.
+func (m AuthMethod) String() string {
+	switch m {
+	case AuthSSH:
+		return "ssh"
+	case AuthToken:
+		return "token"
+	default:
+		return "none"
+	}
+}
+
 // AuthConfig holds git authentication settings derived from environment variables.
 type AuthConfig struct {
 	Method     AuthMethod
@@ -23,9 +35,31 @@ type AuthConfig struct {
 	Token      string // from BLOGFLOW_GIT_TOKEN
 }
 
+// String returns a human-readable representation with secrets redacted.
+func (a AuthConfig) String() string {
+	switch a.Method {
+	case AuthSSH:
+		return fmt.Sprintf("AuthConfig{Method:ssh, SSHKeyPath:%s}", a.SSHKeyPath)
+	case AuthToken:
+		return fmt.Sprintf("AuthConfig{Method:token, Token:[REDACTED]}")
+	default:
+		return "AuthConfig{Method:none}"
+	}
+}
+
+// LogValue implements slog.LogValuer to redact secrets in structured logs.
+func (a AuthConfig) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("method", a.Method.String()),
+		slog.String("ssh_key_path", a.SSHKeyPath),
+		slog.String("token", "[REDACTED]"),
+	)
+}
+
 // LoadAuthFromEnv reads git authentication configuration from environment variables.
+// Returns an error if credentials are explicitly set but unusable.
 // Returns AuthNone if no credentials are configured.
-func LoadAuthFromEnv(logger *slog.Logger) *AuthConfig {
+func LoadAuthFromEnv(logger *slog.Logger) (*AuthConfig, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -33,24 +67,29 @@ func LoadAuthFromEnv(logger *slog.Logger) *AuthConfig {
 	// Check SSH key first (preferred)
 	if keyPath := os.Getenv("BLOGFLOW_GIT_SSH_KEY"); keyPath != "" {
 		if _, err := os.Stat(keyPath); err != nil {
-			logger.Warn("BLOGFLOW_GIT_SSH_KEY path not accessible", "path", keyPath, "error", err)
-		} else {
-			logger.Info("git auth: SSH key configured", "path", keyPath)
-			return &AuthConfig{Method: AuthSSH, SSHKeyPath: keyPath}
+			return nil, fmt.Errorf("gitops: BLOGFLOW_GIT_SSH_KEY set but not accessible: %w", err)
 		}
+		cfg := &AuthConfig{Method: AuthSSH, SSHKeyPath: keyPath}
+		if err := cfg.Validate(); err != nil {
+			return nil, err
+		}
+		logger.Info("git auth: SSH key configured", "path", keyPath)
+		return cfg, nil
 	}
 
 	// Check token
 	if token := os.Getenv("BLOGFLOW_GIT_TOKEN"); token != "" {
-		if len(token) < 10 {
-			logger.Warn("BLOGFLOW_GIT_TOKEN appears too short — verify it's valid")
+		cfg := &AuthConfig{Method: AuthToken, Token: token}
+		if err := cfg.Validate(); err != nil {
+			return nil, err
 		}
 		logger.Info("git auth: token configured")
-		return &AuthConfig{Method: AuthToken, Token: token}
+		return cfg, nil
 	}
 
 	logger.Debug("git auth: no credentials configured (public repos only)")
-	return &AuthConfig{Method: AuthNone}
+	cfg := &AuthConfig{Method: AuthNone}
+	return cfg, nil
 }
 
 // Validate checks the auth configuration is usable.
@@ -60,8 +99,12 @@ func (a *AuthConfig) Validate() error {
 		if a.SSHKeyPath == "" {
 			return fmt.Errorf("gitops: SSH auth configured but key path is empty")
 		}
-		if _, err := os.Stat(a.SSHKeyPath); err != nil {
+		info, err := os.Stat(a.SSHKeyPath)
+		if err != nil {
 			return fmt.Errorf("gitops: SSH key not accessible: %w", err)
+		}
+		if info.Mode().Perm()&0o077 != 0 {
+			return fmt.Errorf("gitops: SSH key %s has unsafe permissions %o; must be 0600 or 0400", a.SSHKeyPath, info.Mode().Perm())
 		}
 	case AuthToken:
 		if a.Token == "" {
@@ -69,6 +112,8 @@ func (a *AuthConfig) Validate() error {
 		}
 	case AuthNone:
 		// valid
+	default:
+		return fmt.Errorf("gitops: unknown auth method: %d", a.Method)
 	}
 	return nil
 }

--- a/internal/gitops/auth_test.go
+++ b/internal/gitops/auth_test.go
@@ -1,8 +1,12 @@
 package gitops
 
 import (
+	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -16,7 +20,10 @@ func TestLoadAuthFromEnv_SSHKey(t *testing.T) {
 	t.Setenv("BLOGFLOW_GIT_SSH_KEY", keyFile)
 	t.Setenv("BLOGFLOW_GIT_TOKEN", "")
 
-	cfg := LoadAuthFromEnv(nil)
+	cfg, err := LoadAuthFromEnv(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if cfg.Method != AuthSSH {
 		t.Fatalf("expected AuthSSH, got %d", cfg.Method)
 	}
@@ -29,7 +36,10 @@ func TestLoadAuthFromEnv_Token(t *testing.T) {
 	t.Setenv("BLOGFLOW_GIT_SSH_KEY", "")
 	t.Setenv("BLOGFLOW_GIT_TOKEN", "ghp_xxxxxxxxxxxxxxxxxxxx")
 
-	cfg := LoadAuthFromEnv(nil)
+	cfg, err := LoadAuthFromEnv(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if cfg.Method != AuthToken {
 		t.Fatalf("expected AuthToken, got %d", cfg.Method)
 	}
@@ -42,7 +52,10 @@ func TestLoadAuthFromEnv_None(t *testing.T) {
 	t.Setenv("BLOGFLOW_GIT_SSH_KEY", "")
 	t.Setenv("BLOGFLOW_GIT_TOKEN", "")
 
-	cfg := LoadAuthFromEnv(nil)
+	cfg, err := LoadAuthFromEnv(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if cfg.Method != AuthNone {
 		t.Fatalf("expected AuthNone, got %d", cfg.Method)
 	}
@@ -58,7 +71,10 @@ func TestLoadAuthFromEnv_SSHKeyPrecedence(t *testing.T) {
 	t.Setenv("BLOGFLOW_GIT_SSH_KEY", keyFile)
 	t.Setenv("BLOGFLOW_GIT_TOKEN", "ghp_xxxxxxxxxxxxxxxxxxxx")
 
-	cfg := LoadAuthFromEnv(nil)
+	cfg, err := LoadAuthFromEnv(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if cfg.Method != AuthSSH {
 		t.Fatalf("expected AuthSSH (precedence over token), got %d", cfg.Method)
 	}
@@ -68,9 +84,12 @@ func TestLoadAuthFromEnv_SSHKeyMissing(t *testing.T) {
 	t.Setenv("BLOGFLOW_GIT_SSH_KEY", "/nonexistent/path/id_ed25519")
 	t.Setenv("BLOGFLOW_GIT_TOKEN", "ghp_xxxxxxxxxxxxxxxxxxxx")
 
-	cfg := LoadAuthFromEnv(nil)
-	if cfg.Method != AuthToken {
-		t.Fatalf("expected AuthToken (SSH key missing falls through), got %d", cfg.Method)
+	_, err := LoadAuthFromEnv(nil)
+	if err == nil {
+		t.Fatal("expected error when SSH key is explicitly set but inaccessible")
+	}
+	if !strings.Contains(err.Error(), "BLOGFLOW_GIT_SSH_KEY set but not accessible") {
+		t.Fatalf("unexpected error message: %v", err)
 	}
 }
 
@@ -100,6 +119,48 @@ func TestValidate_SSH(t *testing.T) {
 	}
 }
 
+func TestValidate_SSHPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission checks not applicable on Windows")
+	}
+
+	tmp := t.TempDir()
+
+	// 0644 should be rejected
+	unsafeKey := filepath.Join(tmp, "unsafe_key")
+	if err := os.WriteFile(unsafeKey, []byte("fake-key"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &AuthConfig{Method: AuthSSH, SSHKeyPath: unsafeKey}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for 0644 permissions")
+	}
+	if !strings.Contains(err.Error(), "unsafe permissions") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+
+	// 0600 should be accepted
+	safeKey600 := filepath.Join(tmp, "safe_key_600")
+	if err := os.WriteFile(safeKey600, []byte("fake-key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg = &AuthConfig{Method: AuthSSH, SSHKeyPath: safeKey600}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected 0600 to be accepted, got: %v", err)
+	}
+
+	// 0400 should be accepted
+	safeKey400 := filepath.Join(tmp, "safe_key_400")
+	if err := os.WriteFile(safeKey400, []byte("fake-key"), 0o400); err != nil {
+		t.Fatal(err)
+	}
+	cfg = &AuthConfig{Method: AuthSSH, SSHKeyPath: safeKey400}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected 0400 to be accepted, got: %v", err)
+	}
+}
+
 func TestValidate_Token(t *testing.T) {
 	// Valid token
 	cfg := &AuthConfig{Method: AuthToken, Token: "ghp_xxxxxxxxxxxxxxxxxxxx"}
@@ -120,3 +181,66 @@ func TestValidate_None(t *testing.T) {
 		t.Fatalf("expected no error for AuthNone, got %v", err)
 	}
 }
+
+func TestValidate_UnknownMethod(t *testing.T) {
+	cfg := &AuthConfig{Method: AuthMethod(99)}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for unknown auth method")
+	}
+	if !strings.Contains(err.Error(), "unknown auth method") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestAuthConfig_StringRedaction(t *testing.T) {
+	cfg := AuthConfig{Method: AuthToken, Token: "ghp_supersecret123"}
+	s := cfg.String()
+	if strings.Contains(s, "ghp_supersecret123") {
+		t.Fatal("String() must not contain the raw token")
+	}
+	if !strings.Contains(s, "[REDACTED]") {
+		t.Fatal("String() must contain [REDACTED] for token auth")
+	}
+
+	cfg = AuthConfig{Method: AuthSSH, SSHKeyPath: "/home/user/.ssh/id_ed25519"}
+	s = cfg.String()
+	if !strings.Contains(s, "/home/user/.ssh/id_ed25519") {
+		t.Fatal("String() should include SSH key path")
+	}
+}
+
+func TestAuthConfig_LogValueRedaction(t *testing.T) {
+	cfg := AuthConfig{Method: AuthToken, Token: "ghp_supersecret123"}
+	lv := cfg.LogValue()
+
+	resolved := lv.Resolve().String()
+	if strings.Contains(resolved, "ghp_supersecret123") {
+		t.Fatal("LogValue() must not contain the raw token")
+	}
+	if !strings.Contains(resolved, "[REDACTED]") {
+		t.Fatal("LogValue() must contain [REDACTED]")
+	}
+}
+
+func TestAuthMethod_String(t *testing.T) {
+	tests := []struct {
+		m    AuthMethod
+		want string
+	}{
+		{AuthNone, "none"},
+		{AuthSSH, "ssh"},
+		{AuthToken, "token"},
+		{AuthMethod(99), "none"},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("AuthMethod(%d)", tt.m), func(t *testing.T) {
+			if got := tt.m.String(); got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Verify AuthConfig implements slog.LogValuer at compile time.
+var _ slog.LogValuer = AuthConfig{}

--- a/internal/gitops/auth_test.go
+++ b/internal/gitops/auth_test.go
@@ -1,0 +1,122 @@
+package gitops
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadAuthFromEnv_SSHKey(t *testing.T) {
+	tmp := t.TempDir()
+	keyFile := filepath.Join(tmp, "id_ed25519")
+	if err := os.WriteFile(keyFile, []byte("fake-key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("BLOGFLOW_GIT_SSH_KEY", keyFile)
+	t.Setenv("BLOGFLOW_GIT_TOKEN", "")
+
+	cfg := LoadAuthFromEnv(nil)
+	if cfg.Method != AuthSSH {
+		t.Fatalf("expected AuthSSH, got %d", cfg.Method)
+	}
+	if cfg.SSHKeyPath != keyFile {
+		t.Fatalf("expected SSHKeyPath %q, got %q", keyFile, cfg.SSHKeyPath)
+	}
+}
+
+func TestLoadAuthFromEnv_Token(t *testing.T) {
+	t.Setenv("BLOGFLOW_GIT_SSH_KEY", "")
+	t.Setenv("BLOGFLOW_GIT_TOKEN", "ghp_xxxxxxxxxxxxxxxxxxxx")
+
+	cfg := LoadAuthFromEnv(nil)
+	if cfg.Method != AuthToken {
+		t.Fatalf("expected AuthToken, got %d", cfg.Method)
+	}
+	if cfg.Token != "ghp_xxxxxxxxxxxxxxxxxxxx" {
+		t.Fatalf("unexpected token value")
+	}
+}
+
+func TestLoadAuthFromEnv_None(t *testing.T) {
+	t.Setenv("BLOGFLOW_GIT_SSH_KEY", "")
+	t.Setenv("BLOGFLOW_GIT_TOKEN", "")
+
+	cfg := LoadAuthFromEnv(nil)
+	if cfg.Method != AuthNone {
+		t.Fatalf("expected AuthNone, got %d", cfg.Method)
+	}
+}
+
+func TestLoadAuthFromEnv_SSHKeyPrecedence(t *testing.T) {
+	tmp := t.TempDir()
+	keyFile := filepath.Join(tmp, "id_ed25519")
+	if err := os.WriteFile(keyFile, []byte("fake-key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("BLOGFLOW_GIT_SSH_KEY", keyFile)
+	t.Setenv("BLOGFLOW_GIT_TOKEN", "ghp_xxxxxxxxxxxxxxxxxxxx")
+
+	cfg := LoadAuthFromEnv(nil)
+	if cfg.Method != AuthSSH {
+		t.Fatalf("expected AuthSSH (precedence over token), got %d", cfg.Method)
+	}
+}
+
+func TestLoadAuthFromEnv_SSHKeyMissing(t *testing.T) {
+	t.Setenv("BLOGFLOW_GIT_SSH_KEY", "/nonexistent/path/id_ed25519")
+	t.Setenv("BLOGFLOW_GIT_TOKEN", "ghp_xxxxxxxxxxxxxxxxxxxx")
+
+	cfg := LoadAuthFromEnv(nil)
+	if cfg.Method != AuthToken {
+		t.Fatalf("expected AuthToken (SSH key missing falls through), got %d", cfg.Method)
+	}
+}
+
+func TestValidate_SSH(t *testing.T) {
+	tmp := t.TempDir()
+	keyFile := filepath.Join(tmp, "id_ed25519")
+	if err := os.WriteFile(keyFile, []byte("fake-key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Valid SSH config
+	cfg := &AuthConfig{Method: AuthSSH, SSHKeyPath: keyFile}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Empty key path
+	cfg = &AuthConfig{Method: AuthSSH, SSHKeyPath: ""}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for empty SSH key path")
+	}
+
+	// Non-existent key
+	cfg = &AuthConfig{Method: AuthSSH, SSHKeyPath: "/nonexistent/key"}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for non-existent SSH key")
+	}
+}
+
+func TestValidate_Token(t *testing.T) {
+	// Valid token
+	cfg := &AuthConfig{Method: AuthToken, Token: "ghp_xxxxxxxxxxxxxxxxxxxx"}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Empty token
+	cfg = &AuthConfig{Method: AuthToken, Token: ""}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for empty token")
+	}
+}
+
+func TestValidate_None(t *testing.T) {
+	cfg := &AuthConfig{Method: AuthNone}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected no error for AuthNone, got %v", err)
+	}
+}

--- a/internal/gitops/auth_test.go
+++ b/internal/gitops/auth_test.go
@@ -88,7 +88,7 @@ func TestLoadAuthFromEnv_SSHKeyMissing(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when SSH key is explicitly set but inaccessible")
 	}
-	if !strings.Contains(err.Error(), "BLOGFLOW_GIT_SSH_KEY set but not accessible") {
+	if !strings.Contains(err.Error(), "SSH key not accessible") {
 		t.Fatalf("unexpected error message: %v", err)
 	}
 }
@@ -211,15 +211,46 @@ func TestAuthConfig_StringRedaction(t *testing.T) {
 }
 
 func TestAuthConfig_LogValueRedaction(t *testing.T) {
+	// Token method: must redact token, must not leak ssh_key_path
 	cfg := AuthConfig{Method: AuthToken, Token: "ghp_supersecret123"}
 	lv := cfg.LogValue()
-
 	resolved := lv.Resolve().String()
 	if strings.Contains(resolved, "ghp_supersecret123") {
 		t.Fatal("LogValue() must not contain the raw token")
 	}
 	if !strings.Contains(resolved, "[REDACTED]") {
-		t.Fatal("LogValue() must contain [REDACTED]")
+		t.Fatal("LogValue() must contain [REDACTED] for token method")
+	}
+	if strings.Contains(resolved, "ssh_key_path") {
+		t.Fatal("LogValue() for token method must not include ssh_key_path")
+	}
+
+	// SSH method: must include ssh_key_path, must not include token field
+	cfg = AuthConfig{Method: AuthSSH, SSHKeyPath: "/home/user/.ssh/id_ed25519"}
+	lv = cfg.LogValue()
+	resolved = lv.Resolve().String()
+	if !strings.Contains(resolved, "/home/user/.ssh/id_ed25519") {
+		t.Fatal("LogValue() for SSH method must include ssh_key_path")
+	}
+	if strings.Contains(resolved, "token") {
+		t.Fatal("LogValue() for SSH method must not include token field")
+	}
+	if !strings.Contains(resolved, "ssh") {
+		t.Fatal("LogValue() for SSH method must include method=ssh")
+	}
+
+	// None method: must only have method=none
+	cfg = AuthConfig{Method: AuthNone}
+	lv = cfg.LogValue()
+	resolved = lv.Resolve().String()
+	if !strings.Contains(resolved, "none") {
+		t.Fatal("LogValue() for AuthNone must include method=none")
+	}
+	if strings.Contains(resolved, "token") {
+		t.Fatal("LogValue() for AuthNone must not include token field")
+	}
+	if strings.Contains(resolved, "ssh_key_path") {
+		t.Fatal("LogValue() for AuthNone must not include ssh_key_path field")
 	}
 }
 

--- a/internal/gitops/auth_test.go
+++ b/internal/gitops/auth_test.go
@@ -128,7 +128,7 @@ func TestValidate_SSHPermissions(t *testing.T) {
 
 	// 0644 should be rejected
 	unsafeKey := filepath.Join(tmp, "unsafe_key")
-	if err := os.WriteFile(unsafeKey, []byte("fake-key"), 0o644); err != nil {
+	if err := os.WriteFile(unsafeKey, []byte("fake-key"), 0o644); err != nil { //nolint:gosec // G306: intentionally unsafe perms to test rejection
 		t.Fatal(err)
 	}
 	cfg := &AuthConfig{Method: AuthSSH, SSHKeyPath: unsafeKey}


### PR DESCRIPTION
Env-based auth: SSH key (BLOGFLOW_GIT_SSH_KEY) or token (BLOGFLOW_GIT_TOKEN). SSH preferred. Key validation at startup. 8 tests, -race clean.