### PR TITLE
fix: wire real handlers + fix overlay symlink fallthrough (#62)

### DIFF
--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -18,6 +17,7 @@ import (
 	"github.com/kenhaines/blogflow/internal/content"
 	"github.com/kenhaines/blogflow/internal/overlayfs"
 	"github.com/kenhaines/blogflow/internal/server"
+	"github.com/kenhaines/blogflow/internal/server/handlers"
 	"github.com/kenhaines/blogflow/internal/theme"
 )
 
@@ -104,27 +104,32 @@ func main() {
 	}
 	logger.Info("theme engine initialized")
 
-	// Suppress unused warnings — real handlers PR will consume these.
-	_ = idx
-	_ = themeEngine
-
 	// 5. Create and configure HTTP server
 	srv := server.New(cfg, logger)
 
-	// 6. Register routes (placeholder handlers until content-handlers PR)
+	// 6. Build handler dependencies and register routes
+	deps := &handlers.Deps{
+		Config: cfg,
+		Index:  idx,
+		Theme:  themeEngine,
+	}
+
 	staticFS, fsErr := fs.Sub(contentOverlay, "static")
 	if fsErr != nil {
 		logger.Warn("static directory not available — /static/ routes will 404", "error", fsErr)
 		staticFS = nil
 	}
 
+	feedHandler := handlers.NewFeedHandler(cfg, idx)
+	sitemapHandler := handlers.NewSitemapHandler(cfg, idx)
+
 	srv.RegisterRoutes(server.RouteOptions{
-		ListHandler:    placeholderHandler("list", logger),
-		PostHandler:    placeholderHandler("post", logger),
-		PageHandler:    placeholderHandler("page", logger),
-		TagHandler:     placeholderHandler("tag", logger),
-		FeedHandler:    placeholderHandler("feed", logger),
-		SitemapHandler: placeholderHandler("sitemap", logger),
+		ListHandler:    handlers.ListHandler(deps),
+		PostHandler:    handlers.PostHandler(deps),
+		PageHandler:    handlers.PageHandler(deps),
+		TagHandler:     handlers.TagHandler(deps),
+		FeedHandler:    feedHandler.ServeHTTP,
+		SitemapHandler: sitemapHandler.ServeHTTP,
 		StaticFS:       staticFS,
 	})
 
@@ -169,11 +174,4 @@ func main() {
 		os.Exit(1)
 	}
 	logger.Info("server stopped")
-}
-
-func placeholderHandler(name string, logger *slog.Logger) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/plain")
-		_, _ = fmt.Fprintf(w, "blogflow: %s handler (placeholder)\n", name)
-	}
 }

--- a/defaults/templates/list.html
+++ b/defaults/templates/list.html
@@ -1,12 +1,12 @@
-{{define "title"}}{{if .PageTitle}}{{.PageTitle}} — {{end}}{{.Site.Title}}{{end}}
+{{define "title"}}{{if .Title}}{{.Title}} — {{end}}{{.Site.Title}}{{end}}
 
 {{define "content"}}
 <section class="post-list">
-    {{if .PageTitle}}<h1>{{.PageTitle}}</h1>{{end}}
+    {{if .Title}}<h1>{{.Title}}</h1>{{end}}
     {{range .Posts}}
     <article class="post-summary">
         <header>
-            <h2><a href="{{.URL}}">{{.Title}}</a></h2>
+            <h2><a href="/posts/{{.Slug}}">{{.Title}}</a></h2>
             {{template "post-meta" .}}
         </header>
         {{if .Summary}}<p class="summary">{{.Summary}}</p>{{end}}

--- a/defaults/templates/page.html
+++ b/defaults/templates/page.html
@@ -2,7 +2,7 @@
 {{define "og_title"}}{{.Page.Title}}{{end}}
 {{define "og_description"}}{{.Page.Description}}{{end}}
 {{define "og_type"}}website{{end}}
-{{define "og_url"}}{{.Page.URL}}{{end}}
+{{define "og_url"}}{{.Site.BaseURL}}/pages/{{.Page.Slug}}{{end}}
 {{define "meta_description"}}{{.Page.Description}}{{end}}
 
 {{define "content"}}
@@ -10,7 +10,7 @@
 <article class="page">
     <h1>{{.Page.Title}}</h1>
     <div class="page-content">
-        {{.Content}}
+        {{.Page.Content}}
     </div>
 </article>
 {{end}}

