### PR TITLE
docs: content authoring guide and theme development guide

### DIFF
--- a/defaults/templates/partials/pagination.html
+++ b/defaults/templates/partials/pagination.html
@@ -2,10 +2,10 @@
 {{if or .Pagination.HasPrev .Pagination.HasNext}}
 <nav class="pagination" aria-label="Page navigation">
     {{if .Pagination.HasPrev}}
-    <a href="{{.Pagination.PrevURL}}" class="pagination-prev" rel="prev">&larr; Newer posts</a>
+    <a href="?page={{.Pagination.PrevPage}}" class="pagination-prev" rel="prev">&larr; Newer posts</a>
     {{end}}
     {{if .Pagination.HasNext}}
-    <a href="{{.Pagination.NextURL}}" class="pagination-next" rel="next">Older posts &rarr;</a>
+    <a href="?page={{.Pagination.NextPage}}" class="pagination-next" rel="next">Older posts &rarr;</a>
     {{end}}
 </nav>
 {{end}}

--- a/docs/content-authoring-guide.md
+++ b/docs/content-authoring-guide.md
@@ -218,6 +218,8 @@ but the defaults above are conventional.
 
 **Content scanning**:
 
+> ⚠️ **Fail-fast scanning**: A single malformed post (missing date, duplicate slug, invalid slug) aborts the entire content scan. Validate content locally with `blogflow --content ./content --dev` before pushing.
+
 - Only `.md` files are processed.
 - Posts require both `title` and `date` in front matter.
 - Pages require only `title`.
@@ -384,21 +386,17 @@ BlogFlow supports three sync strategies (configured via `sync.strategy`):
 | Strategy    | How it works                                           | Best for              |
 |-------------|-------------------------------------------------------|-----------------------|
 | `watch`     | Filesystem watcher (fsnotify) detects local changes.   | Local development     |
-| `webhook`   | GitHub webhook on push to `main` triggers a git pull.  | Production (single server) |
+| `webhook`   | GitHub webhook on push to `main` triggers a git pull.  | See warning below     |
 | `sidecar`   | Kubernetes git-sync sidecar pulls content on a loop.   | Production (Kubernetes) |
 
-**Webhook flow**:
+**Webhook sync**:
 
-```
-GitHub push → POST /api/webhook → HMAC-SHA256 verify → branch filter → git pull → reload content
-```
+> ⚠️ **Not yet implemented.** The webhook sync strategy is currently a stub. HMAC verification, git pull, and content reload are not functional. Use the `watch` strategy for local development. Webhook support is tracked in the project backlog.
 
-**Webhook configuration**:
-- Path: `/api/webhook` (configurable)
-- Secret: set via `BLOGFLOW_WEBHOOK_SECRET` environment variable (≥32 bytes)
-- Allowed events: `push` (default), also supports `ping`, `pull_request`, `release`, `workflow_dispatch`
-- Branch filter: `main` (default)
-- Rate limit: 10 requests/minute (configurable, 1–100)
+When complete, the webhook strategy will accept a GitHub `push` event at a
+configurable endpoint (default `/api/webhook`), verify the payload signature,
+and trigger a content reload. Configuration is accepted in `site.yaml` under
+`sync.webhook` but has no effect until the implementation is finished.
 
 ---
 
@@ -419,12 +417,13 @@ content/
 
 ### Referencing Images in Markdown
 
-Use standard Markdown image syntax with paths relative to the content root:
+All static assets — including media — are served under the `/static/` URL
+prefix by the HTTP server. Use that prefix when referencing images:
 
 ```markdown
-![Architecture diagram](/media/images/architecture-diagram.svg)
+![Architecture diagram](/static/media/images/architecture-diagram.svg)
 
-![Screenshot of the dashboard](/media/images/screenshot.jpg "Dashboard")
+![Screenshot of the dashboard](/static/media/images/screenshot.jpg "Dashboard")
 ```
 
 ### Image Path Resolution
@@ -437,9 +436,8 @@ Images are resolved through the overlay filesystem. The resolution order
 3. **Config layer** — configuration-level assets
 4. **Defaults layer** — embedded default assets (e.g., `favicon.svg`)
 
-Static assets (including media) are served under `/static/` by the HTTP
-server. The `media/` directory contents are accessible through the overlay FS
-at their relative paths.
+Files placed in `content/media/` are served at `/static/media/…` by the HTTP
+server via the overlay FS.
 
 ---
 

--- a/docs/content-authoring-guide.md
+++ b/docs/content-authoring-guide.md
@@ -67,6 +67,10 @@ Dates in front matter accept:
 Display format is controlled by `content.date_format` in `site.yaml` (default:
 `"January 2, 2006"`, following Go time layout conventions).
 
