### PR TITLE
fix: correct Go module path to match GitHub repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📖 Documentation
-    url: https://github.com/kenhaines/blogflow
+    url: https://github.com/khaines/blogflow
     about: Check the README and docs before filing an issue
   - name: 💬 Discussions
-    url: https://github.com/kenhaines/blogflow/discussions
+    url: https://github.com/khaines/blogflow/discussions
     about: Ask questions and share ideas in GitHub Discussions

--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -12,13 +12,13 @@ import (
 	"syscall"
 	"time"
 
-	blogflow "github.com/kenhaines/blogflow"
-	"github.com/kenhaines/blogflow/internal/config"
-	"github.com/kenhaines/blogflow/internal/content"
-	"github.com/kenhaines/blogflow/internal/overlayfs"
-	"github.com/kenhaines/blogflow/internal/server"
-	"github.com/kenhaines/blogflow/internal/server/handlers"
-	"github.com/kenhaines/blogflow/internal/theme"
+	blogflow "github.com/khaines/blogflow"
+	"github.com/khaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/content"
+	"github.com/khaines/blogflow/internal/overlayfs"
+	"github.com/khaines/blogflow/internal/server"
+	"github.com/khaines/blogflow/internal/server/handlers"
+	"github.com/khaines/blogflow/internal/theme"
 )
 
 var version = "dev"

--- a/examples/content/pages/about.md
+++ b/examples/content/pages/about.md
@@ -6,7 +6,7 @@ description: "About this blog and the person behind it."
 
 ## About This Blog
 
