### PR TITLE
feat: implement git-sync sidecar strategy

### DIFF
--- a/internal/gitops/sidecar.go
+++ b/internal/gitops/sidecar.go
@@ -2,33 +2,164 @@ package gitops
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
 )
 
+const defaultSidecarDir = "/data/content"
+
 // SidecarStrategy watches for git-sync sidecar symlink swaps.
+// git-sync atomically swaps a symlink in a shared volume; this strategy
+// detects those swaps via fsnotify and triggers a content reload.
 type SidecarStrategy struct {
 	reloader ContentReloader
 	logger   *slog.Logger
+	dir      string
+	debounce time.Duration
+	watcher  *fsnotify.Watcher
+	mu       sync.Mutex
+	started  bool
+	stopOnce sync.Once
+	done     chan struct{}
 }
 
 // NewSidecarStrategy creates a new sidecar-based sync strategy.
+// The watched directory defaults to /data/content; call SetDir to override.
 func NewSidecarStrategy(reloader ContentReloader, logger *slog.Logger) *SidecarStrategy {
-	return &SidecarStrategy{reloader: reloader, logger: logger}
+	return &SidecarStrategy{
+		reloader: reloader,
+		logger:   logger,
+		dir:      defaultSidecarDir,
+		debounce: 500 * time.Millisecond,
+		done:     make(chan struct{}),
+	}
 }
+
+// SetDir configures the directory to watch for symlink swaps.
+// Must be called before Start.
+func (w *SidecarStrategy) SetDir(dir string) { w.dir = dir }
 
 // Start begins watching for sidecar symlink swaps.
 // It returns promptly; background work runs in a separate goroutine.
-// TODO: symlink detection
 func (w *SidecarStrategy) Start(ctx context.Context) error {
-	w.logger.Warn("sidecar strategy started (stub)")
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.started {
+		return nil
+	}
+
+	if w.dir == "" {
+		return fmt.Errorf("gitops: sidecar strategy has no directory configured — call SetDir before Start")
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("gitops: create sidecar watcher: %w", err)
+	}
+
+	if err := watcher.Add(w.dir); err != nil {
+		_ = watcher.Close()
+		return fmt.Errorf("gitops: sidecar watch %q: %w", w.dir, err)
+	}
+
+	w.watcher = watcher
+	w.started = true
+	w.logger.Info("sidecar strategy started", "dir", w.dir)
+	go w.loop(ctx)
 	return nil
 }
 
 // Stop gracefully shuts down the sidecar watcher.
 func (w *SidecarStrategy) Stop(ctx context.Context) error {
-	w.logger.Info("sidecar strategy stopped")
-	return nil
+	w.mu.Lock()
+	watcher := w.watcher
+	w.mu.Unlock()
+
+	var stopErr error
+	w.stopOnce.Do(func() {
+		if watcher == nil {
+			return
+		}
+		if err := watcher.Close(); err != nil {
+			stopErr = fmt.Errorf("gitops: close sidecar watcher: %w", err)
+		}
+		select {
+		case <-w.done:
+		case <-ctx.Done():
+			stopErr = ctx.Err()
+		}
+		w.logger.Info("sidecar strategy stopped")
+	})
+	return stopErr
 }
 
 // Name returns the strategy name.
 func (w *SidecarStrategy) Name() string { return "sidecar" }
+
+// isSymlinkEvent returns true for events that signal an atomic symlink swap.
+func isSymlinkEvent(op fsnotify.Op) bool {
+	return op&(fsnotify.Create|fsnotify.Remove|fsnotify.Rename) != 0
+}
+
+func (w *SidecarStrategy) loop(ctx context.Context) {
+	defer close(w.done)
+
+	var (
+		timer  *time.Timer
+		timerC <-chan time.Time
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			if timer != nil {
+				timer.Stop()
+			}
+			_ = w.watcher.Close()
+			return
+
+		case event, ok := <-w.watcher.Events:
+			if !ok {
+				return
+			}
+
+			if !isSymlinkEvent(event.Op) {
+				continue
+			}
+
+			w.logger.Debug("symlink event detected", "op", event.Op, "path", event.Name)
+
+			if timer == nil {
+				timer = time.NewTimer(w.debounce)
+				timerC = timer.C
+			} else {
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(w.debounce)
+			}
+
+		case err, ok := <-w.watcher.Errors:
+			if !ok {
+				return
+			}
+			w.logger.Error("sidecar watcher error", "err", err)
+
+		case <-timerC:
+			w.logger.Info("symlink swap detected, reloading content")
+			if err := w.reloader(); err != nil {
+				w.logger.Error("content reload failed", "err", err)
+			}
+			timer = nil
+			timerC = nil
+		}
+	}
+}

