### PR TITLE
feat: add request-ID middleware and proxy-aware client IP

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,12 +53,13 @@ type ThemeConfig struct {
 
 // ServerConfig holds HTTP server settings.
 type ServerConfig struct {
-	Port          int           `yaml:"port"`
-	ReadTimeout   time.Duration `yaml:"read_timeout"`
-	WriteTimeout  time.Duration `yaml:"write_timeout"`
-	IdleTimeout   time.Duration `yaml:"idle_timeout"`
-	TLSTerminated bool          `yaml:"tls_terminated"`
-	HSTSMaxAge    int           `yaml:"hsts_max_age"`
+	Port              int           `yaml:"port"`
+	ReadTimeout       time.Duration `yaml:"read_timeout"`
+	WriteTimeout      time.Duration `yaml:"write_timeout"`
+	IdleTimeout       time.Duration `yaml:"idle_timeout"`
+	TLSTerminated     bool          `yaml:"tls_terminated"`
+	HSTSMaxAge        int           `yaml:"hsts_max_age"`
+	TrustedProxyCIDRs []string      `yaml:"trusted_proxy_cidrs"`
 }
 
 // CacheConfig holds rendered content cache settings.

--- a/internal/server/clientip.go
+++ b/internal/server/clientip.go
@@ -1,0 +1,84 @@
+package server
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// ClientIPResolver resolves the real client IP from an HTTP request, taking
+// into account trusted reverse-proxy headers when the request originates
+// from a trusted proxy CIDR.
+type ClientIPResolver struct {
+	trusted []*net.IPNet
+}
+
+// NewClientIPResolver creates a resolver with the given list of trusted
+// proxy CIDRs (e.g. "10.0.0.0/8", "172.16.0.0/12"). When the list is
+// empty, forwarded headers are never trusted and RemoteAddr is always used.
+func NewClientIPResolver(cidrs []string) (*ClientIPResolver, error) {
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, ipNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, err
+		}
+		nets = append(nets, ipNet)
+	}
+	return &ClientIPResolver{trusted: nets}, nil
+}
+
+// ClientIP returns the best-effort real client IP for the request.
+//
+// If RemoteAddr is from a trusted proxy CIDR, X-Forwarded-For (right-most
+// untrusted entry) or X-Real-IP is used. Otherwise RemoteAddr is returned.
+func (c *ClientIPResolver) ClientIP(r *http.Request) string {
+	remoteIP := extractIP(r.RemoteAddr)
+	if !c.isTrusted(remoteIP) {
+		return remoteIP
+	}
+
+	// Prefer X-Forwarded-For: walk from right to left, skip trusted proxies.
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		ips := strings.Split(xff, ",")
+		for i := len(ips) - 1; i >= 0; i-- {
+			ip := strings.TrimSpace(ips[i])
+			if ip == "" {
+				continue
+			}
+			if !c.isTrusted(ip) {
+				return ip
+			}
+		}
+		// All entries are trusted — fall through to X-Real-IP / RemoteAddr.
+	}
+
+	if realIP := strings.TrimSpace(r.Header.Get("X-Real-IP")); realIP != "" {
+		return realIP
+	}
+
+	return remoteIP
+}
+
+// isTrusted reports whether ip falls within any configured trusted CIDR.
+func (c *ClientIPResolver) isTrusted(ip string) bool {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	for _, n := range c.trusted {
+		if n.Contains(parsed) {
+			return true
+		}
+	}
+	return false
+}
+
+// extractIP strips the port from an address like "1.2.3.4:5678" or "[::1]:80".
+func extractIP(addr string) string {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+	return host
+}

