### PR TITLE
docs: remove stale planned/coming-soon labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Open [http://localhost:8080](http://localhost:8080) — that's it.
 - **Secure by default** — distroless container, rootless (UID 65532), read-only root FS
 - **< 15 MB container** — single static binary on `gcr.io/distroless/static-debian12:nonroot`
 - **Git-driven content** — git-sync sidecar or fsnotify for live reload
-- **HMAC-SHA256 webhooks** (planned) — constant-time signature validation, branch filtering, rate limiting
-- **Atom/RSS feeds** (planned) — auto-generated with configurable item count
+- **HMAC-SHA256 webhooks** — constant-time signature validation, branch filtering, rate limiting
+- **Atom/RSS feeds** — auto-generated with configurable item count
 - **Rendered content cache** — in-memory LRU with configurable TTL
 
 ## Configuration
@@ -83,7 +83,7 @@ cache:
   max_entries: 1000
 
 feed:
-  enabled: true       # (coming soon) feed generation is a planned feature
+  enabled: true
   type: "atom"
   items: 20
 ```
@@ -102,10 +102,10 @@ See [`examples/config/site.yaml`](examples/config/site.yaml) for a fully documen
 | `BLOGFLOW_SERVER_WRITE_TIMEOUT` | Write timeout |
 | `BLOGFLOW_SERVER_IDLE_TIMEOUT` | Idle timeout |
 | `BLOGFLOW_CACHE_ENABLED` | Enable/disable cache (`true`/`false`) |
-| `BLOGFLOW_SYNC_STRATEGY` | Sync strategy: `watch`, `webhook` (planned), `sidecar` |
-| `BLOGFLOW_WEBHOOK_SECRET` | Webhook HMAC secret (planned) (≥ 32 bytes, **never in YAML**) |
-| `BLOGFLOW_SYNC_WEBHOOK_RATE_LIMIT` | Webhook rate limit (planned) (1–100 req/min) |
-| `BLOGFLOW_FEED_TYPE` | Feed format (planned): `atom` or `rss` |
+| `BLOGFLOW_SYNC_STRATEGY` | Sync strategy: `watch`, `webhook`, `sidecar` |
+| `BLOGFLOW_WEBHOOK_SECRET` | Webhook HMAC secret (≥ 32 bytes, **never in YAML**) |
+| `BLOGFLOW_SYNC_WEBHOOK_RATE_LIMIT` | Webhook rate limit (1–100 req/min) |
+| `BLOGFLOW_FEED_TYPE` | Feed format: `atom` or `rss` |
 
 ## Progressive Customization
 

--- a/examples/config/site.yaml
+++ b/examples/config/site.yaml
@@ -72,11 +72,10 @@ cache:
 sync:
   strategy: "watch"           # Content sync strategy:
                               #   "watch"   — fsnotify file watcher (local dev)
-                              #   "webhook" — GitHub/GitLab push webhook (planned)
+                              #   "webhook" — GitHub/GitLab push webhook
                               #   "sidecar" — git-sync sidecar (Kubernetes)
                               # Override: BLOGFLOW_SYNC_STRATEGY
 
-  # NOTE: Webhook support is a planned feature and is not yet implemented.
   webhook:
     path: "/api/webhook"      # URL path for the webhook endpoint
     allowed_events:           # GitHub events to accept
@@ -87,7 +86,7 @@ sync:
     rate_limit: 10            # Max webhook requests per minute (1–100)
 
 # ---------------------------------------------------------------------------
-# Feed — RSS/Atom feed generation (planned — not yet implemented)
+# Feed — RSS/Atom feed generation
 # ---------------------------------------------------------------------------
 feed:
   enabled: true               # Generate a feed at /feed.xml (or /feed.atom)

--- a/examples/content/posts/getting-started-with-blogflow.md
+++ b/examples/content/posts/getting-started-with-blogflow.md
@@ -111,7 +111,7 @@ content:
   posts_per_page: 5
 
 feed:
-  enabled: true       # (coming soon) feed generation is a planned feature
+  enabled: true
   type: "atom"
 ```
 
@@ -152,5 +152,5 @@ The resulting image is under 15 MB and runs rootless on a distroless base.
 ## What's Next?
 
 - Explore [Markdown Features](/posts/markdown-features) to see everything BlogFlow supports
-- Set up webhook sync for automatic deploys on `git push` (coming soon)
+- Set up [webhook sync](/posts/getting-started-with-blogflow#webhooks) for automatic deploys on `git push`
 - Create a custom theme directory with your own templates and CSS


### PR DESCRIPTION
## Summary
Feeds (Atom/RSS) and HMAC-SHA256 webhooks are fully implemented and wired, but README, example config, and the getting-started post still say "(planned)" or "(coming soon)".

### Changes
- **README.md** — removed "(planned)" from webhooks, feeds, and env var table
- **examples/config/site.yaml** — removed "(planned)" note from webhook and feed sections
- **examples/content/posts/getting-started-with-blogflow.md** — removed "(coming soon)" from feed config and webhook next-steps

Design docs retain historical "(planned)" references as architecture records — left intentionally.

Fixes #52