+> **Note:** The default `post-meta.html` partial currently uses a hardcoded
+> format (`January 2, 2006`). Custom themes should read this config value via a
+> template function.
+
 ### Tags and Categories
 
 ```yaml

--- a/docs/content-authoring-guide.md
+++ b/docs/content-authoring-guide.md
@@ -1,0 +1,561 @@
+# Content Authoring Guide
+
+> **Audience**: Blog authors and content editors  
+> **Prerequisite**: BlogFlow binary installed or running via Docker  
+> **Last Updated**: 2025-07-16
+
+This guide covers everything you need to write, organize, and publish content
+with BlogFlow. Start at [Writing Posts](#1-writing-posts) if you just want to
+publish your first article; read through to [Configuration Reference](#7-configuration-reference)
+when you need full control.
+
+---
+
+## 1. Writing Posts
+
+### Front Matter Schema
+
+Every post starts with a YAML front matter block delimited by `---`. BlogFlow
+parses front matter up to **64 KB**.
+
+```yaml
+---
+title: "Deploying to Kubernetes"
+slug: "deploying-to-kubernetes"
+date: 2025-06-20
+updated: 2025-07-01
+tags: ["kubernetes", "devops"]
+categories: ["infrastructure"]
+author: "Jane Doe"
+description: "Step-by-step guide for deploying BlogFlow on K8s."
+draft: false
+template: "tutorial.html"
+image: "https://example.com/hero.png"
+reading_time: 8
+---
+```
+
+| Field          | Type       | Required | Default              | Description                                       |
+|----------------|------------|----------|----------------------|---------------------------------------------------|
+| `title`        | `string`   | **Yes**  | —                    | Post title displayed in listings and feeds.        |
+| `date`         | `time`     | **Yes**  | —                    | Publication date (`YYYY-MM-DD` or RFC 3339).       |
+| `slug`         | `string`   | No       | filename stem        | URL path segment. Must be a plain filename—no `/`, `\`, or `..`. |
+| `updated`      | `time`     | No       | —                    | Last-modified date for feeds and SEO.              |
+| `draft`        | `bool`     | No       | `false`              | When `true`, post is hidden from listings.         |
+| `tags`         | `[]string` | No       | `[]`                 | Tags for grouping and filtering.                   |
+| `categories`   | `[]string` | No       | `[]`                 | Broader groupings than tags.                       |
+| `author`       | `string`   | No       | `site.author.name`   | Post-level author override.                        |
+| `description`  | `string`   | No       | auto-generated       | Summary for feeds and `<meta>` tags.               |
+| `template`     | `string`   | No       | `post.html`          | Custom template filename (plain name, no path).    |
+| `image`        | `string`   | No       | —                    | Featured image URL (`http` or `https` only).       |
+| `reading_time` | `int`      | No       | auto-computed        | Estimated minutes; auto-calculated at ~200 wpm if omitted. |
+
+**Validation rules**:
+
+- `slug` and `template` must be plain filenames—no `/`, `\`, `..`, or null bytes.
+- `image` must use `http` or `https` scheme.
+- Duplicate slugs across posts are rejected at startup (fail-fast).
+
+### Date Format
+
+Dates in front matter accept:
+
+- **Date only**: `2025-06-20` (interpreted as midnight UTC)
+- **Full RFC 3339**: `2025-06-20T14:30:00Z`
+- **With timezone**: `2025-06-20T14:30:00-07:00`
+
+Display format is controlled by `content.date_format` in `site.yaml` (default:
+`"January 2, 2006"`, following Go time layout conventions).
+
+### Tags and Categories
+
+```yaml
+tags: ["go", "docker", "tutorial"]
+categories: ["backend"]
+```
+
+- Tags appear in post metadata and generate `/tags/{tag}` listing pages.
+- Categories are a broader grouping mechanism.
+- Both are case-sensitive—use lowercase consistently.
+
+### Draft Posts
+
+Set `draft: true` to exclude a post from all listings, feeds, and tag pages.
+Draft posts are skipped during content scanning and never served.
+
+```yaml
+---
+title: "Work in Progress"
+date: 2025-07-10
+draft: true
+---
+```
+
+### Custom Templates
+
+Override the default `post.html` template for a specific post:
+
+```yaml
+---
+title: "Photo Gallery"
+date: 2025-07-01
+template: "gallery.html"
+---
+```
+
+The template must exist in your theme's `templates/` directory or in the
+default templates.
+
+### Markdown Features
+
+BlogFlow uses [Goldmark](https://github.com/yuin/goldmark) with the following
+extensions enabled:
+
+| Feature             | Syntax                          | Notes                        |
+|---------------------|---------------------------------|------------------------------|
+| GFM tables          | `\| col \| col \|`             | With column alignment        |
+| Task lists          | `- [x] Done`                   | Checkbox syntax              |
+| Strikethrough       | `~~deleted~~`                   | GFM extension                |
+| Autolinks           | `https://example.com`           | Bare URLs become links       |
+| Footnotes           | `[^1]` / `[^1]: Note text`     | Rendered at page bottom      |
+| Smart quotes        | `"text"` → "text"              | Typographer extension        |
+| Em/en dashes        | `---` / `--`                    | Typographer extension        |
+| Auto heading IDs    | `## My Section` → `id="my-section"` | For anchor links        |
+| Fenced code blocks  | ` ```go `                       | CSS classes for Chroma highlighting |
+
+**HTML handling**: Raw HTML in Markdown is **stripped by default** for XSS
+safety. Content is pre-sanitized through the Goldmark pipeline.
+
+### File Naming Conventions
+
+- Use **kebab-case** for filenames: `deploying-to-kubernetes.md`
+- Extension must be `.md` (only Markdown files are processed)
+- The filename stem becomes the default `slug` if none is specified
+- Files without valid front matter are silently skipped
+
+---
+
+## 2. Writing Pages
+
+### Posts vs Pages
+
+| Aspect     | Posts                              | Pages                             |
+|------------|------------------------------------|------------------------------------|
+| Location   | `posts/` directory                 | `pages/` directory                 |
+| `date`     | **Required**                       | Optional                           |
+| Ordering   | Sorted by date (newest first)      | No automatic ordering              |
+| Listings   | Appear on homepage and tag pages   | Standalone; not in listings         |
+| Template   | `post.html`                        | `page.html`                        |
+| Feed       | Included in RSS/Atom               | Excluded from feeds                |
+
+### Pages Directory
+
+Pages live in the `pages/` directory (configurable via `content.pages_dir`):
+
+```
+content/
+└── pages/
+    ├── about.md
+    └── contact.md
+```
+
+### Example: About Page
+
+```markdown
+---
+title: "About"
+slug: "about"
+description: "Learn more about this blog and its author."
+---
+
+## About This Blog
+
+Welcome! This blog covers topics in distributed systems, Go programming,
+and cloud-native architecture.
+
+## Contact
+
+Reach me at author@example.com or on [GitHub](https://github.com/example).
+```
+
+### Example: Contact Page
+
+```markdown
+---
+title: "Contact"
+slug: "contact"
+description: "Get in touch."
+---
+
+## Get in Touch
+
+- **Email**: hello@example.com
+- **GitHub**: [github.com/example](https://github.com/example)
+- **Twitter**: [@example](https://twitter.com/example)
+```
+
+---
+
+## 3. Content Directory Structure
+
+```
+content/
+├── posts/                    # Blog posts (configurable: content.posts_dir)
+│   ├── hello-world.md
+│   ├── getting-started.md
+│   └── deploying-to-k8s.md
+├── pages/                    # Static pages (configurable: content.pages_dir)
+│   ├── about.md
+│   └── contact.md
+└── media/                    # Images and assets (configurable: content.media_dir)
+    └── images/
+        ├── hero.png
+        └── diagram.svg
+```
+
+**Directory names** (`posts`, `pages`, `media`) are configurable in `site.yaml`
+but the defaults above are conventional.
+
+**Content scanning**:
+
+- Only `.md` files are processed.
+- Posts require both `title` and `date` in front matter.
+- Pages require only `title`.
+- Draft posts (`draft: true`) are excluded from all outputs.
+- Files without valid front matter are skipped.
+
+**Content indexing**: Posts are indexed into several structures for fast lookups:
+
+- **By date**: all posts sorted newest-first (drives homepage)
+- **By slug**: O(1) lookup for individual post pages
+- **By tag**: posts grouped per tag (drives `/tags/{tag}` pages)
+- **By year**: posts grouped by publication year
+- **Pages by slug**: O(1) lookup for static pages
+
+---
+
+## 4. Progressive Customization
+
+BlogFlow follows a four-level progressive customization model. Start simple and
+add complexity only when you need it.
+
+### Level 0 — Just Markdown + Binary
+
+The simplest setup. No configuration file needed.
+
+```
+my-blog/
+└── content/
+    └── posts/
+        └── hello-world.md
+```
+
+```bash
+blogflow --content ./content
+```
+
+BlogFlow uses embedded defaults for everything: templates, CSS, configuration.
+The site title is "My Blog" and it runs on port 8080.
+
+### Level 1 — Add site.yaml
+
+Add a configuration file to customize site identity, server settings, and
+content options.
+
+```
+my-blog/
+├── site.yaml
+└── content/
+    ├── posts/
+    │   └── hello-world.md
+    └── pages/
+        └── about.md
+```
+
+```yaml
+# site.yaml
+site:
+  title: "My Tech Blog"
+  description: "Thoughts on Go and cloud-native systems"
+  base_url: "https://blog.example.com"
+  author:
+    name: "Jane Doe"
+    email: "jane@example.com"
+```
+
+### Level 2 — Custom Theme Directory
+
+Override default templates and CSS with your own theme.
+
+```
+my-blog/
+├── site.yaml
+├── content/
+│   └── posts/
+│       └── hello-world.md
+└── theme/
+    ├── theme.yaml
+    ├── templates/
+    │   ├── base.html
+    │   └── partials/
+    │       └── header.html
+    └── static/
+        └── css/
+            └── main.css
+```
+
+```bash
+blogflow --content ./content --theme ./theme
+```
+
+The overlay FS merges your theme with embedded defaults—override only the files
+you want to change. Everything else falls through to the defaults.
+
+### Level 3 — Separate Content and Theme Repos
+
+For teams, keep content and theme in separate Git repositories. Use git-sync
+sidecars or webhooks to deploy.
+
+```
+# Content repo (authors own this)
+blog-content/
+├── posts/
+│   └── hello-world.md
+├── pages/
+│   └── about.md
+└── media/
+    └── images/
+
+# Theme repo (designers own this)
+blog-theme/
+├── theme.yaml
+├── templates/
+│   └── ...
+└── static/
+    └── ...
+
+# Deployment config
+docker-compose.yml    # BlogFlow + git-sync sidecars
+site.yaml             # Environment-specific config
+```
+
+This separation lets content authors and theme developers work independently
+with different review cycles.
+
+---
+
+## 5. Git Workflow for Content
+
+### Trunk-Based Development
+
+BlogFlow content follows a trunk-based workflow:
+
+1. **`main` is production** — merged content is live.
+2. **Feature branches** for new posts or edits.
+3. **Pull requests** for review before publishing.
+
+```
+main ─────●────────●────────●──── (live)
+           \      /          \
+            post/my-new-article   fix/typo-in-about
+```
+
+### Branch Naming Conventions
+
+| Purpose         | Pattern                          | Example                          |
+|-----------------|----------------------------------|----------------------------------|
+| New post        | `post/<slug>`                    | `post/deploying-to-kubernetes`   |
+| Edit post       | `edit/<slug>`                    | `edit/hello-world`               |
+| New page        | `page/<slug>`                    | `page/contact`                   |
+| Fix/typo        | `fix/<description>`              | `fix/typo-in-about`              |
+| Theme change    | `theme/<description>`            | `theme/dark-mode`                |
+
+### PR Review for Content
+
+- Use PRs for all content changes, even single-post additions.
+- Reviewers check for: front matter validity, broken image paths, tag
+  consistency, and prose quality.
+- Merge to `main` triggers content sync.
+
+### How Content Syncs to the Blog
+
+BlogFlow supports three sync strategies (configured via `sync.strategy`):
+
+| Strategy    | How it works                                           | Best for              |
+|-------------|-------------------------------------------------------|-----------------------|
+| `watch`     | Filesystem watcher (fsnotify) detects local changes.   | Local development     |
+| `webhook`   | GitHub webhook on push to `main` triggers a git pull.  | Production (single server) |
+| `sidecar`   | Kubernetes git-sync sidecar pulls content on a loop.   | Production (Kubernetes) |
+
+**Webhook flow**:
+
+```
+GitHub push → POST /api/webhook → HMAC-SHA256 verify → branch filter → git pull → reload content
+```
+
+**Webhook configuration**:
+- Path: `/api/webhook` (configurable)
+- Secret: set via `BLOGFLOW_WEBHOOK_SECRET` environment variable (≥32 bytes)
+- Allowed events: `push` (default), also supports `ping`, `pull_request`, `release`, `workflow_dispatch`
+- Branch filter: `main` (default)
+- Rate limit: 10 requests/minute (configurable, 1–100)
+
+---
+
+## 6. Media and Images
+
+### Where to Put Images
+
+Place images in the `media/` directory (configurable via `content.media_dir`):
+
+```
+content/
+└── media/
+    └── images/
+        ├── hero.png
+        ├── architecture-diagram.svg
+        └── screenshot.jpg
+```
+
+### Referencing Images in Markdown
+
+Use standard Markdown image syntax with paths relative to the content root:
+
+```markdown
+![Architecture diagram](/media/images/architecture-diagram.svg)
+
+![Screenshot of the dashboard](/media/images/screenshot.jpg "Dashboard")
+```
+
+### Image Path Resolution
+
+Images are resolved through the overlay filesystem. The resolution order
+(highest priority first):
+
+1. **Theme layer** — theme-provided images
+2. **Content layer** — your `media/` directory (most common)
+3. **Config layer** — configuration-level assets
+4. **Defaults layer** — embedded default assets (e.g., `favicon.svg`)
+
+Static assets (including media) are served under `/static/` by the HTTP
+server. The `media/` directory contents are accessible through the overlay FS
+at their relative paths.
+
+---
+
+## 7. Configuration Reference
+
+### Configuration Priority
+
+BlogFlow resolves configuration from three sources (highest priority first):
+
+1. **Environment variables** (`BLOGFLOW_*` prefix)
+2. **`site.yaml`** file
+3. **Embedded defaults**
+
+### Complete site.yaml Schema
+
+```yaml
+# ─── Site Identity ────────────────────────────────────────────
+site:
+  title: "My Blog"                   # string — site display name
+  description: "A blog powered by BlogFlow"  # string — meta description
+  base_url: "http://localhost:8080"  # string — canonical URL (http/https, non-empty host)
+  language: "en"                     # string — BCP 47 language tag
+  author:
+    name: ""                         # string — default author name
+    email: ""                        # string — default author email
+
+# ─── Content Pipeline ────────────────────────────────────────
+content:
+  posts_dir: "posts"                 # string — relative path to posts directory
+  pages_dir: "pages"                 # string — relative path to pages directory
+  media_dir: "media"                 # string — relative path to media directory
+  posts_per_page: 10                 # int    — posts per listing page (1–100)
+  date_format: "January 2, 2006"    # string — Go time layout for display
+  summary_length: 200               # int    — auto-summary character count (50–1000)
+
+# ─── Theme ────────────────────────────────────────────────────
+theme:
+  name: "default"                    # string — theme name
+  path: ""                           # string — path to custom theme (empty = embedded)
+
+# ─── Server ───────────────────────────────────────────────────
+server:
+  port: 8080                         # int      — listen port (1–65535)
+  read_timeout: "5s"                 # duration — HTTP read timeout
+  write_timeout: "10s"               # duration — HTTP write timeout
+  idle_timeout: "120s"               # duration — keep-alive idle timeout
+
+# ─── Cache ────────────────────────────────────────────────────
+cache:
+  enabled: true                      # bool     — enable render cache
+  ttl: "1h"                          # duration — cache entry lifetime (max 24h)
+  max_entries: 1000                  # int      — max cached entries (0–100000)
+
+# ─── Sync ─────────────────────────────────────────────────────
+sync:
+  strategy: "watch"                  # string — "watch", "webhook", or "sidecar"
+  webhook:
+    path: "/api/webhook"             # string — webhook endpoint path
+    # secret: — NEVER set in YAML; use BLOGFLOW_WEBHOOK_SECRET env var
+    allowed_events:                  # []string — accepted GitHub event types
+      - "push"
+    branch_filter: "main"            # string — only sync pushes to this branch
+    rate_limit: 10                   # int    — max requests per minute (1–100)
+
+# ─── Feed ─────────────────────────────────────────────────────
+feed:
+  enabled: true                      # bool   — generate feed
+  type: "atom"                       # string — "atom" or "rss"
+  items: 20                          # int    — max feed entries (1–100)
+```
+
+### Validation Rules
+
+| Field                | Constraint                                    |
+|----------------------|-----------------------------------------------|
+| `server.port`        | 1–65535                                       |
+| `server.*_timeout`   | Must be > 0                                   |
+| `site.base_url`      | Valid HTTP/HTTPS URL with non-empty host       |
+| `content.*_dir`      | Relative paths only; no `..` or absolute paths |
+| `content.posts_per_page` | 1–100                                     |
+| `content.summary_length` | 50–1000                                   |
+| `cache.max_entries`  | 0–100,000                                     |
+| `sync.strategy`      | `watch`, `webhook`, or `sidecar`              |
+| `sync.webhook.secret`| ≥32 bytes (required when strategy is `webhook`) |
+| `feed.type`          | `atom` or `rss` (when `feed.enabled` is `true`) |
+| `feed.items`         | 1–100 (when `feed.enabled` is `true`)          |
+
+### Environment Variable Overrides
+
+All environment variables use the `BLOGFLOW_` prefix:
+
+| Environment Variable                | Config Path                  | Type     |
+|-------------------------------------|------------------------------|----------|
+| `BLOGFLOW_SITE_TITLE`              | `site.title`                 | string   |
+| `BLOGFLOW_SITE_DESCRIPTION`        | `site.description`           | string   |
+| `BLOGFLOW_SITE_BASE_URL`           | `site.base_url`              | string   |
+| `BLOGFLOW_SERVER_PORT`             | `server.port`                | int      |
+| `BLOGFLOW_SERVER_READ_TIMEOUT`     | `server.read_timeout`        | duration |
+| `BLOGFLOW_SERVER_WRITE_TIMEOUT`    | `server.write_timeout`       | duration |
+| `BLOGFLOW_SERVER_IDLE_TIMEOUT`     | `server.idle_timeout`        | duration |
+| `BLOGFLOW_CACHE_ENABLED`           | `cache.enabled`              | bool     |
+| `BLOGFLOW_SYNC_STRATEGY`           | `sync.strategy`              | string   |
+| `BLOGFLOW_WEBHOOK_SECRET`          | `sync.webhook.secret`        | string   |
+| `BLOGFLOW_SYNC_WEBHOOK_RATE_LIMIT` | `sync.webhook.rate_limit`    | int      |
+| `BLOGFLOW_FEED_TYPE`               | `feed.type`                  | string   |
+
+### Secret Handling
+
+BlogFlow enforces strict secret hygiene:
+
+- **Webhook secret** (`sync.webhook.secret`): Must be set via
+  `BLOGFLOW_WEBHOOK_SECRET` environment variable. Never place secrets in
+  `site.yaml`.
+- **Git tokens**: Use environment variables or mounted secrets (Kubernetes).
+- **YAML scanning**: BlogFlow scans YAML files for common secret patterns
+  (tokens, keys, passwords) and rejects them before parsing.
+- **YAML safety**: Anchor/alias constructs are rejected to prevent
+  billion-laughs denial-of-service attacks.
+- **Config file size**: Limited to 1 MB.

--- a/docs/theme-development-guide.md
+++ b/docs/theme-development-guide.md
@@ -1,0 +1,500 @@
+# Theme Development Guide
+
+> **Audience**: Theme developers and front-end engineers  
+> **Prerequisite**: Familiarity with HTML, CSS, and Go `html/template` syntax  
+> **Last Updated**: 2025-07-16
+
+This guide covers how to build, customize, and override BlogFlow themes. Start
+with the [directory structure](#1-theme-directory-structure) to understand the
+layout, then work through templates, functions, and styling.
+
+---
+
+## 1. Theme Directory Structure
+
+A BlogFlow theme is a directory containing templates, static assets, and an
+optional manifest:
+
+```
+my-theme/
+├── theme.yaml                # Theme metadata (optional)
+├── templates/
+│   ├── base.html             # Master layout — all pages extend this
+│   ├── post.html             # Single blog post
+│   ├── list.html             # Post listing / homepage
+│   ├── page.html             # Static page (about, contact)
+│   ├── 404.html              # Not found page
+│   └── partials/
+│       ├── header.html       # Site header / navigation
+│       ├── footer.html       # Site footer
+│       ├── post-meta.html    # Post date, tags, reading time
+│       └── pagination.html   # Previous / next page controls
+└── static/
+    ├── css/
+    │   └── main.css          # Primary stylesheet
+    ├── images/
+    │   └── favicon.svg       # Site icon
+    └── js/                   # Client-side scripts (if any)
+```
+
+**Activate a custom theme**:
+
+```bash
+blogflow --content ./content --theme ./my-theme
+```
+
+Or in `site.yaml`:
+
+```yaml
+theme:
+  name: "my-theme"
+  path: "./my-theme"
+```
+
+---
+
+## 2. Go html/template Syntax Basics
+
+BlogFlow templates use Go's standard
+[`html/template`](https://pkg.go.dev/html/template) package, which provides
+automatic HTML escaping for XSS safety.
+
+### Actions
+
+```html
+<!-- Output a value (auto-escaped) -->
+{{ .Site.Title }}
+
+<!-- Conditional -->
+{{ if .Post }}
+  <h1>{{ .Post.Title }}</h1>
+{{ else }}
+  <h1>{{ .Title }}</h1>
+{{ end }}
+
+<!-- Range over a slice -->
+{{ range .Posts }}
+  <article>
+    <h2>{{ .Title }}</h2>
+    <p>{{ .Summary }}</p>
+  </article>
+{{ end }}
+
+<!-- Range with empty fallback -->
+{{ range .Posts }}
+  <article>{{ .Title }}</article>
+{{ else }}
+  <p>No posts yet.</p>
+{{ end }}
+
+<!-- Variable assignment -->
+{{ $name := .Site.Author.Name }}
+<span>{{ $name }}</span>
+
+<!-- With (rebind dot) -->
+{{ with .Post }}
+  <h1>{{ .Title }}</h1>
+{{ end }}
+```
+
+### Template Blocks
+
+The base template defines named blocks that child templates override:
+
+```html
+<!-- base.html -->
+<html>
+<head>
+  <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
+</head>
+<body>
+  {{ template "partials/header.html" . }}
+  <main>{{ block "content" . }}{{ end }}</main>
+  {{ template "partials/footer.html" . }}
+</body>
+</html>
+```
+
+```html
+<!-- post.html — overrides blocks from base.html -->
+{{ define "title" }}{{ .Post.Title }} — {{ .Site.Title }}{{ end }}
+
+{{ define "content" }}
+<article>
+  <h1>{{ .Post.Title }}</h1>
+  {{ template "partials/post-meta.html" .Post }}
+  <div class="post-content">{{ .Post.Content }}</div>
+</article>
+{{ end }}
+```
+
+### Including Partials
+
+```html
+{{ template "partials/header.html" . }}
+{{ template "partials/footer.html" . }}
+{{ template "partials/post-meta.html" .Post }}
+{{ template "partials/pagination.html" . }}
+```
+
+The dot (`.`) passes the current data context to the partial.
+
+---
+
+## 3. Available Template Functions
+
+BlogFlow registers these functions in addition to Go's built-in template
+functions:
+
+| Function      | Signature                            | Description                                |
+|---------------|--------------------------------------|--------------------------------------------|
+| `formatDate`  | `(t time.Time, layout string) string` | Format a time value using a Go time layout string. |
+| `now`         | `() time.Time`                       | Returns the current time.                  |
+| `lower`       | `(s string) string`                  | Convert string to lowercase.               |
+| `upper`       | `(s string) string`                  | Convert string to uppercase.               |
+| `truncate`    | `(s string, n int) string`           | Truncate to `n` runes at word boundary, appending `…`. |
+| `readingTime` | `(content string) int`               | Estimated reading time in minutes (~200 wpm). |
+| `urlize`      | `(s string) string`                  | Convert to URL-safe slug: lowercase, spaces→hyphens, strip special chars. |
+| `add`         | `(a, b int) int`                     | Integer addition.                          |
+| `sub`         | `(a, b int) int`                     | Integer subtraction.                       |
+| `seq`         | `(start, end int) ([]int, error)`    | Generate an integer sequence. Max range: 10,000. |
+
+### Usage Examples
+
+```html
+<!-- Format a post date -->
+<time datetime="{{ formatDate .Date "2006-01-02" }}">
+  {{ formatDate .Date "January 2, 2006" }}
+</time>
+
+<!-- Show reading time -->
+{{ $min := readingTime .Content }}
+{{ if gt $min 0 }}
+  <span>{{ $min }} min read</span>
+{{ end }}
+
+<!-- Generate a tag URL -->
+<a href="/tags/{{ urlize .Tag }}">{{ .Tag }}</a>
+
+<!-- Truncate a summary -->
+<p>{{ truncate .Summary 120 }}</p>
+
+<!-- Pagination arithmetic -->
+<span>Page {{ .Pagination.CurrentPage }} of {{ .Pagination.TotalPages }}</span>
+
+<!-- Generate page number sequence -->
+{{ range seq 1 .Pagination.TotalPages }}
+  <a href="/page/{{ . }}">{{ . }}</a>
+{{ end }}
+
+<!-- Copyright year -->
+<footer>&copy; {{ formatDate now "2006" }} {{ .Site.Author.Name }}</footer>
+```
+
+---
+
+## 4. Template Data Context
+
+Every template receives a `PageData` struct as its root context (`.`):
+
+### PageData
+
+| Field        | Type              | Available In         | Description                          |
+|--------------|-------------------|----------------------|--------------------------------------|
+| `.Site`      | `SiteConfig`      | All templates        | Site metadata from configuration.     |
+| `.Feed`      | `FeedConfig`      | All templates        | Feed settings (enabled, type, items). |
+| `.Post`      | `*Post`           | `post.html`          | The current blog post.               |
+| `.Page`      | `*Post`           | `page.html`          | The current static page.             |
+| `.Posts`     | `[]*Post`         | `list.html`          | List of posts for current page.      |
+| `.Tag`       | `string`          | `list.html` (tag)    | Current tag filter (empty on homepage). |
+| `.Title`     | `string`          | All templates        | Page title override.                 |
+| `.Pagination`| `*Pagination`     | `list.html`          | Pagination metadata.                 |
+
+### Post (and Page)
+
+Posts and pages share the same structure:
+
+| Field          | Type            | Description                                |
+|----------------|-----------------|--------------------------------------------|
+| `.Title`       | `string`        | Title from front matter.                   |
+| `.Slug`        | `string`        | URL segment.                               |
+| `.Date`        | `time.Time`     | Publication date.                          |
+| `.Updated`     | `time.Time`     | Last modified date (zero if unset).        |
+| `.Draft`       | `bool`          | Draft status.                              |
+| `.Tags`        | `[]string`      | Tag list.                                  |
+| `.Categories`  | `[]string`      | Category list.                             |
+| `.Author`      | `string`        | Author name (post-level or site default).  |
+| `.Description` | `string`        | Summary for SEO / feeds.                   |
+| `.Template`    | `string`        | Custom template name (if specified).       |
+| `.Image`       | `string`        | Featured image URL.                        |
+| `.Content`     | `template.HTML` | Rendered HTML from Markdown (safe to emit).|
+| `.Summary`     | `string`        | Auto-generated plain-text summary (~200 chars). |
+| `.ReadingTime` | `int`           | Estimated reading time in minutes.         |
+| `.Path`        | `string`        | Original `.md` file path relative to content root. |
+
+### SiteConfig
+
+| Field              | Type     | Description                           |
+|--------------------|----------|---------------------------------------|
+| `.Site.Title`      | `string` | Site display name.                    |
+| `.Site.Description`| `string` | Meta description.                     |
+| `.Site.BaseURL`    | `string` | Canonical base URL.                   |
+| `.Site.Language`   | `string` | BCP 47 language tag (e.g., `"en"`).   |
+| `.Site.Author.Name`| `string` | Default author name.                  |
+| `.Site.Author.Email`| `string`| Default author email.                 |
+
+### FeedConfig
+
+| Field          | Type   | Description                              |
+|----------------|--------|------------------------------------------|
+| `.Feed.Enabled`| `bool` | Whether feed generation is on.            |
+| `.Feed.Type`   | `string`| `"atom"` or `"rss"`.                    |
+| `.Feed.Items`  | `int`  | Maximum items in the feed.               |
+
+### Pagination
+
+| Field                       | Type   | Description                         |
+|-----------------------------|--------|-------------------------------------|
+| `.Pagination.CurrentPage`   | `int`  | Current page number (1-indexed).    |
+| `.Pagination.TotalPages`    | `int`  | Total number of pages.              |
+| `.Pagination.HasPrev`       | `bool` | Whether a previous page exists.     |
+| `.Pagination.HasNext`       | `bool` | Whether a next page exists.         |
+| `.Pagination.PrevPage`      | `int`  | Previous page number.               |
+| `.Pagination.NextPage`      | `int`  | Next page number.                   |
+
+---
+
+## 5. Partial Templates
+
+Partials live in `templates/partials/` and are included with the `template`
+action:
+
+```html
+{{ template "partials/header.html" . }}
+```
+
+### Default Partials
+
+BlogFlow ships these partials in the embedded defaults:
+
+| Partial              | Purpose                                              |
+|----------------------|------------------------------------------------------|
+| `partials/header.html`     | Site header with navigation and title link.    |
+| `partials/footer.html`     | Site footer with copyright and attribution.    |
+| `partials/post-meta.html`  | Post metadata: date, reading time, tag links.  |
+| `partials/pagination.html` | Previous / next page navigation with aria labels. |
+
+### Creating Custom Partials
+
+Add new partials to your theme's `templates/partials/` directory:
+
+```html
+<!-- templates/partials/social-links.html -->
+<nav class="social-links" aria-label="Social media">
+  {{ with .Site.Author.Name }}
+    <a href="https://github.com/{{ urlize . }}">GitHub</a>
+  {{ end }}
+</nav>
+```
+
+Then include it in any template:
+
+```html
+{{ template "partials/social-links.html" . }}
+```
+
+---
+
+## 6. Overriding Default Templates via Overlay FS
+
+BlogFlow's overlay filesystem lets you selectively replace default templates
+without forking the entire theme. Place files at the same relative path in your
+theme directory to shadow the defaults.
+
+### Resolution Order
+
+The overlay FS checks layers in this order (highest priority first):
+
+1. **Theme layer** — your custom `--theme` directory
+2. **Content layer** — the `--content` directory
+3. **Config layer** — configuration files
+4. **Defaults layer** — embedded defaults (`embed.FS`)
+
+### Override Examples
+
+**Override just the header**:
+
+```
+my-theme/
+└── templates/
+    └── partials/
+        └── header.html    # ← shadows defaults/templates/partials/header.html
+```
+
+All other templates (`base.html`, `post.html`, `footer.html`, etc.) continue
+to use the embedded defaults.
+
+**Override the base layout**:
+
+```
+my-theme/
+└── templates/
+    └── base.html          # ← shadows defaults/templates/base.html
+```
+
+**Override CSS only** (no template changes):
+
+```
+my-theme/
+└── static/
+    └── css/
+        └── main.css       # ← shadows defaults/static/css/main.css
+```
+
+### How It Works
+
+When BlogFlow resolves a template path like `templates/post.html`:
+
+1. Check theme layer → if found, use it
+2. Check content layer → if found, use it
+3. Check config layer → if found, use it
+4. Check defaults layer → use the embedded version
+
+The overlay FS implements Go's `fs.FS`, `fs.ReadFileFS`, `fs.ReadDirFS`, and
+`fs.StatFS` interfaces. `ReadDir` returns the **union** of directory entries
+across all layers, with higher layers shadowing lower ones.
+
+### Safety Features
+
+- **Max file size**: 64 MB per file
+- **Symlink escape detection**: disk-backed layers reject symlinks that escape
+  the layer root
+- **Negative cache**: absent paths are cached (up to 100,000 entries) to avoid
+  repeated layer traversal
+- **Hot reload**: layers can be invalidated and replaced at runtime (used by
+  sync strategies)
+
+---
+
+## 7. CSS Architecture
+
+### Custom Properties
+
+The default theme uses CSS custom properties for consistent theming:
+
+```css
+:root {
+  --color-bg: #ffffff;
+  --color-text: #1a1a1a;
+  --color-link: #0066cc;
+  --color-link-hover: #004499;
+  --color-border: #e0e0e0;
+  --color-code-bg: #f5f5f5;
+  --font-body: system-ui, -apple-system, sans-serif;
+  --font-mono: "SFMono-Regular", Consolas, monospace;
+  --max-width: 42rem;
+}
+```
+
+Override these in your custom `main.css` to change the entire color scheme
+without rewriting styles.
+
+### Dark Mode
+
+Implement dark mode with a `prefers-color-scheme` media query:
+
+```css
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #1a1a1a;
+    --color-text: #e0e0e0;
+    --color-link: #66b3ff;
+    --color-link-hover: #99ccff;
+    --color-border: #333333;
+    --color-code-bg: #2d2d2d;
+  }
+}
+```
+
+### Responsive Design
+
+The default theme is mobile-first with a fluid layout:
+
+```css
+body {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+/* Wider viewports */
+@media (min-width: 768px) {
+  body {
+    padding: 2rem;
+  }
+}
+```
+
+### Syntax Highlighting
+
+Code blocks use CSS classes compatible with
+[Chroma](https://github.com/alecthomas/chroma) syntax highlighter. The default
+theme includes base Chroma styles. Customize by overriding the `.chroma` and
+related classes:
+
+```css
+.chroma .kw { color: #007020; font-weight: bold; }  /* Keyword */
+.chroma .s  { color: #4070a0; }                      /* String */
+.chroma .c  { color: #60a0b0; font-style: italic; }  /* Comment */
+```
+
+---
+
+## 8. Static Assets
+
+### Serving Static Files
+
+All files under `static/` in your theme (or the defaults) are served at the
+`/static/` URL prefix:
+
+| File Path                       | Served At                     |
+|---------------------------------|-------------------------------|
+| `static/css/main.css`           | `/static/css/main.css`        |
+| `static/images/favicon.svg`     | `/static/images/favicon.svg`  |
+| `static/js/app.js`              | `/static/js/app.js`           |
+
+### Referencing in Templates
+
+```html
+<!-- CSS -->
+<link rel="stylesheet" href="/static/css/main.css">
+
+<!-- Favicon -->
+<link rel="icon" href="/static/images/favicon.svg" type="image/svg+xml">
+
+<!-- JavaScript -->
+<script src="/static/js/app.js" defer></script>
+```
+
+### Adding Custom Assets
+
+Place any static files in your theme's `static/` directory. They are served
+through the overlay FS, so theme assets shadow default assets at the same path.
+
+```
+my-theme/
+└── static/
+    ├── css/
+    │   ├── main.css          # Overrides default CSS
+    │   └── syntax.css        # Additional stylesheet
+    ├── images/
+    │   └── logo.svg          # Custom logo
+    └── js/
+        └── theme-toggle.js   # Dark mode toggle
+```
+
+### Content-Security-Policy
+
+The default `base.html` template includes a Content-Security-Policy meta tag.
+If you add external resources (fonts, CDN scripts), you may need to adjust the
+CSP in your custom `base.html`.

--- a/docs/theme-development-guide.md
+++ b/docs/theme-development-guide.md
@@ -108,9 +108,9 @@ The base template defines named blocks that child templates override:
   <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
 </head>
 <body>
-  {{ template "header" . }}
+  {{ template "partials/header.html" . }}
   <main>{{ block "content" . }}{{ end }}</main>
-  {{ template "footer" . }}
+  {{ template "partials/footer.html" . }}
 </body>
 </html>
 ```
@@ -131,8 +131,8 @@ The base template defines named blocks that child templates override:
 ### Including Partials
 
 ```html
-{{ template "header" . }}
-{{ template "footer" . }}
+{{ template "partials/header.html" . }}
+{{ template "partials/footer.html" . }}
 {{ template "post-meta" .Post }}
 {{ template "pagination" . }}
 ```
@@ -273,23 +273,25 @@ action. The template name is the `{{define "name"}}` identifier inside the
 file — **not** the file path:
 
 ```html
-{{ template "header" . }}
+{{ template "partials/header.html" . }}
 ```
 
 ### Default Partials
 
 BlogFlow ships these partials in the embedded defaults:
 
-| `{{define}}` Name | File                         | Purpose                                              |
-|-------------------|------------------------------|------------------------------------------------------|
-| `header`          | `partials/header.html`       | Site header with navigation and title link.           |
-| `footer`          | `partials/footer.html`       | Site footer with copyright and attribution.           |
-| `post-meta`       | `partials/post-meta.html`    | Post metadata: date, reading time, tag links.         |
-| `pagination`      | `partials/pagination.html`   | Previous / next page navigation with aria labels.     |
+| `{{define}}` Name          | File                         | Purpose                                              |
+|----------------------------|------------------------------|------------------------------------------------------|
+| `partials/header.html`     | `partials/header.html`       | Site header with navigation and title link.           |
+| `partials/footer.html`     | `partials/footer.html`       | Site footer with copyright and attribution.           |
+| `post-meta`                | `partials/post-meta.html`    | Post metadata: date, reading time, tag links.         |
+| `pagination`               | `partials/pagination.html`   | Previous / next page navigation with aria labels.     |
 
-> **Naming convention**: Partial template names match the filename stem (e.g.,
-> `header.html` defines `"header"`). When creating custom partials, follow the
-> same pattern — define the template with a short name, not a file path.
+> **Naming convention**: The `{{define}}` name must match exactly what
+> `{{template}}` uses. The default header and footer use full-path names
+> (`partials/header.html`, `partials/footer.html`), while post-meta and
+> pagination use short names. When overriding a partial, keep the same
+> `{{define}}` name so existing `{{template}}` calls continue to resolve.
 
 ### Creating Custom Partials
 

--- a/docs/theme-development-guide.md
+++ b/docs/theme-development-guide.md
@@ -108,9 +108,9 @@ The base template defines named blocks that child templates override:
   <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
 </head>
 <body>
-  {{ template "partials/header.html" . }}
+  {{ template "header" . }}
   <main>{{ block "content" . }}{{ end }}</main>
-  {{ template "partials/footer.html" . }}
+  {{ template "footer" . }}
 </body>
 </html>
 ```
@@ -122,7 +122,7 @@ The base template defines named blocks that child templates override:
 {{ define "content" }}
 <article>
   <h1>{{ .Post.Title }}</h1>
-  {{ template "partials/post-meta.html" .Post }}
+  {{ template "post-meta" .Post }}
   <div class="post-content">{{ .Post.Content }}</div>
 </article>
 {{ end }}
@@ -131,10 +131,10 @@ The base template defines named blocks that child templates override:
 ### Including Partials
 
 ```html
-{{ template "partials/header.html" . }}
-{{ template "partials/footer.html" . }}
-{{ template "partials/post-meta.html" .Post }}
-{{ template "partials/pagination.html" . }}
+{{ template "header" . }}
+{{ template "footer" . }}
+{{ template "post-meta" .Post }}
+{{ template "pagination" . }}
 ```
 
 The dot (`.`) passes the current data context to the partial.
@@ -167,11 +167,9 @@ functions:
   {{ formatDate .Date "January 2, 2006" }}
 </time>
 
-<!-- Show reading time -->
+<!-- Show reading time (readingTime always returns at least 1) -->
 {{ $min := readingTime .Content }}
-{{ if gt $min 0 }}
-  <span>{{ $min }} min read</span>
-{{ end }}
+<span>{{ $min }} min read</span>
 
 <!-- Generate a tag URL -->
 <a href="/tags/{{ urlize .Tag }}">{{ .Tag }}</a>
@@ -182,9 +180,13 @@ functions:
 <!-- Pagination arithmetic -->
 <span>Page {{ .Pagination.CurrentPage }} of {{ .Pagination.TotalPages }}</span>
 
+<!-- Previous / Next links using PrevPage and NextPage (int fields) -->
+{{ if .Pagination.HasPrev }}<a href="?page={{ .Pagination.PrevPage }}">← Prev</a>{{ end }}
+{{ if .Pagination.HasNext }}<a href="?page={{ .Pagination.NextPage }}">Next →</a>{{ end }}
+
 <!-- Generate page number sequence -->
 {{ range seq 1 .Pagination.TotalPages }}
-  <a href="/page/{{ . }}">{{ . }}</a>
+  <a href="?page={{ . }}">{{ . }}</a>
 {{ end }}
 
 <!-- Copyright year -->
@@ -267,22 +269,27 @@ Posts and pages share the same structure:
 ## 5. Partial Templates
 
 Partials live in `templates/partials/` and are included with the `template`
-action:
+action. The template name is the `{{define "name"}}` identifier inside the
+file — **not** the file path:
 
 ```html
-{{ template "partials/header.html" . }}
+{{ template "header" . }}
 ```
 
 ### Default Partials
 
 BlogFlow ships these partials in the embedded defaults:
 
-| Partial              | Purpose                                              |
-|----------------------|------------------------------------------------------|
-| `partials/header.html`     | Site header with navigation and title link.    |
-| `partials/footer.html`     | Site footer with copyright and attribution.    |
-| `partials/post-meta.html`  | Post metadata: date, reading time, tag links.  |
-| `partials/pagination.html` | Previous / next page navigation with aria labels. |
+| `{{define}}` Name | File                         | Purpose                                              |
+|-------------------|------------------------------|------------------------------------------------------|
+| `header`          | `partials/header.html`       | Site header with navigation and title link.           |
+| `footer`          | `partials/footer.html`       | Site footer with copyright and attribution.           |
+| `post-meta`       | `partials/post-meta.html`    | Post metadata: date, reading time, tag links.         |
+| `pagination`      | `partials/pagination.html`   | Previous / next page navigation with aria labels.     |
+
+> **Naming convention**: Partial template names match the filename stem (e.g.,
+> `header.html` defines `"header"`). When creating custom partials, follow the
+> same pattern — define the template with a short name, not a file path.
 
 ### Creating Custom Partials
 
@@ -300,7 +307,7 @@ Add new partials to your theme's `templates/partials/` directory:
 Then include it in any template:
 
 ```html
-{{ template "partials/social-links.html" . }}
+{{ template "social-links" . }}
 ```
 
 ---
@@ -495,6 +502,27 @@ my-theme/
 
 ### Content-Security-Policy
 
-The default `base.html` template includes a Content-Security-Policy meta tag.
-If you add external resources (fonts, CDN scripts), you may need to adjust the
-CSP in your custom `base.html`.
+BlogFlow enforces a strict Content-Security-Policy via an **HTTP header** set
+in the server middleware (`internal/server/server.go`,
+`securityHeadersMiddleware`). The default policy is:
+
+```
+default-src 'none'; script-src 'none'; object-src 'none';
+connect-src 'none'; style-src 'self'; img-src 'self' https: data:;
+font-src 'self' https:; base-uri 'self'; form-action 'self';
+frame-ancestors 'self'
+```
+
+The `base.html` meta tag contains a similar CSP as **supplementary
+defense-in-depth**. However, when the HTTP header is present (which it always
+is when served by BlogFlow), browsers ignore the meta tag CSP entirely. The
+meta tag only matters if someone serves the HTML files through a different
+server that omits the header.
+
+**To allow external resources** (CDN fonts, analytics scripts, etc.), you must
+modify the `securityHeadersMiddleware` in `internal/server/server.go` — editing
+the `base.html` meta tag alone has no effect.
+
+> ⚠️ `frame-ancestors` **cannot** be set via a `<meta>` tag — the browser spec
+> forbids it. This directive is only effective in the HTTP header, which
+> BlogFlow already sets.


### PR DESCRIPTION
Content guide (560 lines): front matter schema, markdown features, progressive customization, git workflow, config reference. Theme guide (501 lines): template syntax, functions, data context, partials, overlay FS, CSS architecture.