--- a/internal/server/clientip_test.go
+++ b/internal/server/clientip_test.go
@@ -1,0 +1,178 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewClientIPResolver_InvalidCIDR(t *testing.T) {
+	_, err := NewClientIPResolver([]string{"not-a-cidr"})
+	if err == nil {
+		t.Fatal("expected error for invalid CIDR, got nil")
+	}
+}
+
+func TestClientIP_NoTrustedProxies(t *testing.T) {
+	resolver, err := NewClientIPResolver(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "203.0.113.50:12345"
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+	req.Header.Set("X-Real-IP", "5.6.7.8")
+
+	got := resolver.ClientIP(req)
+	if got != "203.0.113.50" {
+		t.Errorf("ClientIP = %q, want %q (should ignore forwarded headers)", got, "203.0.113.50")
+	}
+}
+
+func TestClientIP_TrustedProxy_XForwardedFor(t *testing.T) {
+	resolver, err := NewClientIPResolver([]string{"10.0.0.0/8"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	req.Header.Set("X-Forwarded-For", "203.0.113.50, 10.0.0.5")
+
+	got := resolver.ClientIP(req)
+	if got != "203.0.113.50" {
+		t.Errorf("ClientIP = %q, want %q", got, "203.0.113.50")
+	}
+}
+
+func TestClientIP_TrustedProxy_XRealIP(t *testing.T) {
+	resolver, err := NewClientIPResolver([]string{"10.0.0.0/8"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	req.Header.Set("X-Real-IP", "203.0.113.99")
+
+	got := resolver.ClientIP(req)
+	if got != "203.0.113.99" {
+		t.Errorf("ClientIP = %q, want %q", got, "203.0.113.99")
+	}
+}
+
+func TestClientIP_TrustedProxy_XFFPreferredOverXRealIP(t *testing.T) {
+	resolver, err := NewClientIPResolver([]string{"10.0.0.0/8"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	req.Header.Set("X-Forwarded-For", "198.51.100.1")
+	req.Header.Set("X-Real-IP", "203.0.113.99")
+
+	got := resolver.ClientIP(req)
+	if got != "198.51.100.1" {
+		t.Errorf("ClientIP = %q, want %q (XFF should take precedence)", got, "198.51.100.1")
+	}
+}
+
+func TestClientIP_TrustedProxy_AllXFFTrusted_FallsToXRealIP(t *testing.T) {
+	resolver, err := NewClientIPResolver([]string{"10.0.0.0/8", "172.16.0.0/12"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	req.Header.Set("X-Forwarded-For", "10.0.0.2, 172.16.0.5")
+	req.Header.Set("X-Real-IP", "203.0.113.77")
+
+	got := resolver.ClientIP(req)
+	if got != "203.0.113.77" {
+		t.Errorf("ClientIP = %q, want %q (all XFF trusted, should fall to X-Real-IP)", got, "203.0.113.77")
+	}
+}
+
+func TestClientIP_TrustedProxy_NoHeaders_FallsToRemoteAddr(t *testing.T) {
+	resolver, err := NewClientIPResolver([]string{"10.0.0.0/8"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+
+	got := resolver.ClientIP(req)
+	if got != "10.0.0.1" {
+		t.Errorf("ClientIP = %q, want %q", got, "10.0.0.1")
+	}
+}
+
+func TestClientIP_UntrustedProxy(t *testing.T) {
+	resolver, err := NewClientIPResolver([]string{"10.0.0.0/8"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "192.168.1.1:5555"
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+
+	got := resolver.ClientIP(req)
+	if got != "192.168.1.1" {
+		t.Errorf("ClientIP = %q, want %q (proxy not trusted)", got, "192.168.1.1")
+	}
+}
+
+func TestClientIP_IPv6(t *testing.T) {
+	resolver, err := NewClientIPResolver([]string{"fd00::/8"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "[fd00::1]:8080"
+	req.Header.Set("X-Forwarded-For", "2001:db8::1")
+
+	got := resolver.ClientIP(req)
+	if got != "2001:db8::1" {
+		t.Errorf("ClientIP = %q, want %q", got, "2001:db8::1")
+	}
+}
+
+func TestClientIP_MultipleXFF_SkipsTrusted(t *testing.T) {
+	resolver, err := NewClientIPResolver([]string{"10.0.0.0/8"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	req.Header.Set("X-Forwarded-For", "203.0.113.1, 10.0.0.2, 10.0.0.3")
+
+	got := resolver.ClientIP(req)
+	if got != "203.0.113.1" {
+		t.Errorf("ClientIP = %q, want %q (should skip trusted proxies right-to-left)", got, "203.0.113.1")
+	}
+}
+
+func TestExtractIP(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"1.2.3.4:5678", "1.2.3.4"},
+		{"[::1]:80", "::1"},
+		{"1.2.3.4", "1.2.3.4"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := extractIP(tt.input); got != tt.want {
+				t.Errorf("extractIP(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/requestid.go
+++ b/internal/server/requestid.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"net/http"
+)
+
+type contextKey string
+
+const requestIDKey contextKey = "request_id"
+
+const requestIDHeader = "X-Request-Id"
+
+// generateUUID returns a new UUID v4 string using crypto/rand.
+func generateUUID() (string, error) {
+	var uuid [16]byte
+	if _, err := rand.Read(uuid[:]); err != nil {
+		return "", fmt.Errorf("generating request ID: %w", err)
+	}
+	// Set version 4 and variant bits per RFC 4122.
+	uuid[6] = (uuid[6] & 0x0f) | 0x40
+	uuid[8] = (uuid[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:16]), nil
+}
+
+// isValidRequestID checks that an incoming request ID is safe to propagate.
+// It must be 1–128 printable ASCII characters (no control chars or spaces > 127).
+func isValidRequestID(id string) bool {
+	if len(id) == 0 || len(id) > 128 {
+		return false
+	}
+	for i := 0; i < len(id); i++ {
+		c := id[i]
+		if c < 0x21 || c > 0x7e {
+			return false
+		}
+	}
+	return true
+}
+
+// requestIDMiddleware adds a unique request ID to every request.
+// If the incoming request carries a valid X-Request-Id header the value is
+// reused (for distributed tracing propagation); otherwise a new UUID v4 is
+// generated. The ID is stored in the request context and set as a response
+// header.
+func (s *Server) requestIDMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.Header.Get(requestIDHeader)
+		if !isValidRequestID(id) {
+			var err error
+			id, err = generateUUID()
+			if err != nil {
+				s.logger.Error("failed to generate request ID", "error", err)
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				return
+			}
+		}
+
+		ctx := context.WithValue(r.Context(), requestIDKey, id)
+		w.Header().Set(requestIDHeader, id)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// RequestIDFromContext returns the request ID stored in the context, or "".
+func RequestIDFromContext(ctx context.Context) string {
+	if id, ok := ctx.Value(requestIDKey).(string); ok {
+		return id
+	}
+	return ""
+}

--- a/internal/server/requestid_test.go
+++ b/internal/server/requestid_test.go
@@ -1,0 +1,141 @@
+package server
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+)
+
+var uuidV4Re = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+func TestGenerateUUID_Format(t *testing.T) {
+	seen := make(map[string]bool, 100)
+	for range 100 {
+		id, err := generateUUID()
+		if err != nil {
+			t.Fatalf("generateUUID() error: %v", err)
+		}
+		if !uuidV4Re.MatchString(id) {
+			t.Errorf("generateUUID() = %q, does not match UUID v4 pattern", id)
+		}
+		if seen[id] {
+			t.Errorf("duplicate UUID in 100 iterations: %s", id)
+		}
+		seen[id] = true
+	}
+}
+
+func TestIsValidRequestID(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"valid uuid", "550e8400-e29b-41d4-a716-446655440000", true},
+		{"valid short", "abc123", true},
+		{"empty", "", false},
+		{"too long", string(make([]byte, 129)), false},
+		{"has space", "abc 123", false},
+		{"has tab", "abc\t123", false},
+		{"has newline", "abc\n123", false},
+		{"has null", "abc\x00def", false},
+		{"non-ascii", "café", false},
+		{"printable symbols", "req-123_456.test", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidRequestID(tt.input); got != tt.want {
+				t.Errorf("isValidRequestID(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func newRequestIDTestServer(t *testing.T) *Server {
+	t.Helper()
+	cfg := defaultTestConfig()
+	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	s.RegisterRoutes(testRouteOptions())
+	return s
+}
+
+func TestRequestIDMiddleware_GeneratesNew(t *testing.T) {
+	s := newRequestIDTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	id := rec.Header().Get(requestIDHeader)
+	if id == "" {
+		t.Fatal("expected X-Request-Id response header, got empty")
+	}
+	if !uuidV4Re.MatchString(id) {
+		t.Errorf("generated ID %q does not match UUID v4 pattern", id)
+	}
+}
+
+func TestRequestIDMiddleware_PropagatesValid(t *testing.T) {
+	s := newRequestIDTestServer(t)
+
+	incoming := "trace-abc-123"
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req.Header.Set(requestIDHeader, incoming)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get(requestIDHeader); got != incoming {
+		t.Errorf("X-Request-Id = %q, want %q", got, incoming)
+	}
+}
+
+func TestRequestIDMiddleware_RejectsInvalid(t *testing.T) {
+	s := newRequestIDTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req.Header.Set(requestIDHeader, "bad\nheader")
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	id := rec.Header().Get(requestIDHeader)
+	if id == "bad\nheader" {
+		t.Error("invalid request ID should not be propagated")
+	}
+	if !uuidV4Re.MatchString(id) {
+		t.Errorf("expected new UUID for invalid input, got %q", id)
+	}
+}
+
+func TestRequestIDMiddleware_InContext(t *testing.T) {
+	cfg := defaultTestConfig()
+	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	var ctxID string
+	opts := testRouteOptions()
+	opts.ListHandler = func(w http.ResponseWriter, r *http.Request) {
+		ctxID = RequestIDFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}
+	s.RegisterRoutes(opts)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	headerID := rec.Header().Get(requestIDHeader)
+	if ctxID == "" {
+		t.Fatal("request ID not found in context")
+	}
+	if ctxID != headerID {
+		t.Errorf("context ID %q != header ID %q", ctxID, headerID)
+	}
+}
+
+func TestRequestIDFromContext_EmptyContext(t *testing.T) {
+	if got := RequestIDFromContext(httptest.NewRequest(http.MethodGet, "/", nil).Context()); got != "" {
+		t.Errorf("RequestIDFromContext on empty context = %q, want empty", got)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,6 +27,7 @@ type Server struct {
 	ready      atomic.Bool
 	readyCh    chan struct{}
 	readyOnce  sync.Once
+	ipResolver *ClientIPResolver
 }
 
 // New creates a new BlogFlow server.
@@ -36,11 +37,19 @@ func New(cfg *config.Config, logger *slog.Logger) *Server {
 	}
 
 	mux := http.NewServeMux()
+
+	ipResolver, err := NewClientIPResolver(cfg.Server.TrustedProxyCIDRs)
+	if err != nil {
+		logger.Error("invalid trusted proxy CIDR", "error", err)
+		panic(fmt.Sprintf("server: invalid trusted proxy CIDR: %v", err))
+	}
+
 	s := &Server{
-		mux:     mux,
-		config:  cfg,
-		logger:  logger,
-		readyCh: make(chan struct{}),
+		mux:        mux,
+		config:     cfg,
+		logger:     logger,
+		readyCh:    make(chan struct{}),
+		ipResolver: ipResolver,
 	}
 
 	s.httpServer = &http.Server{
@@ -170,13 +179,15 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	return s.httpServer.Shutdown(ctx)
 }
 
-// middleware chains standard middleware: logging, security headers, recovery, metrics.
+// middleware chains standard middleware: request-ID, logging, security headers, recovery, metrics.
 func (s *Server) middleware(next http.Handler) http.Handler {
-	// Order: logging (outermost) → recovery → security headers → metrics → handler
-	return s.loggingMiddleware(
-		s.recoveryMiddleware(
-			s.securityHeadersMiddleware(
-				MetricsMiddleware(next),
+	// Order: request-ID (outermost) → logging → recovery → security headers → metrics → handler
+	return s.requestIDMiddleware(
+		s.loggingMiddleware(
+			s.recoveryMiddleware(
+				s.securityHeadersMiddleware(
+					MetricsMiddleware(next),
+				),
 			),
 		),
 	)
@@ -193,6 +204,8 @@ func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
 			"status", wrapped.statusCode,
 			"duration", time.Since(start),
 			"remote", r.RemoteAddr,
+			"client_ip", s.ipResolver.ClientIP(r),
+			"request_id", RequestIDFromContext(r.Context()),
 		)
 	})
 }


### PR DESCRIPTION
## Summary

Adds two new middleware components and a client IP resolver:

### Request-ID Middleware (`requestid.go`)
- Generates UUID v4 request IDs using `crypto/rand` (no external deps)
- Propagates incoming `X-Request-Id` header if valid (1–128 printable ASCII)
- Sets `X-Request-Id` response header and stores ID in request context
- Enables log correlation across distributed services

### Proxy-Aware Client IP (`clientip.go`)
- Configurable trusted proxy CIDRs via `server.trusted_proxy_cidrs`
- Parses `X-Forwarded-For` (right-to-left, skipping trusted proxies) and `X-Real-IP`
- Only trusts forwarded headers when `RemoteAddr` is from a trusted CIDR
- When no trusted proxies configured, always uses `RemoteAddr`

### Logging
- Request logs now include `request_id` and `client_ip` fields

### Tests
- UUID v4 format and uniqueness validation
- Valid/invalid request ID propagation
- Context storage and retrieval
- Trusted/untrusted proxy scenarios, IPv6, multi-hop XFF chains

Fixes #23
Fixes #28