--- a/internal/gitops/sidecar.go
+++ b/internal/gitops/sidecar.go
@@ -80,11 +80,12 @@ func (w *SidecarStrategy) Stop(ctx context.Context) error {
 	watcher := w.watcher
 	w.mu.Unlock()
 
+	if watcher == nil {
+		return nil
+	}
+
 	var stopErr error
 	w.stopOnce.Do(func() {
-		if watcher == nil {
-			return
-		}
 		if err := watcher.Close(); err != nil {
 			stopErr = fmt.Errorf("gitops: close sidecar watcher: %w", err)
 		}
@@ -120,7 +121,6 @@ func (w *SidecarStrategy) loop(ctx context.Context) {
 			if timer != nil {
 				timer.Stop()
 			}
-			_ = w.watcher.Close()
 			return
 
 		case event, ok := <-w.watcher.Events:

--- a/internal/gitops/sidecar_test.go
+++ b/internal/gitops/sidecar_test.go
@@ -1,0 +1,200 @@
+package gitops
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func sidecarTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestSidecarStrategy_SymlinkSwapTriggersReload(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Create initial symlink target and symlink.
+	target1 := filepath.Join(dir, "repo-v1")
+	if err := os.Mkdir(target1, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "current")
+	if err := os.Symlink(target1, link); err != nil {
+		t.Fatal(err)
+	}
+
+	var called atomic.Int32
+	reloader := ContentReloader(func() error {
+		called.Add(1)
+		return nil
+	})
+
+	s := NewSidecarStrategy(reloader, sidecarTestLogger())
+	s.SetDir(dir)
+	s.debounce = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := s.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = s.Stop(context.Background()) }()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Simulate atomic symlink swap (remove old, create new).
+	target2 := filepath.Join(dir, "repo-v2")
+	if err := os.Mkdir(target2, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	newLink := filepath.Join(dir, "current.tmp")
+	if err := os.Symlink(target2, newLink); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(newLink, link); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+
+	if got := called.Load(); got < 1 {
+		t.Errorf("reloader called %d times, want >= 1", got)
+	}
+}
+
+func TestSidecarStrategy_Debounce(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	var called atomic.Int32
+	reloader := ContentReloader(func() error {
+		called.Add(1)
+		return nil
+	})
+
+	s := NewSidecarStrategy(reloader, sidecarTestLogger())
+	s.SetDir(dir)
+	s.debounce = 200 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := s.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = s.Stop(context.Background()) }()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Rapid symlink-like events: create and remove files quickly.
+	for i := 0; i < 5; i++ {
+		name := filepath.Join(dir, fmt.Sprintf("current-%d", i))
+		if err := os.WriteFile(name, []byte("v"), 0o644); err != nil { //nolint:gosec // G306: test files
+			t.Fatal(err)
+		}
+		_ = os.Remove(name)
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Wait for debounce + buffer.
+	time.Sleep(500 * time.Millisecond)
+
+	if got := called.Load(); got != 1 {
+		t.Errorf("reloader called %d times, want 1", got)
+	}
+}
+
+func TestSidecarStrategy_ContextCancel(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	s := NewSidecarStrategy(func() error { return nil }, sidecarTestLogger())
+	s.SetDir(dir)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if err := s.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	cancel()
+
+	select {
+	case <-s.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit after context cancel")
+	}
+
+	// Stop should be safe even after context cancel.
+	if err := s.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSidecarStrategy_StopIdempotent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	s := NewSidecarStrategy(func() error { return nil }, sidecarTestLogger())
+	s.SetDir(dir)
+
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// First stop.
+	if err := s.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-s.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit within 2 seconds")
+	}
+
+	// Second stop should not error.
+	if err := s.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSidecarStrategy_StopBeforeStart(t *testing.T) {
+	t.Parallel()
+
+	s := NewSidecarStrategy(func() error { return nil }, sidecarTestLogger())
+
+	// Stop without Start should be safe.
+	if err := s.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSidecarStrategy_Name(t *testing.T) {
+	t.Parallel()
+
+	s := NewSidecarStrategy(func() error { return nil }, sidecarTestLogger())
+	if got := s.Name(); got != "sidecar" {
+		t.Errorf("Name() = %q, want %q", got, "sidecar")
+	}
+}
+
+func TestSidecarStrategy_StartErrorNoDir(t *testing.T) {
+	t.Parallel()
+
+	s := NewSidecarStrategy(func() error { return nil }, sidecarTestLogger())
+	s.SetDir("")
+
+	err := s.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected error when starting with empty dir")
+	}
+}

--- a/internal/gitops/sync_test.go
+++ b/internal/gitops/sync_test.go
@@ -173,6 +173,9 @@ func TestStrategy_StartStop(t *testing.T) {
 			if ws, ok := s.(*gitops.WatchStrategy); ok {
 				ws.SetDirs(t.TempDir())
 			}
+			if ss, ok := s.(*gitops.SidecarStrategy); ok {
+				ss.SetDir(t.TempDir())
+			}
 
 			if err := s.Start(ctx); err != nil {
 				t.Errorf("%s.Start() error: %v", tc.name, err)
@@ -209,6 +212,9 @@ func TestStrategy_DoubleStop(t *testing.T) {
 
 			if ws, ok := s.(*gitops.WatchStrategy); ok {
 				ws.SetDirs(t.TempDir())
+			}
+			if ss, ok := s.(*gitops.SidecarStrategy); ok {
+				ss.SetDir(t.TempDir())
 			}
 
 			if err := s.Start(ctx); err != nil {


### PR DESCRIPTION
Replaces the stub `SidecarStrategy` with a working fsnotify-based implementation that detects atomic symlink swaps used by git-sync sidecar containers in Kubernetes.

## Changes
- **`internal/gitops/sidecar.go`**: Full implementation with fsnotify watcher, 500ms debounce, context cancellation, and structured logging
- **`internal/gitops/sidecar_test.go`**: Tests for symlink swap detection, debouncing, context cancellation, idempotent Stop(), and edge cases
- **`internal/gitops/sync_test.go`**: Updated integration tests to set sidecar dir for StartStop/DoubleStop tests

## How it works
1. Watches configured directory (default `/data/content`) for `Create`, `Remove`, and `Rename` events
2. Debounces rapid events within a 500ms window to avoid reload storms
3. Calls the `ContentReloader` callback when a symlink swap is detected
4. Respects context cancellation and supports clean shutdown

Fixes #53