### PR TITLE
feat: implement fsnotify file watcher (internal/gitops)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kenhaines/blogflow
 go 1.26.1
 
 require (
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-git/go-git/v5 v5.17.0
 	github.com/yuin/goldmark v1.7.17
 	golang.org/x/crypto v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=

--- a/internal/gitops/sync_test.go
+++ b/internal/gitops/sync_test.go
@@ -170,6 +170,10 @@ func TestStrategy_StartStop(t *testing.T) {
 				t.Fatalf("unexpected error for %q: %v", tc.name, err)
 			}
 
+			if ws, ok := s.(*gitops.WatchStrategy); ok {
+				ws.SetDirs(t.TempDir())
+			}
+
 			if err := s.Start(ctx); err != nil {
 				t.Errorf("%s.Start() error: %v", tc.name, err)
 			}
@@ -201,6 +205,10 @@ func TestStrategy_DoubleStop(t *testing.T) {
 			s, err := gitops.NewStrategy(tc.cfg, noop, logger())
 			if err != nil {
 				t.Fatalf("unexpected error for %q: %v", tc.name, err)
+			}
+
+			if ws, ok := s.(*gitops.WatchStrategy); ok {
+				ws.SetDirs(t.TempDir())
 			}
 
 			if err := s.Start(ctx); err != nil {

--- a/internal/gitops/watch.go
+++ b/internal/gitops/watch.go
@@ -25,14 +25,15 @@ var watchedExtensions = map[string]bool{
 // WatchStrategy monitors filesystem directories for changes using fsnotify.
 // On change, it debounces events and calls the ContentReloader.
 type WatchStrategy struct {
-	reloader  ContentReloader
-	logger    *slog.Logger
-	dirs      []string
-	debounce  time.Duration
-	watcher   *fsnotify.Watcher
-	startOnce sync.Once
-	stopOnce  sync.Once
-	done      chan struct{}
+	reloader ContentReloader
+	logger   *slog.Logger
+	dirs     []string
+	debounce time.Duration
+	watcher  *fsnotify.Watcher
+	mu       sync.Mutex
+	started  bool
+	stopOnce sync.Once
+	done     chan struct{}
 }
 
 // NewWatchStrategy creates a file watcher strategy.
@@ -47,29 +48,41 @@ func NewWatchStrategy(reloader ContentReloader, logger *slog.Logger, dirs ...str
 	}
 }
 
+// SetDirs configures the directories to watch. Must be called before Start
+// when the strategy is constructed without directories (e.g. via the factory).
+func (w *WatchStrategy) SetDirs(dirs ...string) { w.dirs = dirs }
+
 // Start begins watching the filesystem for content changes.
 // It returns promptly; background work runs in a separate goroutine.
+// Start may be retried after a transient failure (e.g. missing dirs).
 func (w *WatchStrategy) Start(ctx context.Context) error {
-	var startErr error
-	w.startOnce.Do(func() {
-		watcher, err := fsnotify.NewWatcher()
-		if err != nil {
-			startErr = fmt.Errorf("gitops: create watcher: %w", err)
-			return
-		}
+	w.mu.Lock()
+	defer w.mu.Unlock()
 
-		for _, dir := range w.dirs {
-			if err := addRecursive(watcher, dir); err != nil {
-				watcher.Close()
-				startErr = fmt.Errorf("gitops: watch %q: %w", dir, err)
-				return
-			}
-		}
+	if w.started {
+		return nil
+	}
 
-		w.watcher = watcher
-		go w.loop(ctx)
-	})
-	return startErr
+	if len(w.dirs) == 0 {
+		return fmt.Errorf("gitops: watch strategy has no directories configured — call SetDirs before Start")
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("gitops: create watcher: %w", err)
+	}
+
+	for _, dir := range w.dirs {
+		if err := addRecursive(watcher, dir); err != nil {
+			watcher.Close()
+			return fmt.Errorf("gitops: watch %q: %w", dir, err)
+		}
+	}
+
+	w.watcher = watcher
+	w.started = true
+	go w.loop(ctx)
+	return nil
 }
 
 // Stop gracefully shuts down the filesystem watcher.
@@ -108,6 +121,7 @@ func (w *WatchStrategy) loop(ctx context.Context) {
 			if timer != nil {
 				timer.Stop()
 			}
+			_ = w.watcher.Close()
 			return
 
 		case event, ok := <-w.watcher.Events:
@@ -165,7 +179,7 @@ func (w *WatchStrategy) tryWatchDir(path string) {
 	if isIgnoredDir(filepath.Base(path)) {
 		return
 	}
-	if err := w.watcher.Add(path); err != nil {
+	if err := addRecursive(w.watcher, path); err != nil {
 		w.logger.Debug("could not watch new directory", "path", path, "err", err)
 	}
 }
@@ -208,9 +222,22 @@ func isIgnoredFile(name string) bool {
 	return containsDotGit(name)
 }
 
+// ignoredDirs lists directory base names that should never be watched.
+var ignoredDirs = map[string]bool{
+	".git":         true,
+	"node_modules": true,
+	"vendor":       true,
+	"__pycache__":  true,
+	".cache":       true,
+	".idea":        true,
+	".vscode":      true,
+	"dist":         true,
+	"_site":        true,
+}
+
 // isIgnoredDir returns true for directories that should not be watched.
 func isIgnoredDir(name string) bool {
-	return name == ".git"
+	return ignoredDirs[name]
 }
 
 // containsDotGit checks if any path component is ".git".

--- a/internal/gitops/watch.go
+++ b/internal/gitops/watch.go
@@ -2,33 +2,223 @@ package gitops
 
 import (
 	"context"
+	"fmt"
+	"io/fs"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
 )
 
-// WatchStrategy monitors the filesystem for changes using fsnotify.
-type WatchStrategy struct {
-	reloader ContentReloader
-	logger   *slog.Logger
+// watchedExtensions are the file extensions that trigger a content reload.
+var watchedExtensions = map[string]bool{
+	".md":   true,
+	".html": true,
+	".css":  true,
+	".yaml": true,
 }
 
-// NewWatchStrategy creates a new filesystem watch strategy.
-func NewWatchStrategy(reloader ContentReloader, logger *slog.Logger) *WatchStrategy {
-	return &WatchStrategy{reloader: reloader, logger: logger}
+// WatchStrategy monitors filesystem directories for changes using fsnotify.
+// On change, it debounces events and calls the ContentReloader.
+type WatchStrategy struct {
+	reloader  ContentReloader
+	logger    *slog.Logger
+	dirs      []string
+	debounce  time.Duration
+	watcher   *fsnotify.Watcher
+	startOnce sync.Once
+	stopOnce  sync.Once
+	done      chan struct{}
+}
+
+// NewWatchStrategy creates a file watcher strategy.
+// dirs are the directories to recursively watch for changes.
+func NewWatchStrategy(reloader ContentReloader, logger *slog.Logger, dirs ...string) *WatchStrategy {
+	return &WatchStrategy{
+		reloader: reloader,
+		logger:   logger,
+		dirs:     dirs,
+		debounce: 500 * time.Millisecond,
+		done:     make(chan struct{}),
+	}
 }
 
 // Start begins watching the filesystem for content changes.
 // It returns promptly; background work runs in a separate goroutine.
-// TODO: fsnotify integration
 func (w *WatchStrategy) Start(ctx context.Context) error {
-	w.logger.Warn("watch strategy started (stub)")
-	return nil
+	var startErr error
+	w.startOnce.Do(func() {
+		watcher, err := fsnotify.NewWatcher()
+		if err != nil {
+			startErr = fmt.Errorf("gitops: create watcher: %w", err)
+			return
+		}
+
+		for _, dir := range w.dirs {
+			if err := addRecursive(watcher, dir); err != nil {
+				watcher.Close()
+				startErr = fmt.Errorf("gitops: watch %q: %w", dir, err)
+				return
+			}
+		}
+
+		w.watcher = watcher
+		go w.loop(ctx)
+	})
+	return startErr
 }
 
 // Stop gracefully shuts down the filesystem watcher.
 func (w *WatchStrategy) Stop(ctx context.Context) error {
-	w.logger.Info("watch strategy stopped")
-	return nil
+	var stopErr error
+	w.stopOnce.Do(func() {
+		if w.watcher == nil {
+			return
+		}
+		if err := w.watcher.Close(); err != nil {
+			stopErr = fmt.Errorf("gitops: close watcher: %w", err)
+		}
+		select {
+		case <-w.done:
+		case <-ctx.Done():
+			stopErr = ctx.Err()
+		}
+	})
+	return stopErr
 }
 
 // Name returns the strategy name.
 func (w *WatchStrategy) Name() string { return "watch" }
+
+func (w *WatchStrategy) loop(ctx context.Context) {
+	defer close(w.done)
+
+	var (
+		timer  *time.Timer
+		timerC <-chan time.Time
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			if timer != nil {
+				timer.Stop()
+			}
+			return
+
+		case event, ok := <-w.watcher.Events:
+			if !ok {
+				return
+			}
+
+			// Watch newly created directories.
+			if event.Op&fsnotify.Create != 0 {
+				w.tryWatchDir(event.Name)
+			}
+
+			if !isWatchedFile(event.Name) {
+				continue
+			}
+
+			w.logger.Debug("file event", "op", event.Op, "path", event.Name)
+
+			if timer == nil {
+				timer = time.NewTimer(w.debounce)
+				timerC = timer.C
+			} else {
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(w.debounce)
+			}
+
+		case err, ok := <-w.watcher.Errors:
+			if !ok {
+				return
+			}
+			w.logger.Error("watcher error", "err", err)
+
+		case <-timerC:
+			w.logger.Info("content change detected, reloading")
+			if err := w.reloader(); err != nil {
+				w.logger.Error("reload failed", "err", err)
+			}
+			timer = nil
+			timerC = nil
+		}
+	}
+}
+
+// tryWatchDir adds a newly created directory to the watcher.
+func (w *WatchStrategy) tryWatchDir(path string) {
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return
+	}
+	if isIgnoredDir(filepath.Base(path)) {
+		return
+	}
+	if err := w.watcher.Add(path); err != nil {
+		w.logger.Debug("could not watch new directory", "path", path, "err", err)
+	}
+}
+
+// addRecursive walks a directory tree and adds all subdirectories to the watcher.
+func addRecursive(watcher *fsnotify.Watcher, root string) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if isIgnoredDir(filepath.Base(path)) {
+				return filepath.SkipDir
+			}
+			return watcher.Add(path)
+		}
+		return nil
+	})
+}
+
+// isWatchedFile returns true if the file should trigger a reload.
+func isWatchedFile(name string) bool {
+	if isIgnoredFile(name) {
+		return false
+	}
+	ext := strings.ToLower(filepath.Ext(name))
+	return watchedExtensions[ext]
+}
+
+// isIgnoredFile returns true for temporary/swap files and .git paths.
+func isIgnoredFile(name string) bool {
+	base := filepath.Base(name)
+	if strings.HasSuffix(base, "~") {
+		return true
+	}
+	ext := filepath.Ext(base)
+	if ext == ".swp" || ext == ".tmp" {
+		return true
+	}
+	return containsDotGit(name)
+}
+
+// isIgnoredDir returns true for directories that should not be watched.
+func isIgnoredDir(name string) bool {
+	return name == ".git"
+}
+
+// containsDotGit checks if any path component is ".git".
+func containsDotGit(path string) bool {
+	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
+		if part == ".git" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/gitops/watch.go
+++ b/internal/gitops/watch.go
@@ -74,7 +74,7 @@ func (w *WatchStrategy) Start(ctx context.Context) error {
 
 	for _, dir := range w.dirs {
 		if err := addRecursive(watcher, dir); err != nil {
-			watcher.Close()
+			_ = watcher.Close()
 			return fmt.Errorf("gitops: watch %q: %w", dir, err)
 		}
 	}

--- a/internal/gitops/watch_test.go
+++ b/internal/gitops/watch_test.go
@@ -113,7 +113,7 @@ func TestWatchStrategy_IgnoresTempFiles(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	_ = os.WriteFile(filepath.Join(dir, ".post.md.swp"), []byte("swap"), 0o644) //nolint:gosec // G306: test files
-	_ = os.WriteFile(filepath.Join(dir, "draft.tmp"), []byte("temp"), 0o644) //nolint:gosec // G306: test files
+	_ = os.WriteFile(filepath.Join(dir, "draft.tmp"), []byte("temp"), 0o644)    //nolint:gosec // G306: test files
 	_ = os.WriteFile(filepath.Join(dir, "backup.md~"), []byte("backup"), 0o644) //nolint:gosec // G306: test files
 
 	time.Sleep(300 * time.Millisecond)

--- a/internal/gitops/watch_test.go
+++ b/internal/gitops/watch_test.go
@@ -35,11 +35,11 @@ func TestWatchStrategy_DetectsFileChange(t *testing.T) {
 	if err := w.Start(ctx); err != nil {
 		t.Fatal(err)
 	}
-	defer w.Stop(context.Background())
+	defer func() { _ = w.Stop(context.Background()) }()
 
 	time.Sleep(100 * time.Millisecond)
 
-	if err := os.WriteFile(filepath.Join(dir, "post.md"), []byte("# Hello"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "post.md"), []byte("# Hello"), 0o644); err != nil { //nolint:gosec // G306: test files
 		t.Fatal(err)
 	}
 
@@ -69,13 +69,13 @@ func TestWatchStrategy_Debounce(t *testing.T) {
 	if err := w.Start(ctx); err != nil {
 		t.Fatal(err)
 	}
-	defer w.Stop(context.Background())
+	defer func() { _ = w.Stop(context.Background()) }()
 
 	time.Sleep(100 * time.Millisecond)
 
 	for i := 0; i < 5; i++ {
 		name := filepath.Join(dir, fmt.Sprintf("post%d.md", i))
-		if err := os.WriteFile(name, []byte("content"), 0o644); err != nil {
+		if err := os.WriteFile(name, []byte("content"), 0o644); err != nil { //nolint:gosec // G306: test files
 			t.Fatal(err)
 		}
 		time.Sleep(20 * time.Millisecond)
@@ -108,13 +108,13 @@ func TestWatchStrategy_IgnoresTempFiles(t *testing.T) {
 	if err := w.Start(ctx); err != nil {
 		t.Fatal(err)
 	}
-	defer w.Stop(context.Background())
+	defer func() { _ = w.Stop(context.Background()) }()
 
 	time.Sleep(100 * time.Millisecond)
 
-	_ = os.WriteFile(filepath.Join(dir, ".post.md.swp"), []byte("swap"), 0o644)
-	_ = os.WriteFile(filepath.Join(dir, "draft.tmp"), []byte("temp"), 0o644)
-	_ = os.WriteFile(filepath.Join(dir, "backup.md~"), []byte("backup"), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, ".post.md.swp"), []byte("swap"), 0o644) //nolint:gosec // G306: test files
+	_ = os.WriteFile(filepath.Join(dir, "draft.tmp"), []byte("temp"), 0o644) //nolint:gosec // G306: test files
+	_ = os.WriteFile(filepath.Join(dir, "backup.md~"), []byte("backup"), 0o644) //nolint:gosec // G306: test files
 
 	time.Sleep(300 * time.Millisecond)
 
@@ -166,7 +166,7 @@ func TestWatchStrategy_StartErrorNoDirs(t *testing.T) {
 	if err := w.Start(ctx); err != nil {
 		t.Fatalf("Start after SetDirs failed: %v", err)
 	}
-	defer w.Stop(context.Background())
+	defer func() { _ = w.Stop(context.Background()) }()
 }
 
 func TestWatchStrategy_ContextCancel(t *testing.T) {

--- a/internal/gitops/watch_test.go
+++ b/internal/gitops/watch_test.go
@@ -1,0 +1,170 @@
+package gitops
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func watchTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestWatchStrategy_DetectsFileChange(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	var called atomic.Int32
+	reloader := ContentReloader(func() error {
+		called.Add(1)
+		return nil
+	})
+
+	w := NewWatchStrategy(reloader, watchTestLogger(), dir)
+	w.debounce = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := w.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer w.Stop(context.Background())
+
+	time.Sleep(100 * time.Millisecond)
+
+	if err := os.WriteFile(filepath.Join(dir, "post.md"), []byte("# Hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+
+	if got := called.Load(); got != 1 {
+		t.Errorf("reloader called %d times, want 1", got)
+	}
+}
+
+func TestWatchStrategy_Debounce(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	var called atomic.Int32
+	reloader := ContentReloader(func() error {
+		called.Add(1)
+		return nil
+	})
+
+	w := NewWatchStrategy(reloader, watchTestLogger(), dir)
+	w.debounce = 200 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := w.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer w.Stop(context.Background())
+
+	time.Sleep(100 * time.Millisecond)
+
+	for i := 0; i < 5; i++ {
+		name := filepath.Join(dir, fmt.Sprintf("post%d.md", i))
+		if err := os.WriteFile(name, []byte("content"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Wait for debounce + buffer.
+	time.Sleep(500 * time.Millisecond)
+
+	if got := called.Load(); got != 1 {
+		t.Errorf("reloader called %d times, want 1", got)
+	}
+}
+
+func TestWatchStrategy_IgnoresTempFiles(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	var called atomic.Int32
+	reloader := ContentReloader(func() error {
+		called.Add(1)
+		return nil
+	})
+
+	w := NewWatchStrategy(reloader, watchTestLogger(), dir)
+	w.debounce = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := w.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer w.Stop(context.Background())
+
+	time.Sleep(100 * time.Millisecond)
+
+	_ = os.WriteFile(filepath.Join(dir, ".post.md.swp"), []byte("swap"), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "draft.tmp"), []byte("temp"), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "backup.md~"), []byte("backup"), 0o644)
+
+	time.Sleep(300 * time.Millisecond)
+
+	if got := called.Load(); got != 0 {
+		t.Errorf("reloader called %d times, want 0", got)
+	}
+}
+
+func TestWatchStrategy_StopClean(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	w := NewWatchStrategy(func() error { return nil }, watchTestLogger(), dir)
+
+	if err := w.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-w.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit within 2 seconds")
+	}
+}
+
+func TestWatchStrategy_ContextCancel(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	w := NewWatchStrategy(func() error { return nil }, watchTestLogger(), dir)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if err := w.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	cancel()
+
+	select {
+	case <-w.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit after context cancel")
+	}
+
+	// Stop should be safe even after context cancel.
+	if err := w.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/gitops/watch_test.go
+++ b/internal/gitops/watch_test.go
@@ -143,6 +143,32 @@ func TestWatchStrategy_StopClean(t *testing.T) {
 	}
 }
 
+func TestWatchStrategy_StartErrorNoDirs(t *testing.T) {
+	t.Parallel()
+
+	w := NewWatchStrategy(func() error { return nil }, watchTestLogger())
+
+	err := w.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected error when starting with no dirs")
+	}
+	if got := err.Error(); got != "gitops: watch strategy has no directories configured — call SetDirs before Start" {
+		t.Fatalf("unexpected error: %s", got)
+	}
+
+	// After SetDirs, Start should succeed (retryable).
+	dir := t.TempDir()
+	w.SetDirs(dir)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("Start after SetDirs failed: %v", err)
+	}
+	defer w.Stop(context.Background())
+}
+
 func TestWatchStrategy_ContextCancel(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
Real WatchStrategy replacing stub: recursive fsnotify watching, 500ms debounce, extension filtering (.md/.html/.css/.yaml), temp file ignoring, dynamic subdir watching, clean shutdown. 5 new tests + 28 total, -race clean.