### PR TITLE
feat: implement HMAC-SHA256 webhook handler (internal/gitops)

### DIFF
--- a/internal/gitops/sync_test.go
+++ b/internal/gitops/sync_test.go
@@ -34,7 +34,7 @@ func TestNewStrategy_Webhook(t *testing.T) {
 
 	cfg := &config.SyncConfig{
 		Strategy: "webhook",
-		Webhook:  config.WebhookConfig{Path: "/_hook"},
+		Webhook:  config.WebhookConfig{Path: "/_hook", Secret: "test-secret"},
 	}
 
 	s, err := gitops.NewStrategy(cfg, noop, logger())
@@ -133,7 +133,7 @@ func TestStrategy_Name(t *testing.T) {
 
 			cfg := &config.SyncConfig{Strategy: tc.strategy}
 			if tc.strategy == "webhook" {
-				cfg.Webhook = config.WebhookConfig{Path: "/_hook"}
+				cfg.Webhook = config.WebhookConfig{Path: "/_hook", Secret: "test-secret"}
 			}
 
 			s, err := gitops.NewStrategy(cfg, noop, logger())
@@ -156,7 +156,7 @@ func TestStrategy_StartStop(t *testing.T) {
 		cfg  *config.SyncConfig
 	}{
 		{"watch", &config.SyncConfig{Strategy: "watch"}},
-		{"webhook", &config.SyncConfig{Strategy: "webhook", Webhook: config.WebhookConfig{Path: "/_hook"}}},
+		{"webhook", &config.SyncConfig{Strategy: "webhook", Webhook: config.WebhookConfig{Path: "/_hook", Secret: "test-secret"}}},
 		{"sidecar", &config.SyncConfig{Strategy: "sidecar"}},
 	}
 
@@ -189,7 +189,7 @@ func TestStrategy_DoubleStop(t *testing.T) {
 		cfg  *config.SyncConfig
 	}{
 		{"watch", &config.SyncConfig{Strategy: "watch"}},
-		{"webhook", &config.SyncConfig{Strategy: "webhook", Webhook: config.WebhookConfig{Path: "/_hook"}}},
+		{"webhook", &config.SyncConfig{Strategy: "webhook", Webhook: config.WebhookConfig{Path: "/_hook", Secret: "test-secret"}}},
 		{"sidecar", &config.SyncConfig{Strategy: "sidecar"}},
 	}
 

--- a/internal/gitops/webhook.go
+++ b/internal/gitops/webhook.go
@@ -196,6 +196,11 @@ func (rl *rateLimiter) allow(ip string) bool {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
+	// Prevent unbounded growth of the clients map.
+	if len(rl.clients) > 10_000 {
+		rl.clients = make(map[string][]time.Time)
+	}
+
 	now := time.Now()
 	cutoff := now.Add(-rl.window)
 

--- a/internal/gitops/webhook.go
+++ b/internal/gitops/webhook.go
@@ -2,38 +2,66 @@ package gitops
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/kenhaines/blogflow/internal/config"
 )
 
+const maxPayloadSize = 1 << 20 // 1 MB
+
 // WebhookStrategy listens for HTTP webhook callbacks to trigger content reload.
+// Validates HMAC-SHA256 signatures, filters by branch, and rate-limits.
 type WebhookStrategy struct {
 	config   config.WebhookConfig
 	reloader ContentReloader
 	logger   *slog.Logger
+	handler  http.HandlerFunc
 }
 
 // NewWebhookStrategy creates a new webhook-based sync strategy.
-// Path must be non-empty and start with "/".
+// Path must be non-empty and start with "/". Secret must be non-empty.
 func NewWebhookStrategy(cfg config.WebhookConfig, reloader ContentReloader, logger *slog.Logger) (*WebhookStrategy, error) {
 	if cfg.Path == "" || cfg.Path[0] != '/' {
 		return nil, fmt.Errorf("gitops: webhook path must be non-empty and start with '/' (got %q)", cfg.Path)
 	}
 
-	return &WebhookStrategy{config: cfg, reloader: reloader, logger: logger}, nil
+	if cfg.Secret == "" {
+		return nil, fmt.Errorf("gitops: webhook secret must not be empty")
+	}
+
+	w := &WebhookStrategy{
+		config:   cfg,
+		reloader: reloader,
+		logger:   logger,
+	}
+
+	rl := newRateLimiter(cfg.RateLimit)
+	w.handler = w.buildHandler(rl)
+
+	return w, nil
 }
 
-// Start begins listening for webhook callbacks.
-// It returns promptly; background work runs in a separate goroutine.
-// TODO: wire to server webhook route
+// Handler returns the HTTP handler for registration with the server.
+func (w *WebhookStrategy) Handler() http.HandlerFunc { return w.handler }
+
+// Start activates the webhook strategy. The HTTP handler is registered
+// externally with the server, so no background goroutine is needed.
 func (w *WebhookStrategy) Start(ctx context.Context) error {
-	w.logger.Warn("webhook strategy started (stub)", "path", w.config.Path)
+	w.logger.Info("webhook strategy active", "path", w.config.Path)
 	return nil
 }
 
-// Stop gracefully shuts down the webhook listener.
+// Stop gracefully shuts down the webhook strategy.
 func (w *WebhookStrategy) Stop(ctx context.Context) error {
 	w.logger.Info("webhook strategy stopped")
 	return nil
@@ -41,3 +69,150 @@ func (w *WebhookStrategy) Stop(ctx context.Context) error {
 
 // Name returns the strategy name.
 func (w *WebhookStrategy) Name() string { return "webhook" }
+
+func (w *WebhookStrategy) buildHandler(rl *rateLimiter) http.HandlerFunc {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(rw, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		// Rate-limit by remote IP.
+		ip := remoteIP(r)
+		if rl != nil && !rl.allow(ip) {
+			w.logger.Warn("rate limited", "ip", ip)
+			http.Error(rw, "rate limit exceeded", http.StatusTooManyRequests)
+			return
+		}
+
+		// Limit request body size.
+		r.Body = http.MaxBytesReader(rw, r.Body, maxPayloadSize)
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.logger.Warn("body read error", "error", err)
+			http.Error(rw, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+
+		// Validate HMAC-SHA256 signature.
+		sigHeader := r.Header.Get("X-Hub-Signature-256")
+		if sigHeader == "" {
+			w.logger.Warn("missing signature header")
+			http.Error(rw, "missing signature", http.StatusUnauthorized)
+			return
+		}
+
+		if !verifySignature([]byte(w.config.Secret), body, sigHeader) {
+			w.logger.Warn("invalid signature")
+			http.Error(rw, "invalid signature", http.StatusUnauthorized)
+			return
+		}
+
+		// Filter by branch.
+		if w.config.BranchFilter != "" {
+			var payload struct {
+				Ref string `json:"ref"`
+			}
+
+			if err := json.Unmarshal(body, &payload); err != nil {
+				w.logger.Warn("invalid JSON payload", "error", err)
+				http.Error(rw, "invalid payload", http.StatusBadRequest)
+				return
+			}
+
+			expectedRef := "refs/heads/" + w.config.BranchFilter
+			if payload.Ref != expectedRef {
+				w.logger.Debug("ignoring push to non-matching branch",
+					"ref", payload.Ref, "filter", w.config.BranchFilter)
+				rw.WriteHeader(http.StatusOK)
+				fmt.Fprint(rw, "accepted (no action)")
+				return
+			}
+		}
+
+		// Trigger content reload.
+		if err := w.reloader(); err != nil {
+			w.logger.Error("content reload failed", "error", err)
+			http.Error(rw, "reload failed", http.StatusInternalServerError)
+			return
+		}
+
+		w.logger.Info("content reloaded via webhook")
+		rw.WriteHeader(http.StatusOK)
+		fmt.Fprint(rw, "ok")
+	}
+}
+
+// verifySignature validates an HMAC-SHA256 signature with constant-time comparison.
+func verifySignature(secret, payload []byte, sigHeader string) bool {
+	sig, found := strings.CutPrefix(sigHeader, "sha256=")
+	if !found {
+		return false
+	}
+
+	decoded, err := hex.DecodeString(sig)
+	if err != nil {
+		return false
+	}
+
+	mac := hmac.New(sha256.New, secret)
+	mac.Write(payload)
+	expected := mac.Sum(nil)
+
+	return hmac.Equal(decoded, expected)
+}
+
+// remoteIP extracts the client IP from the request, stripping the port.
+func remoteIP(r *http.Request) string {
+	addr := r.RemoteAddr
+	if idx := strings.LastIndex(addr, ":"); idx != -1 {
+		return addr[:idx]
+	}
+	return addr
+}
+
+// rateLimiter implements a sliding-window rate limiter per IP.
+type rateLimiter struct {
+	mu      sync.Mutex
+	limit   int
+	window  time.Duration
+	clients map[string][]time.Time
+}
+
+func newRateLimiter(limit int) *rateLimiter {
+	if limit <= 0 {
+		return nil
+	}
+
+	return &rateLimiter{
+		limit:   limit,
+		window:  time.Minute,
+		clients: make(map[string][]time.Time),
+	}
+}
+
+func (rl *rateLimiter) allow(ip string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	cutoff := now.Add(-rl.window)
+
+	timestamps := rl.clients[ip]
+	valid := timestamps[:0]
+
+	for _, ts := range timestamps {
+		if ts.After(cutoff) {
+			valid = append(valid, ts)
+		}
+	}
+
+	if len(valid) >= rl.limit {
+		rl.clients[ip] = valid
+		return false
+	}
+
+	rl.clients[ip] = append(valid, now)
+	return true
+}

--- a/internal/gitops/webhook.go
+++ b/internal/gitops/webhook.go
@@ -126,7 +126,7 @@ func (w *WebhookStrategy) buildHandler(rl *rateLimiter) http.HandlerFunc {
 				w.logger.Debug("ignoring push to non-matching branch",
 					"ref", payload.Ref, "filter", w.config.BranchFilter)
 				rw.WriteHeader(http.StatusOK)
-				fmt.Fprint(rw, "accepted (no action)")
+				_, _ = fmt.Fprint(rw, "accepted (no action)")
 				return
 			}
 		}
@@ -140,7 +140,7 @@ func (w *WebhookStrategy) buildHandler(rl *rateLimiter) http.HandlerFunc {
 
 		w.logger.Info("content reloaded via webhook")
 		rw.WriteHeader(http.StatusOK)
-		fmt.Fprint(rw, "ok")
+		_, _ = fmt.Fprint(rw, "ok")
 	}
 }
 
@@ -164,7 +164,17 @@ func verifySignature(secret, payload []byte, sigHeader string) bool {
 }
 
 // remoteIP extracts the client IP from the request, stripping the port.
+// remoteIP extracts the client IP from the request.
+// Checks X-Forwarded-For first (for reverse-proxy deployments), falls back to RemoteAddr.
 func remoteIP(r *http.Request) string {
+	// Trust X-Forwarded-For if present (standard reverse proxy header).
+	// Takes the first (leftmost) IP — the original client.
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if idx := strings.Index(xff, ","); idx != -1 {
+			return strings.TrimSpace(xff[:idx])
+		}
+		return strings.TrimSpace(xff)
+	}
 	addr := r.RemoteAddr
 	if idx := strings.LastIndex(addr, ":"); idx != -1 {
 		return addr[:idx]
@@ -196,13 +206,17 @@ func (rl *rateLimiter) allow(ip string) bool {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
-	// Prevent unbounded growth of the clients map.
-	if len(rl.clients) > 10_000 {
-		rl.clients = make(map[string][]time.Time)
-	}
-
 	now := time.Now()
 	cutoff := now.Add(-rl.window)
+
+	// Periodic eviction: sweep stale entries when map grows large.
+	if len(rl.clients) > 1000 {
+		for k, timestamps := range rl.clients {
+			if len(timestamps) == 0 || timestamps[len(timestamps)-1].Before(cutoff) {
+				delete(rl.clients, k)
+			}
+		}
+	}
 
 	timestamps := rl.clients[ip]
 	valid := timestamps[:0]

--- a/internal/gitops/webhook_test.go
+++ b/internal/gitops/webhook_test.go
@@ -244,6 +244,54 @@ func TestWebhookHandler_EmptySecret(t *testing.T) {
 	}
 }
 
+func TestWebhookHandler_RateLimited(t *testing.T) {
+	t.Parallel()
+
+	secret := "test-secret"
+
+	var calls atomic.Int64
+	reloader := gitops.ContentReloader(func() error {
+		calls.Add(1)
+		return nil
+	})
+
+	w, err := gitops.NewWebhookStrategy(config.WebhookConfig{
+		Path:      "/hook",
+		Secret:    secret,
+		RateLimit: 2,
+	}, reloader, webhookLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload := makePayload("refs/heads/main")
+	sig := signPayload([]byte(secret), payload)
+
+	sendRequest := func() int {
+		req := httptest.NewRequest(http.MethodPost, "/hook", bytes.NewReader(payload))
+		req.Header.Set("X-Hub-Signature-256", sig)
+		rec := httptest.NewRecorder()
+		w.Handler().ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	// First two requests should succeed.
+	for i := range 2 {
+		if code := sendRequest(); code != http.StatusOK {
+			t.Fatalf("request %d: got %d, want %d", i+1, code, http.StatusOK)
+		}
+	}
+
+	// Third request should be rate-limited.
+	if code := sendRequest(); code != http.StatusTooManyRequests {
+		t.Fatalf("request 3: got %d, want %d", code, http.StatusTooManyRequests)
+	}
+
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("reloader called %d times, want 2", got)
+	}
+}
+
 func TestWebhookHandler_InvalidPath(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gitops/webhook_test.go
+++ b/internal/gitops/webhook_test.go
@@ -317,3 +317,55 @@ func TestWebhookHandler_InvalidPath(t *testing.T) {
 		})
 	}
 }
+
+func TestWebhookHandler_XForwardedFor(t *testing.T) {
+	secret := []byte("test-secret-min-32-bytes-long!!!!")
+	called := 0
+	reloader := func() error { called++; return nil }
+
+	cfg := config.WebhookConfig{
+		Path:         "/api/webhook",
+		Secret:       string(secret),
+		BranchFilter: "main",
+		RateLimit:    1,
+	}
+
+	ws, err := gitops.NewWebhookStrategy(cfg, reloader, slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler := ws.Handler()
+	payload := []byte(`{"ref":"refs/heads/main"}`)
+	sig := signPayload(secret, payload)
+
+	// First request from "10.0.0.1" via XFF — should pass
+	req1 := httptest.NewRequest(http.MethodPost, "/api/webhook", bytes.NewReader(payload))
+	req1.Header.Set("X-Hub-Signature-256", sig)
+	req1.Header.Set("X-Forwarded-For", "10.0.0.1")
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first XFF request: expected 200, got %d", rec1.Code)
+	}
+
+	// Second from same XFF IP — rate limited
+	req2 := httptest.NewRequest(http.MethodPost, "/api/webhook", bytes.NewReader(payload))
+	req2.Header.Set("X-Hub-Signature-256", sig)
+	req2.Header.Set("X-Forwarded-For", "10.0.0.1")
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusTooManyRequests {
+		t.Fatalf("same XFF IP: expected 429, got %d", rec2.Code)
+	}
+
+	// Third from different XFF IP — should pass
+	req3 := httptest.NewRequest(http.MethodPost, "/api/webhook", bytes.NewReader(payload))
+	req3.Header.Set("X-Hub-Signature-256", sig)
+	req3.Header.Set("X-Forwarded-For", "10.0.0.2")
+	rec3 := httptest.NewRecorder()
+	handler.ServeHTTP(rec3, req3)
+	if rec3.Code != http.StatusOK {
+		t.Fatalf("different XFF IP: expected 200, got %d", rec3.Code)
+	}
+}

--- a/internal/gitops/webhook_test.go
+++ b/internal/gitops/webhook_test.go
@@ -1,0 +1,271 @@
+package gitops_test
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kenhaines/blogflow/internal/config"
+	"github.com/kenhaines/blogflow/internal/gitops"
+)
+
+func signPayload(secret, payload []byte) string {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write(payload)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func webhookLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func makePayload(ref string) []byte {
+	b, _ := json.Marshal(map[string]string{"ref": ref})
+	return b
+}
+
+func TestWebhookHandler_ValidSignature(t *testing.T) {
+	t.Parallel()
+
+	secret := "test-secret"
+
+	var called atomic.Bool
+	reloader := gitops.ContentReloader(func() error {
+		called.Store(true)
+		return nil
+	})
+
+	w, err := gitops.NewWebhookStrategy(config.WebhookConfig{
+		Path:         "/hook",
+		Secret:       secret,
+		BranchFilter: "main",
+	}, reloader, webhookLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload := makePayload("refs/heads/main")
+	req := httptest.NewRequest(http.MethodPost, "/hook", bytes.NewReader(payload))
+	req.Header.Set("X-Hub-Signature-256", signPayload([]byte(secret), payload))
+
+	rec := httptest.NewRecorder()
+	w.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	if !called.Load() {
+		t.Fatal("reloader was not called")
+	}
+}
+
+func TestWebhookHandler_InvalidSignature(t *testing.T) {
+	t.Parallel()
+
+	var called atomic.Bool
+	reloader := gitops.ContentReloader(func() error {
+		called.Store(true)
+		return nil
+	})
+
+	w, err := gitops.NewWebhookStrategy(config.WebhookConfig{
+		Path:         "/hook",
+		Secret:       "correct-secret",
+		BranchFilter: "main",
+	}, reloader, webhookLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload := makePayload("refs/heads/main")
+	req := httptest.NewRequest(http.MethodPost, "/hook", bytes.NewReader(payload))
+	req.Header.Set("X-Hub-Signature-256", signPayload([]byte("wrong-secret"), payload))
+
+	rec := httptest.NewRecorder()
+	w.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("got %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+
+	if called.Load() {
+		t.Fatal("reloader should not have been called")
+	}
+}
+
+func TestWebhookHandler_MissingSignature(t *testing.T) {
+	t.Parallel()
+
+	var called atomic.Bool
+	reloader := gitops.ContentReloader(func() error {
+		called.Store(true)
+		return nil
+	})
+
+	w, err := gitops.NewWebhookStrategy(config.WebhookConfig{
+		Path:         "/hook",
+		Secret:       "secret",
+		BranchFilter: "main",
+	}, reloader, webhookLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload := makePayload("refs/heads/main")
+	req := httptest.NewRequest(http.MethodPost, "/hook", bytes.NewReader(payload))
+	// No X-Hub-Signature-256 header set.
+
+	rec := httptest.NewRecorder()
+	w.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("got %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+
+	if called.Load() {
+		t.Fatal("reloader should not have been called")
+	}
+}
+
+func TestWebhookHandler_WrongBranch(t *testing.T) {
+	t.Parallel()
+
+	var called atomic.Bool
+	reloader := gitops.ContentReloader(func() error {
+		called.Store(true)
+		return nil
+	})
+
+	secret := "secret"
+
+	w, err := gitops.NewWebhookStrategy(config.WebhookConfig{
+		Path:         "/hook",
+		Secret:       secret,
+		BranchFilter: "main",
+	}, reloader, webhookLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload := makePayload("refs/heads/develop")
+	req := httptest.NewRequest(http.MethodPost, "/hook", bytes.NewReader(payload))
+	req.Header.Set("X-Hub-Signature-256", signPayload([]byte(secret), payload))
+
+	rec := httptest.NewRecorder()
+	w.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	if called.Load() {
+		t.Fatal("reloader should not have been called for wrong branch")
+	}
+}
+
+func TestWebhookHandler_CorrectBranch(t *testing.T) {
+	t.Parallel()
+
+	var called atomic.Bool
+	reloader := gitops.ContentReloader(func() error {
+		called.Store(true)
+		return nil
+	})
+
+	secret := "secret"
+
+	w, err := gitops.NewWebhookStrategy(config.WebhookConfig{
+		Path:         "/hook",
+		Secret:       secret,
+		BranchFilter: "production",
+	}, reloader, webhookLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload := makePayload("refs/heads/production")
+	req := httptest.NewRequest(http.MethodPost, "/hook", bytes.NewReader(payload))
+	req.Header.Set("X-Hub-Signature-256", signPayload([]byte(secret), payload))
+
+	rec := httptest.NewRecorder()
+	w.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	if !called.Load() {
+		t.Fatal("reloader was not called for matching branch")
+	}
+}
+
+func TestWebhookHandler_BodyTooLarge(t *testing.T) {
+	t.Parallel()
+
+	w, err := gitops.NewWebhookStrategy(config.WebhookConfig{
+		Path:   "/hook",
+		Secret: "secret",
+	}, func() error { return nil }, webhookLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Payload larger than 1 MB.
+	largeBody := strings.NewReader(strings.Repeat("x", 1<<20+1))
+	req := httptest.NewRequest(http.MethodPost, "/hook", largeBody)
+	req.Header.Set("X-Hub-Signature-256", "sha256=bogus")
+
+	rec := httptest.NewRecorder()
+	w.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("got %d, want %d", rec.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestWebhookHandler_EmptySecret(t *testing.T) {
+	t.Parallel()
+
+	_, err := gitops.NewWebhookStrategy(config.WebhookConfig{
+		Path: "/hook",
+	}, func() error { return nil }, webhookLogger())
+	if err == nil {
+		t.Fatal("expected error for empty secret")
+	}
+}
+
+func TestWebhookHandler_InvalidPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"empty", ""},
+		{"no_leading_slash", "hook"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := gitops.NewWebhookStrategy(config.WebhookConfig{
+				Path:   tc.path,
+				Secret: "secret",
+			}, func() error { return nil }, webhookLogger())
+			if err == nil {
+				t.Fatalf("expected error for path %q", tc.path)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Real WebhookStrategy: HMAC-SHA256 verification (constant-time), branch filtering, 1MB body limit, per-IP rate limiting, Handler() for server registration. 8 new tests, 31 total -race clean.