### PR TITLE
feat: add healthcheck subcommand for distroless containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /app ./cmd/blogflow
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=build /app /app
 USER nonroot:nonroot
+HEALTHCHECK --interval=30s --timeout=3s CMD ["/app", "healthcheck"]
 ENTRYPOINT ["/app"]

--- a/cmd/blogflow/healthcheck.go
+++ b/cmd/blogflow/healthcheck.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	healthcheckTimeout = 2 * time.Second
+	healthcheckPath    = "/healthz"
+	defaultPort        = 8080
+)
+
+// runHealthcheck performs an HTTP GET against the local /healthz endpoint
+// and exits 0 on success (HTTP 200) or 1 on any failure. This allows
+// distroless containers (no curl/wget) to use the binary itself as a
+// Docker HEALTHCHECK or Kubernetes liveness probe command.
+func runHealthcheck(args []string) int {
+	fs := flag.NewFlagSet("healthcheck", flag.ContinueOnError)
+	port := fs.Int("port", defaultPort, "port to probe")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "healthcheck: %v\n", err)
+		return 1
+	}
+
+	url := fmt.Sprintf("http://localhost:%d%s", *port, healthcheckPath)
+
+	client := &http.Client{Timeout: healthcheckTimeout}
+	resp, err := client.Get(url)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "healthcheck: %v\n", err)
+		return 1
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort close
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "healthcheck: unhealthy (status %d)\n", resp.StatusCode)
+		return 1
+	}
+	return 0
+}

--- a/cmd/blogflow/healthcheck_test.go
+++ b/cmd/blogflow/healthcheck_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// newTestHealthServer starts an HTTP server that responds to /healthz
+// with the given status code. It returns the listener (caller must close).
+func newTestHealthServer(t *testing.T, status int) net.Listener {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		_, _ = fmt.Fprint(w, "ok")
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	srv := &http.Server{
+		Handler:     mux,
+		ReadTimeout: 5 * time.Second,
+	}
+	go srv.Serve(ln) //nolint:errcheck
+
+	return ln
+}
+
+func TestRunHealthcheck_Healthy(t *testing.T) {
+	ln := newTestHealthServer(t, http.StatusOK)
+	defer ln.Close() //nolint:errcheck
+
+	port := ln.Addr().(*net.TCPAddr).Port
+	code := runHealthcheck([]string{"--port", fmt.Sprintf("%d", port)})
+	if code != 0 {
+		t.Errorf("expected exit 0, got %d", code)
+	}
+}
+
+func TestRunHealthcheck_Unhealthy(t *testing.T) {
+	ln := newTestHealthServer(t, http.StatusServiceUnavailable)
+	defer ln.Close() //nolint:errcheck
+
+	port := ln.Addr().(*net.TCPAddr).Port
+	code := runHealthcheck([]string{"--port", fmt.Sprintf("%d", port)})
+	if code != 1 {
+		t.Errorf("expected exit 1, got %d", code)
+	}
+}
+
+func TestRunHealthcheck_ConnectionRefused(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close() // close immediately so nothing is listening
+
+	code := runHealthcheck([]string{"--port", fmt.Sprintf("%d", port)})
+	if code != 1 {
+		t.Errorf("expected exit 1, got %d", code)
+	}
+}
+
+func TestRunHealthcheck_InvalidFlag(t *testing.T) {
+	code := runHealthcheck([]string{"--bogus"})
+	if code != 1 {
+		t.Errorf("expected exit 1, got %d", code)
+	}
+}

--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -24,6 +24,11 @@ import (
 var version = "dev"
 
 func main() {
+	// Subcommand: healthcheck (must run before flag.Parse)
+	if len(os.Args) > 1 && os.Args[1] == "healthcheck" {
+		os.Exit(runHealthcheck(os.Args[2:]))
+	}
+
 	// CLI flags
 	contentPath := flag.String("content", "", "Path to content directory")
 	themePath := flag.String("theme", "", "Path to custom theme directory")


### PR DESCRIPTION
## Summary

Adds a `blogflow healthcheck` CLI subcommand and Docker `HEALTHCHECK` instruction for distroless containers where `curl`/`wget` are unavailable.

### Changes

- **`cmd/blogflow/healthcheck.go`** — `runHealthcheck()` function: HTTP GET to `localhost:<port>/healthz` with 2s timeout, exits 0 (healthy) or 1 (unhealthy). Accepts `--port` flag (default 8080).
- **`cmd/blogflow/main.go`** — Intercepts `os.Args[1] == "healthcheck"` before `flag.Parse()` to dispatch to the subcommand.
- **`cmd/blogflow/healthcheck_test.go`** — Tests for healthy, unhealthy, connection-refused, and invalid-flag scenarios.
- **`Dockerfile`** — Adds `HEALTHCHECK --interval=30s --timeout=3s CMD ["/app", "healthcheck"]`.

The existing `/healthz` endpoint (returns 200 "ok") was already in place.

Fixes #46