-This blog is powered by [BlogFlow](https://github.com/kenhaines/blogflow), a compact blog engine written in Go. It turns Markdown files into a clean, fast website with zero configuration required.
+This blog is powered by [BlogFlow](https://github.com/khaines/blogflow), a compact blog engine written in Go. It turns Markdown files into a clean, fast website with zero configuration required.
 
 ## About Me
 
@@ -23,7 +23,7 @@ BlogFlow is designed around a few core principles:
 
 ## Contact
 
-- **GitHub:** [github.com/kenhaines](https://github.com/kenhaines)
+- **GitHub:** [github.com/khaines](https://github.com/khaines)
 - **Email:** hello@example.com
 
 ---

--- a/examples/content/posts/getting-started-with-blogflow.md
+++ b/examples/content/posts/getting-started-with-blogflow.md
@@ -21,7 +21,7 @@ This tutorial walks through setting up a blog with BlogFlow — from zero to a c
 Build from source:
 
 ```bash
-git clone https://github.com/kenhaines/blogflow.git
+git clone https://github.com/khaines/blogflow.git
 cd blogflow
 make build
 ```
@@ -137,7 +137,7 @@ Pages are served at `/<slug>` — this one appears at `/about`.
 ## Step 7: Deploy with Docker
 
 Use the pre-built BlogFlow image (or build from the
-[engine repo](https://github.com/kenhaines/blogflow)):
+[engine repo](https://github.com/khaines/blogflow)):
 
 ```bash
 docker run -p 8080:8080 \

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kenhaines/blogflow
+module github.com/khaines/blogflow
 
 go 1.26.1
 

--- a/internal/content/cache.go
+++ b/internal/content/cache.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kenhaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/config"
 )
 
 // CacheEntry holds a rendered HTML fragment and its metadata.

--- a/internal/content/cache_test.go
+++ b/internal/content/cache_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kenhaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/config"
 )
 
 func testCacheConfig() config.CacheConfig {

--- a/internal/gitops/sync.go
+++ b/internal/gitops/sync.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/kenhaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/config"
 )
 
 // ContentReloader is called when content changes are detected.

--- a/internal/gitops/sync_test.go
+++ b/internal/gitops/sync_test.go
@@ -6,8 +6,8 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/kenhaines/blogflow/internal/config"
-	"github.com/kenhaines/blogflow/internal/gitops"
+	"github.com/khaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/gitops"
 )
 
 var noop gitops.ContentReloader = func() error { return nil }

--- a/internal/gitops/webhook.go
+++ b/internal/gitops/webhook.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kenhaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/config"
 )
 
 const maxPayloadSize = 1 << 20 // 1 MB

--- a/internal/gitops/webhook_test.go
+++ b/internal/gitops/webhook_test.go
@@ -14,8 +14,8 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/kenhaines/blogflow/internal/config"
-	"github.com/kenhaines/blogflow/internal/gitops"
+	"github.com/khaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/gitops"
 )
 
 func signPayload(secret, payload []byte) string {

--- a/internal/server/handlers/feed.go
+++ b/internal/server/handlers/feed.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/kenhaines/blogflow/internal/config"
-	"github.com/kenhaines/blogflow/internal/content"
+	"github.com/khaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/content"
 )
 
 // Atom XML structures.

--- a/internal/server/handlers/feed_test.go
+++ b/internal/server/handlers/feed_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kenhaines/blogflow/internal/config"
-	"github.com/kenhaines/blogflow/internal/content"
-	"github.com/kenhaines/blogflow/internal/server/handlers"
+	"github.com/khaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/content"
+	"github.com/khaines/blogflow/internal/server/handlers"
 )
 
 func testConfig() *config.Config {

--- a/internal/server/handlers/handlers.go
+++ b/internal/server/handlers/handlers.go
@@ -9,9 +9,9 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/kenhaines/blogflow/internal/config"
-	"github.com/kenhaines/blogflow/internal/content"
-	"github.com/kenhaines/blogflow/internal/theme"
+	"github.com/khaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/content"
+	"github.com/khaines/blogflow/internal/theme"
 )
 
 // Deps holds shared dependencies for all handlers.

--- a/internal/server/handlers/handlers_test.go
+++ b/internal/server/handlers/handlers_test.go
@@ -9,10 +9,10 @@ import (
 	"testing/fstest"
 	"time"
 
-	"github.com/kenhaines/blogflow/internal/config"
-	"github.com/kenhaines/blogflow/internal/content"
-	"github.com/kenhaines/blogflow/internal/server/handlers"
-	"github.com/kenhaines/blogflow/internal/theme"
+	"github.com/khaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/content"
+	"github.com/khaines/blogflow/internal/server/handlers"
+	"github.com/khaines/blogflow/internal/theme"
 )
 
 // testDeps builds a Deps with a minimal theme engine and test content.

--- a/internal/server/handlers/sitemap.go
+++ b/internal/server/handlers/sitemap.go
@@ -6,8 +6,8 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/kenhaines/blogflow/internal/config"
-	"github.com/kenhaines/blogflow/internal/content"
+	"github.com/khaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/content"
 )
 
 // Sitemap XML structures per sitemaps.org protocol.

--- a/internal/server/handlers/sitemap_test.go
+++ b/internal/server/handlers/sitemap_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kenhaines/blogflow/internal/content"
-	"github.com/kenhaines/blogflow/internal/server/handlers"
+	"github.com/khaines/blogflow/internal/content"
+	"github.com/khaines/blogflow/internal/server/handlers"
 )
 
 func TestSitemapHandler(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,7 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/kenhaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/config"
 )
 
 // Server is the BlogFlow HTTP server.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -14,7 +14,7 @@ import (
 	"testing/fstest"
 	"time"
 
-	"github.com/kenhaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/config"
 )
 
 func defaultTestConfig() *config.Config {


### PR DESCRIPTION
## Summary
The Go module path was `github.com/kenhaines/blogflow` but the repo lives at `github.com/khaines/blogflow`. This mismatch causes `go install` / `go get` to fail on any machine other than the original dev environment, since Go resolves the module path to a URL.

### Changes (19 files, pure rename)
- **go.mod** — `module github.com/khaines/blogflow`
- **All Go imports** — 14 `.go` files updated (cmd, content, gitops, server, handlers)
- **Example content** — clone URLs and GitHub links in `getting-started-with-blogflow.md` and `about.md`
- **Issue templates** — `config.yml` links

### Verification
- `go build ./...` ✅
- `go test -race ./...` ✅ (all 7 packages pass)
- `golangci-lint run ./...` ✅ (0 issues)
- `grep -r kenhaines` ✅ (0 matches outside .git)