### PR TITLE
feat: add Permissions-Policy and HSTS security headers

### DIFF
--- a/examples/config/site.yaml
+++ b/examples/config/site.yaml
@@ -56,6 +56,12 @@ server:
   read_timeout: "5s"          # Max time to read request (Go duration)
   write_timeout: "10s"        # Max time to write response
   idle_timeout: "120s"        # Max time for idle keep-alive connections
+  # tls_terminated: false     # Set to true when behind a TLS-terminating reverse proxy
+                              # to enable Strict-Transport-Security (HSTS) header.
+                              # Override: BLOGFLOW_SERVER_TLS_TERMINATED
+  # hsts_max_age: 63072000   # HSTS max-age in seconds (default: 63072000 = 2 years).
+                              # Only used when tls_terminated is true.
+                              # Override: BLOGFLOW_SERVER_HSTS_MAX_AGE
 
 # ---------------------------------------------------------------------------
 # Cache — in-memory rendered content cache

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,10 +53,12 @@ type ThemeConfig struct {
 
 // ServerConfig holds HTTP server settings.
 type ServerConfig struct {
-	Port         int           `yaml:"port"`
-	ReadTimeout  time.Duration `yaml:"read_timeout"`
-	WriteTimeout time.Duration `yaml:"write_timeout"`
-	IdleTimeout  time.Duration `yaml:"idle_timeout"`
+	Port          int           `yaml:"port"`
+	ReadTimeout   time.Duration `yaml:"read_timeout"`
+	WriteTimeout  time.Duration `yaml:"write_timeout"`
+	IdleTimeout   time.Duration `yaml:"idle_timeout"`
+	TLSTerminated bool          `yaml:"tls_terminated"`
+	HSTSMaxAge    int           `yaml:"hsts_max_age"`
 }
 
 // CacheConfig holds rendered content cache settings.
@@ -112,10 +114,12 @@ func Default() *Config {
 			Name: "default",
 		},
 		Server: ServerConfig{
-			Port:         8080,
-			ReadTimeout:  5 * time.Second,
-			WriteTimeout: 10 * time.Second,
-			IdleTimeout:  120 * time.Second,
+			Port:          8080,
+			ReadTimeout:   5 * time.Second,
+			WriteTimeout:  10 * time.Second,
+			IdleTimeout:   120 * time.Second,
+			TLSTerminated: false,
+			HSTSMaxAge:    63072000, // 2 years
 		},
 		Cache: CacheConfig{
 			Enabled:    true,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -649,6 +649,8 @@ func TestValidate_FieldBounds(t *testing.T) {
 		{"cache max_entries too high", func(c *Config) { c.Cache.MaxEntries = 100001 }, "cache.max_entries"},
 		{"feed items too low", func(c *Config) { c.Feed.Items = 0 }, "feed.items"},
 		{"feed items too high", func(c *Config) { c.Feed.Items = 101 }, "feed.items"},
+		{"hsts_max_age negative", func(c *Config) { c.Server.HSTSMaxAge = -1 }, "server.hsts_max_age"},
+		{"hsts_max_age too high", func(c *Config) { c.Server.HSTSMaxAge = 63072001 }, "server.hsts_max_age"},
 		{
 			"webhook path no leading slash",
 			func(c *Config) {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -280,6 +280,22 @@ var envMap = map[string]func(*Config, string) error{
 		c.Feed.Type = v
 		return nil
 	},
+	"BLOGFLOW_SERVER_TLS_TERMINATED": func(c *Config, v string) error {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return fmt.Errorf("cannot parse env var BLOGFLOW_SERVER_TLS_TERMINATED as bool: %w", err)
+		}
+		c.Server.TLSTerminated = b
+		return nil
+	},
+	"BLOGFLOW_SERVER_HSTS_MAX_AGE": func(c *Config, v string) error {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("cannot parse env var BLOGFLOW_SERVER_HSTS_MAX_AGE as int: %w", err)
+		}
+		c.Server.HSTSMaxAge = n
+		return nil
+	},
 }
 
 func applyEnvOverrides(cfg *Config) error {
@@ -488,6 +504,15 @@ func Validate(cfg *Config) error {
 				Message: "must be between 1 and 100",
 			})
 		}
+	}
+
+	// Server.HSTSMaxAge: 0–63072000 (2 years); only emitted when TLSTerminated
+	if cfg.Server.HSTSMaxAge < 0 || cfg.Server.HSTSMaxAge > 63072000 {
+		errs = append(errs, FieldError{
+			Field:   "server.hsts_max_age",
+			Value:   cfg.Server.HSTSMaxAge,
+			Message: "must be between 0 and 63072000 (2 years)",
+		})
 	}
 
 	// Feed validation only when feed is enabled

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -181,6 +181,12 @@ func (s *Server) securityHeadersMiddleware(next http.Handler) http.Handler {
 				"connect-src 'none'; style-src 'self'; img-src 'self' https: data:; "+
 				"font-src 'self' https:; base-uri 'self'; form-action 'self'; "+
 				"frame-ancestors 'self'")