--- a/defaults/templates/post.html
+++ b/defaults/templates/post.html
@@ -2,7 +2,7 @@
 {{define "og_title"}}{{.Post.Title}}{{end}}
 {{define "og_description"}}{{.Post.Description}}{{end}}
 {{define "og_type"}}article{{end}}
-{{define "og_url"}}{{.Post.URL}}{{end}}
+{{define "og_url"}}{{.Site.BaseURL}}/posts/{{.Post.Slug}}{{end}}
 {{define "meta_description"}}{{.Post.Description}}{{end}}
 
 {{define "content"}}
@@ -13,7 +13,7 @@
         {{template "post-meta" .Post}}
     </header>
     <div class="post-content">
-        {{.Content}}
+        {{.Post.Content}}
     </div>
 </article>
 {{end}}

--- a/internal/overlayfs/overlayfs.go
+++ b/internal/overlayfs/overlayfs.go
@@ -541,6 +541,10 @@ func checkSymlinkSafe(root, name string) error {
 	fullPath := filepath.Join(root, filepath.FromSlash(name))
 	resolved, err := filepath.EvalSymlinks(fullPath)
 	if err != nil {
+		// Path doesn't exist in this layer — not a symlink issue, allow fallthrough
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
 		return err
 	}
 	// Verify resolved path is still under root

--- a/internal/server/handlers/handlers_test.go
+++ b/internal/server/handlers/handlers_test.go
@@ -40,17 +40,20 @@ func testDeps(t *testing.T, posts, pages []*content.Post) *handlers.Deps {
 
 	// Minimal templates that render enough to assert on.
 	tmplFS := fstest.MapFS{
+		"templates/base.html": &fstest.MapFile{
+			Data: []byte(`{{block "content" .}}{{end}}`),
+		},
 		"templates/list.html": &fstest.MapFile{
-			Data: []byte(`{{.Title}}|posts={{len .Posts}}|page={{.Pagination.CurrentPage}}|total={{.Pagination.TotalPages}}`),
+			Data: []byte(`{{define "content"}}{{.Title}}|posts={{len .Posts}}|page={{.Pagination.CurrentPage}}|total={{.Pagination.TotalPages}}{{end}}`),
 		},
 		"templates/post.html": &fstest.MapFile{
-			Data: []byte(`post:{{.Post.Slug}}|{{.Title}}`),
+			Data: []byte(`{{define "content"}}post:{{.Post.Slug}}|{{.Title}}{{end}}`),
 		},
 		"templates/page.html": &fstest.MapFile{
-			Data: []byte(`page:{{.Page.Slug}}|{{.Title}}`),
+			Data: []byte(`{{define "content"}}page:{{.Page.Slug}}|{{.Title}}{{end}}`),
 		},
 		"templates/404.html": &fstest.MapFile{
-			Data: []byte(`404:{{.Title}}`),
+			Data: []byte(`{{define "content"}}404:{{.Title}}{{end}}`),
 		},
 	}
 	eng, err := theme.NewEngine(tmplFS)

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -1,8 +1,6 @@
-// Package theme loads Go html/templates from the overlay FS and renders pages.
-//
-// The Engine reads .html files from a templates/ directory within the provided
-// fs.FS (typically an OverlayFS), parses them with custom template functions,
-// and caches the result. Callers render named templates with arbitrary data.
+// Package theme loads Go html/templates from the overlay FS and renders
+// blog pages. Base template and partials are shared; page templates are
+// cloned per request so their {{define}} blocks don't collide.
 package theme
 
 import (
@@ -19,12 +17,12 @@ import (
 // Engine loads and caches templates from the overlay FS.
 type Engine struct {
 	fs    fs.FS
-	tmpl  atomic.Pointer[template.Template]
+	base  atomic.Pointer[template.Template] // base.html + partials
+	pages atomic.Pointer[map[string]string] // page template sources keyed by path
 	funcs template.FuncMap
 }
 
 // NewEngine creates a theme engine that reads templates from the given fs.FS.
-// The fs should be an OverlayFS or similar — templates are resolved through it.
 func NewEngine(fsys fs.FS) (*Engine, error) {
 	e := &Engine{
 		fs:    fsys,
@@ -36,15 +34,30 @@ func NewEngine(fsys fs.FS) (*Engine, error) {
 	return e, nil
 }
 
-// Render renders a named template to the writer with the given data.
-// Output is buffered so that partial content is never written on error.
+// Render renders a page using base.html with the named page template's
+// block overrides ({{define "content"}}, {{define "title"}}, etc.).
+// Each page template is cloned+parsed per request so defines don't collide.
 func (e *Engine) Render(w io.Writer, name string, data any) error {
+	pages := *e.pages.Load()
+	src, ok := pages[name]
+	if !ok {
+		return fmt.Errorf("theme: template %q not found", name)
+	}
+
+	clone, err := e.base.Load().Clone()
+	if err != nil {
+		return fmt.Errorf("theme: clone: %w", err)
+	}
+	if _, err := clone.Parse(src); err != nil {
+		return fmt.Errorf("theme: parse page %s: %w", name, err)
+	}
+
 	var buf bytes.Buffer
-	if err := e.tmpl.Load().ExecuteTemplate(&buf, name, data); err != nil {
+	if err := clone.ExecuteTemplate(&buf, "templates/base.html", data); err != nil {
 		return err
 	}
-	_, err := buf.WriteTo(w)
-	return err
+	_, writeErr := buf.WriteTo(w)
+	return writeErr
 }
 
 // RenderToString renders a named template to a string.
@@ -57,13 +70,13 @@ func (e *Engine) RenderToString(name string, data any) (string, error) {
 }
 
 // Reload re-reads all templates from the filesystem.
-// Called after content/theme changes for hot-reload.
 func (e *Engine) Reload() error {
 	return e.loadTemplates()
 }
 
 func (e *Engine) loadTemplates() error {
-	tmpl := template.New("").Funcs(e.funcs)
+	base := template.New("").Funcs(e.funcs)
+	pages := make(map[string]string)
 
 	err := fs.WalkDir(e.fs, "templates", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -81,9 +94,22 @@ func (e *Engine) loadTemplates() error {
 			return fmt.Errorf("reading template %s: %w", path, readErr)
 		}
 
-		// Use the full path as template name (e.g., "templates/post.html").
-		if _, parseErr := tmpl.New(path).Parse(string(data)); parseErr != nil {
-			return fmt.Errorf("parsing template %s: %w", path, parseErr)
+		src := string(data)
+
+		// Base template and partials go into the shared base set.
+		// Page templates (list, post, page, 404) are stored separately
+		// and cloned+parsed per request so their defines don't collide.
+		//
+		// Convention: partials may use {{define "name"}} blocks to export
+		// a short alias (e.g., {{define "post-meta"}}). Without a define
+		// block, the partial is registered under its full WalkDir path
+		// (e.g., "templates/partials/header.html"). Both patterns work.
+		if strings.Contains(path, "partials/") || path == "templates/base.html" {
+			if _, parseErr := base.New(path).Parse(src); parseErr != nil {
+				return fmt.Errorf("parsing template %s: %w", path, parseErr)
+			}
+		} else {
+			pages[path] = src
 		}
 
 		return nil
@@ -92,7 +118,13 @@ func (e *Engine) loadTemplates() error {
 		return fmt.Errorf("loading templates: %w", err)
 	}
 
-	e.tmpl.Store(tmpl)
+	// Validate base.html exists — all page renders depend on it.
+	if base.Lookup("templates/base.html") == nil {
+		return fmt.Errorf("loading templates: templates/base.html not found (required)")
+	}
+
+	e.base.Store(base)
+	e.pages.Store(&pages)
 	return nil
 }
 
@@ -128,9 +160,6 @@ func defaultFuncMap() template.FuncMap {
 			}
 			return 1
 		},
-		// safeHTML was intentionally removed — content from the scanner is
-		// already typed as template.HTML, so a conversion helper is unnecessary
-		// and would widen the XSS attack surface.
 		"urlize": func(s string) string {
 			s = strings.ToLower(s)
 			s = strings.ReplaceAll(s, " ", "-")

--- a/internal/theme/theme_test.go
+++ b/internal/theme/theme_test.go
@@ -10,6 +10,10 @@ import (
 
 func testFS(files map[string]string) fstest.MapFS {
 	m := make(fstest.MapFS)
+	// Always include base template for the engine's clone+parse pattern
+	if _, ok := files["templates/base.html"]; !ok {
+		m["templates/base.html"] = &fstest.MapFile{Data: []byte(`<!DOCTYPE html>{{block "content" .}}{{end}}`)}
+	}
 	for k, v := range files {
 		m[k] = &fstest.MapFile{Data: []byte(v)}
 	}
@@ -18,7 +22,7 @@ func testFS(files map[string]string) fstest.MapFS {
 
 func TestNewEngine_LoadsTemplates(t *testing.T) {
 	fs := testFS(map[string]string{
-		"templates/index.html": `<h1>Hello</h1>`,
+		"templates/index.html": `{{define "content"}}<h1>Hello</h1>{{end}}`,
 	})
 
 	e, err := NewEngine(fs)
@@ -30,14 +34,14 @@ func TestNewEngine_LoadsTemplates(t *testing.T) {
 	if err := e.Render(&b, "templates/index.html", nil); err != nil {
 		t.Fatalf("Render: %v", err)
 	}
-	if got := b.String(); got != "<h1>Hello</h1>" {
-		t.Errorf("got %q, want %q", got, "<h1>Hello</h1>")
+	if got := b.String(); !strings.Contains(got, "<h1>Hello</h1>") {
+		t.Errorf("output %q does not contain %q", got, "<h1>Hello</h1>")
 	}
 }
 
 func TestRender_WithData(t *testing.T) {
 	fs := testFS(map[string]string{
-		"templates/post.html": `<h1>{{.Title}}</h1><p>by {{.Author}}</p>`,
+		"templates/post.html": `{{define "content"}}<h1>{{.Title}}</h1><p>by {{.Author}}</p>{{end}}`,
 	})
 
 	e, err := NewEngine(fs)
@@ -55,8 +59,8 @@ func TestRender_WithData(t *testing.T) {
 		t.Fatalf("Render: %v", err)
 	}
 	want := `<h1>My Post</h1><p>by Alice</p>`
-	if got := b.String(); got != want {
-		t.Errorf("got %q, want %q", got, want)
+	if got := b.String(); !strings.Contains(got, want) {
+		t.Errorf("output %q does not contain %q", got, want)
 	}
 }
 
@@ -69,73 +73,73 @@ func TestRender_FuncMap(t *testing.T) {
 	}{
 		{
 			name:     "formatDate",
-			template: `{{formatDate .Date "2006-01-02"}}`,
+			template: `{{define "content"}}{{formatDate .Date "2006-01-02"}}{{end}}`,
 			data:     struct{ Date time.Time }{Date: time.Date(2025, 3, 15, 0, 0, 0, 0, time.UTC)},
 			want:     "2025-03-15",
 		},
 		{
 			name:     "lower",
-			template: `{{lower .}}`,
+			template: `{{define "content"}}{{lower .}}{{end}}`,
 			data:     "HELLO",
 			want:     "hello",
 		},
 		{
 			name:     "upper",
-			template: `{{upper .}}`,
+			template: `{{define "content"}}{{upper .}}{{end}}`,
 			data:     "hello",
 			want:     "HELLO",
 		},
 		{
 			name:     "truncate_short",
-			template: `{{truncate . 10}}`,
+			template: `{{define "content"}}{{truncate . 10}}{{end}}`,
 			data:     "short",
 			want:     "short",
 		},
 		{
 			name:     "truncate_long_word_boundary",
-			template: `{{truncate . 20}}`,
+			template: `{{define "content"}}{{truncate . 20}}{{end}}`,
 			data:     "This is a long sentence that should be truncated",
 			want:     "This is a long…",
 		},
 		{
 			name:     "truncate_long_no_space",
-			template: `{{truncate . 5}}`,
+			template: `{{define "content"}}{{truncate . 5}}{{end}}`,
 			data:     "abcdefghij",
 			want:     "abcde…",
 		},
 		{
 			name:     "urlize",
-			template: `{{urlize .}}`,
+			template: `{{define "content"}}{{urlize .}}{{end}}`,
 			data:     "Hello World! 123",
 			want:     "hello-world-123",
 		},
 		{
 			name:     "add",
-			template: `{{add 2 3}}`,
+			template: `{{define "content"}}{{add 2 3}}{{end}}`,
 			data:     nil,
 			want:     "5",
 		},
 		{
 			name:     "sub",
-			template: `{{sub 10 3}}`,
+			template: `{{define "content"}}{{sub 10 3}}{{end}}`,
 			data:     nil,
 			want:     "7",
 		},
 		{
 			name:     "seq",
-			template: `{{range seq 1 3}}{{.}} {{end}}`,
+			template: `{{define "content"}}{{range seq 1 3}}{{.}} {{end}}{{end}}`,
 			data:     nil,
 			want:     "1 2 3 ",
 		},
 		{
 			name:     "readingTime_short",
-			template: `{{readingTime .}}`,
+			template: `{{define "content"}}{{readingTime .}}{{end}}`,
 			data:     "A few words",
 			want:     "1",
 		},
 		{
 			name:     "readingTime_long",
-			template: `{{readingTime .}}`,
+			template: `{{define "content"}}{{readingTime .}}{{end}}`,
 			data:     strings.Repeat("word ", 600),
 			want:     "3",
 		},
@@ -154,8 +158,8 @@ func TestRender_FuncMap(t *testing.T) {
 			if err != nil {
 				t.Fatalf("RenderToString: %v", err)
 			}
-			if got != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("output %q does not contain %q", got, tt.want)
 			}
 		})
 	}
@@ -164,7 +168,7 @@ func TestRender_FuncMap(t *testing.T) {
 func TestRender_Partials(t *testing.T) {
 	fs := testFS(map[string]string{
 		"templates/partials/header.html": `<header>{{.SiteName}}</header>`,
-		"templates/page.html":            `{{template "templates/partials/header.html" .}}<main>content</main>`,
+		"templates/page.html":            `{{define "content"}}{{template "templates/partials/header.html" .}}<main>content</main>{{end}}`,
 	})
 
 	e, err := NewEngine(fs)
@@ -178,14 +182,14 @@ func TestRender_Partials(t *testing.T) {
 		t.Fatalf("RenderToString: %v", err)
 	}
 	want := `<header>BlogFlow</header><main>content</main>`
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
+	if !strings.Contains(got, want) {
+		t.Errorf("output %q does not contain %q", got, want)
 	}
 }
 
 func TestRender_MissingTemplate(t *testing.T) {
 	fs := testFS(map[string]string{
-		"templates/index.html": `<h1>Hello</h1>`,
+		"templates/index.html": `{{define "content"}}<h1>Hello</h1>{{end}}`,
 	})
 
 	e, err := NewEngine(fs)
@@ -202,9 +206,10 @@ func TestRender_MissingTemplate(t *testing.T) {
 
 func TestRender_Blocks(t *testing.T) {
 	t.Run("default_block", func(t *testing.T) {
-		// When no {{define}} overrides the block, the default content is used.
+		// When the page template does not override the block, the default is used.
 		fs := testFS(map[string]string{
-			"templates/base.html": `<html>{{block "content" .}}default{{end}}</html>`,
+			"templates/base.html":  `<html>{{block "content" .}}default{{end}}</html>`,
+			"templates/empty.html": ``,
 		})
 
 		e, err := NewEngine(fs)
@@ -212,7 +217,7 @@ func TestRender_Blocks(t *testing.T) {
 			t.Fatalf("NewEngine: %v", err)
 		}
 
-		got, err := e.RenderToString("templates/base.html", nil)
+		got, err := e.RenderToString("templates/empty.html", nil)
 		if err != nil {
 			t.Fatalf("RenderToString: %v", err)
 		}
@@ -222,7 +227,7 @@ func TestRender_Blocks(t *testing.T) {
 	})
 
 	t.Run("overridden_block", func(t *testing.T) {
-		// A {{define}} in another template overrides the block default.
+		// A {{define}} in a page template overrides the block default.
 		fs := testFS(map[string]string{
 			"templates/base.html": `<html>{{block "content" .}}default{{end}}</html>`,
 			"templates/home.html": `{{define "content"}}home page{{end}}`,
@@ -233,7 +238,7 @@ func TestRender_Blocks(t *testing.T) {
 			t.Fatalf("NewEngine: %v", err)
 		}
 
-		got, err := e.RenderToString("templates/base.html", nil)
+		got, err := e.RenderToString("templates/home.html", nil)
 		if err != nil {
 			t.Fatalf("RenderToString: %v", err)
 		}
@@ -245,7 +250,8 @@ func TestRender_Blocks(t *testing.T) {
 
 func TestReload(t *testing.T) {
 	m := fstest.MapFS{
-		"templates/index.html": &fstest.MapFile{Data: []byte(`v1`)},
+		"templates/base.html":  &fstest.MapFile{Data: []byte(`<!DOCTYPE html>{{block "content" .}}{{end}}`)},
+		"templates/index.html": &fstest.MapFile{Data: []byte(`{{define "content"}}v1{{end}}`)},
 	}
 
 	e, err := NewEngine(m)
@@ -257,12 +263,12 @@ func TestReload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RenderToString: %v", err)
 	}
-	if got != "v1" {
-		t.Errorf("before reload: got %q, want %q", got, "v1")
+	if !strings.Contains(got, "v1") {
+		t.Errorf("before reload: output %q does not contain %q", got, "v1")
 	}
 
-	// Update the file in the MapFS.
-	m["templates/index.html"] = &fstest.MapFile{Data: []byte(`v2`)}
+	// Update the page template in the MapFS.
+	m["templates/index.html"] = &fstest.MapFile{Data: []byte(`{{define "content"}}v2{{end}}`)}
 
 	if err := e.Reload(); err != nil {
 		t.Fatalf("Reload: %v", err)
@@ -272,13 +278,16 @@ func TestReload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RenderToString after reload: %v", err)
 	}
-	if got != "v2" {
-		t.Errorf("after reload: got %q, want %q", got, "v2")
+	if !strings.Contains(got, "v2") {
+		t.Errorf("after reload: output %q does not contain %q", got, "v2")
 	}
 }
 
 func TestReload_ConcurrentWithRender(t *testing.T) {
-	m := fstest.MapFS{"templates/t.html": &fstest.MapFile{Data: []byte("v1")}}
+	m := fstest.MapFS{
+		"templates/base.html": &fstest.MapFile{Data: []byte(`<!DOCTYPE html>{{block "content" .}}{{end}}`)},
+		"templates/t.html":    &fstest.MapFile{Data: []byte(`{{define "content"}}v1{{end}}`)},
+	}
 	e, err := NewEngine(m)
 	if err != nil {
 		t.Fatal(err)
@@ -303,9 +312,10 @@ func TestReload_ConcurrentWithRender(t *testing.T) {
 }
 
 func TestNewEngine_NoTemplatesDir(t *testing.T) {
-	fs := testFS(map[string]string{
-		"static/main.css": `body {}`,
-	})
+	// Use raw MapFS so testFS doesn't auto-add templates/base.html.
+	fs := fstest.MapFS{
+		"static/main.css": &fstest.MapFile{Data: []byte(`body {}`)},
+	}
 
 	_, err := NewEngine(fs)
 	if err == nil {
@@ -315,7 +325,7 @@ func TestNewEngine_NoTemplatesDir(t *testing.T) {
 
 func TestRender_HTMLEscaping(t *testing.T) {
 	fs := testFS(map[string]string{
-		"templates/page.html": `<p>{{.Content}}</p>`,
+		"templates/page.html": `{{define "content"}}<p>{{.Content}}</p>{{end}}`,
 	})
 
 	e, err := NewEngine(fs)
@@ -333,14 +343,14 @@ func TestRender_HTMLEscaping(t *testing.T) {
 		t.Errorf("expected HTML escaping, got raw script tag: %s", got)
 	}
 	want := `<p>&lt;script&gt;alert(&#34;xss&#34;)&lt;/script&gt;</p>`
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
+	if !strings.Contains(got, want) {
+		t.Errorf("output %q does not contain %q", got, want)
 	}
 }
 
 func TestRenderToString(t *testing.T) {
 	fs := testFS(map[string]string{
-		"templates/greeting.html": `Hello, {{.Name}}!`,
+		"templates/greeting.html": `{{define "content"}}Hello, {{.Name}}!{{end}}`,
 	})
 
 	e, err := NewEngine(fs)
@@ -353,7 +363,7 @@ func TestRenderToString(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RenderToString: %v", err)
 	}
-	if got != "Hello, World!" {
-		t.Errorf("got %q, want %q", got, "Hello, World!")
+	if !strings.Contains(got, "Hello, World!") {
+		t.Errorf("output %q does not contain %q", got, "Hello, World!")
 	}
 }


### PR DESCRIPTION
Replaces placeholder handlers with real content/feed/sitemap handlers. Fixes overlay FS symlink check that blocked layer fallthrough for non-existent paths.

Fixes #62
Addresses #52 — feeds are now fully wired and functional (README '(planned)' label should be updated)

Tested: `make run` serves defaults, `--content ./examples/content` serves 3 posts + 1 page with theme rendering, feed.xml + sitemap.xml working.