### PR TITLE
fix: guard WatchStrategy.Stop() watcher read with mutex

### DIFF
--- a/internal/gitops/watch.go
+++ b/internal/gitops/watch.go
@@ -87,12 +87,16 @@ func (w *WatchStrategy) Start(ctx context.Context) error {
 
 // Stop gracefully shuts down the filesystem watcher.
 func (w *WatchStrategy) Stop(ctx context.Context) error {
+	w.mu.Lock()
+	watcher := w.watcher
+	w.mu.Unlock()
+
 	var stopErr error
 	w.stopOnce.Do(func() {
-		if w.watcher == nil {
+		if watcher == nil {
 			return
 		}
-		if err := w.watcher.Close(); err != nil {
+		if err := watcher.Close(); err != nil {
 			stopErr = fmt.Errorf("gitops: close watcher: %w", err)
 		}
 		select {

--- a/internal/gitops/watch_test.go
+++ b/internal/gitops/watch_test.go
@@ -194,3 +194,19 @@ func TestWatchStrategy_ContextCancel(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestWatchStrategy_ConcurrentStartStop(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	w := NewWatchStrategy(func() error { return nil }, watchTestLogger(), dir)
+
+	// Run with -race to detect the data race on w.watcher.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = w.Start(context.Background())
+	}()
+	_ = w.Stop(context.Background())
+	<-done
+}


### PR DESCRIPTION
## Summary
Fixes a data race in `WatchStrategy.Stop()` — `w.watcher` was read without holding `w.mu`, racing with `Start()` which writes it under the lock.

### Fix
Snapshot `w.watcher` under `w.mu` before entering `stopOnce.Do`:
```go
w.mu.Lock()
watcher := w.watcher
w.mu.Unlock()
```

### Test
Added `TestWatchStrategy_ConcurrentStartStop` — launches `Start()` and `Stop()` concurrently. Passes with `-race` detector.

Fixes #56