+		w.Header().Set("Permissions-Policy",
+			"camera=(), microphone=(), geolocation=(), payment=(), usb=(), browsing-topics=(), interest-cohort=()")
+		if s.config.Server.TLSTerminated {
+			w.Header().Set("Strict-Transport-Security",
+				fmt.Sprintf("max-age=%d; includeSubDomains", s.config.Server.HSTSMaxAge))
+		}
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -154,6 +154,51 @@ func TestSecurityHeaders(t *testing.T) {
 	}
 }
 
+func TestPermissionsPolicyHeader(t *testing.T) {
+	s := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	got := rec.Header().Get("Permissions-Policy")
+	want := "camera=(), microphone=(), geolocation=(), payment=(), usb=(), browsing-topics=(), interest-cohort=()"
+	if got != want {
+		t.Errorf("Permissions-Policy = %q, want %q", got, want)
+	}
+}
+
+func TestHSTSHeader_DefaultOff(t *testing.T) {
+	s := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Strict-Transport-Security"); got != "" {
+		t.Errorf("HSTS should be absent by default, got %q", got)
+	}
+}
+
+func TestHSTSHeader_EnabledWhenTLSTerminated(t *testing.T) {
+	cfg := defaultTestConfig()
+	cfg.Server.TLSTerminated = true
+	cfg.Server.HSTSMaxAge = 63072000
+
+	s := New(cfg, slog.Default())
+	s.RegisterRoutes(testRouteOptions())
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	got := rec.Header().Get("Strict-Transport-Security")
+	want := "max-age=63072000; includeSubDomains"
+	if got != want {
+		t.Errorf("Strict-Transport-Security = %q, want %q", got, want)
+	}
+}
+
 func TestCSPHeader(t *testing.T) {
 	s := newTestServer(t)
 


### PR DESCRIPTION
## Summary

Add two missing security headers to BlogFlow's HTTP middleware:

### Permissions-Policy (always set)
Opts out of browser APIs the blog doesn't use:
```
Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()
```

### HSTS (conditional)
Only set when `server.tls_terminated: true` is configured (safe default for local dev):
```
Strict-Transport-Security: max-age=63072000; includeSubDomains
```

### Changes
- **internal/config/config.go**: Added `TLSTerminated` and `HSTSMaxAge` fields to `ServerConfig`
- **internal/config/loader.go**: Added `BLOGFLOW_SERVER_TLS_TERMINATED` and `BLOGFLOW_SERVER_HSTS_MAX_AGE` env var overrides
- **internal/server/server.go**: Added both headers to `securityHeadersMiddleware`
- **internal/server/server_test.go**: Added tests for Permissions-Policy (always present), HSTS absent by default, HSTS present when TLS terminated
- **examples/config/site.yaml**: Documented new config fields (commented out)

Fixes #26
Fixes #27