### PR TITLE
security: pin trivy-action to v0.35.0 by SHA digest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
           format: 'sarif'


### PR DESCRIPTION
Replace mutable `@master` with immutable SHA `57a97c7e7821a5776cebc9bb87c984fa69cba8f1` (v0.35.0). Prevents supply-chain attacks via compromised action tags. Flagged as Critical in PR #38 RFL.