### PR TITLE
fix: replace 100ms readiness heuristic with channel signal

### DIFF
--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -158,14 +158,17 @@ func main() {
 		errCh <- srv.Start()
 	}()
 
-	// Brief wait to detect immediate bind failures
+	// Wait for listener to bind or an immediate failure
 	select {
 	case err := <-errCh:
 		logger.Error("server failed to start", "error", err)
 		os.Exit(1)
-	case <-time.After(100 * time.Millisecond):
+	case <-srv.Ready():
 		srv.SetReady(true)
 		logger.Info("server ready")
+	case <-time.After(5 * time.Second):
+		logger.Error("server did not become ready within timeout")
+		os.Exit(1)
 	}
 
 	// Wait for server to finish (shutdown or error)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"runtime/debug"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -24,6 +25,8 @@ type Server struct {
 	config     *config.Config
 	logger     *slog.Logger
 	ready      atomic.Bool
+	readyCh    chan struct{}
+	readyOnce  sync.Once
 }
 
 // New creates a new BlogFlow server.
@@ -34,9 +37,10 @@ func New(cfg *config.Config, logger *slog.Logger) *Server {
 
 	mux := http.NewServeMux()
 	s := &Server{
-		mux:    mux,
-		config: cfg,
-		logger: logger,
+		mux:     mux,
+		config:  cfg,
+		logger:  logger,
+		readyCh: make(chan struct{}),
 	}
 
 	s.httpServer = &http.Server{
@@ -122,18 +126,35 @@ func (s *Server) RegisterRoutes(opts RouteOptions) {
 	}
 }
 
+// Ready returns a channel that is closed once the server's network listener
+// is bound and the server is ready to accept connections.
+func (s *Server) Ready() <-chan struct{} {
+	return s.readyCh
+}
+
 // Start begins serving HTTP. Blocks until the server stops.
 func (s *Server) Start() error {
-	s.logger.Info("server starting", "addr", s.httpServer.Addr)
-	if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	addr := s.httpServer.Addr
+	if addr == "" {
+		addr = ":http"
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("server: %w", err)
+	}
+	s.logger.Info("server listening", "addr", ln.Addr().String())
+	s.readyOnce.Do(func() { close(s.readyCh) })
+	if err := s.httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
 		return fmt.Errorf("server: %w", err)
 	}
 	return nil
 }
 
 // Serve begins serving HTTP on the given listener. Blocks until the server stops.
+// The ready channel is closed immediately since the listener is already bound.
 func (s *Server) Serve(ln net.Listener) error {
 	s.logger.Info("server starting", "addr", ln.Addr().String())
+	s.readyOnce.Do(func() { close(s.readyCh) })
 	if err := s.httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
 		return fmt.Errorf("server: %w", err)
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -356,3 +356,133 @@ func TestReadyEndpoint_CacheControl(t *testing.T) {
 		t.Errorf("Cache-Control = %q, want %q", got, "no-store")
 	}
 }
+
+func TestReadyChannel_ClosedAfterStart(t *testing.T) {
+	cfg := defaultTestConfig()
+	cfg.Server.Port = 0 // let OS pick a free port
+	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	s.RegisterRoutes(testRouteOptions())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.Start()
+	}()
+
+	select {
+	case <-s.Ready():
+		// success — channel closed once listener is bound
+	case err := <-errCh:
+		t.Fatalf("Start returned before Ready: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Ready channel was not closed within timeout")
+	}
+
+	// Clean shutdown
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := s.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown error: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("Start returned unexpected error: %v", err)
+	}
+}
+
+func TestReadyChannel_ClosedAfterServe(t *testing.T) {
+	cfg := defaultTestConfig()
+	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	s.RegisterRoutes(testRouteOptions())
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.Serve(ln)
+	}()
+
+	select {
+	case <-s.Ready():
+		// success — channel closed when Serve is called with pre-bound listener
+	case err := <-errCh:
+		t.Fatalf("Serve returned before Ready: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Ready channel was not closed within timeout")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := s.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown error: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("Serve returned unexpected error: %v", err)
+	}
+}
+
+func TestReadyChannel_DoubleCloseProtection(t *testing.T) {
+	cfg := defaultTestConfig()
+	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	s.RegisterRoutes(testRouteOptions())
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.Serve(ln)
+	}()
+
+	select {
+	case <-s.Ready():
+	case <-time.After(5 * time.Second):
+		t.Fatal("Ready channel was not closed within timeout")
+	}
+
+	// Calling Serve's close path again via shutdown+re-serve should not panic
+	// thanks to sync.Once protection. Verify by directly invoking the ready
+	// signal a second time through a second Serve on a new listener.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := s.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown error: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("Serve returned unexpected error: %v", err)
+	}
+
+	// A second Serve on the same Server must not panic from double-close.
+	ln2, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen (2nd): %v", err)
+	}
+	errCh2 := make(chan error, 1)
+	go func() {
+		errCh2 <- s.Serve(ln2)
+	}()
+
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel2()
+	if err := s.Shutdown(ctx2); err != nil {
+		t.Fatalf("Shutdown (2nd) error: %v", err)
+	}
+	if err := <-errCh2; err != nil {
+		t.Fatalf("Serve (2nd) returned unexpected error: %v", err)
+	}
+}
+
+func TestReadyChannel_NotClosedBeforeStart(t *testing.T) {
+	cfg := defaultTestConfig()
+	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	select {
+	case <-s.Ready():
+		t.Fatal("Ready channel should not be closed before Start/Serve")
+	default:
+		// expected — channel is still open
+	}
+}


### PR DESCRIPTION
## Summary

Replace the fragile 100ms `time.After` heuristic in `main.go` with a deterministic channel-based readiness signal.

### Changes

- **`Server.Ready()`**: New method returning a `<-chan struct{}` that is closed once `net.Listen` succeeds
- **`Server.Start()`**: Now calls `net.Listen` explicitly, closes the ready channel, then serves — giving callers a reliable signal
- **`Server.Serve()`**: Also closes the ready channel immediately since the listener is already bound
- **`main.go`**: Replaces `time.After(100ms)` with `<-srv.Ready()` (with a 5s safety timeout)
- **Tests**: 3 new tests verify the channel is closed after Start, after Serve, and not before either

### Why

The old approach was racy: on slow CI machines the server might not be listening after 100ms, causing flaky startup detection. On fast machines it wasted 100ms on every start. The channel gives an instant, deterministic signal.

Fixes #65
Fixes #34