### PR TITLE
feat: add HTTP caching headers to feed and sitemap

### DIFF
--- a/internal/server/handlers/cache.go
+++ b/internal/server/handlers/cache.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -37,14 +38,16 @@ func writeXMLCached(w http.ResponseWriter, r *http.Request, contentType string, 
 		w.Header().Set("Last-Modified", lastMod.UTC().Format(http.TimeFormat))
 	}
 
-	// Conditional: If-None-Match
-	if match := r.Header.Get("If-None-Match"); match == etag {
-		w.WriteHeader(http.StatusNotModified)
-		return
-	}
-
-	// Conditional: If-Modified-Since
-	if !lastMod.IsZero() {
+	// Conditional: If-None-Match takes precedence (RFC 7232 §3.2).
+	// When present, If-Modified-Since MUST be ignored (RFC 7232 §3.3).
+	if inm := r.Header.Get("If-None-Match"); inm != "" {
+		if etagMatches(inm, etag) {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		// ETag did not match — serve fresh response; skip If-Modified-Since.
+	} else if !lastMod.IsZero() {
+		// Conditional: If-Modified-Since (only when If-None-Match is absent).
 		if ims := r.Header.Get("If-Modified-Since"); ims != "" {
 			if t, err := http.ParseTime(ims); err == nil {
 				if !lastMod.UTC().Truncate(time.Second).After(t.UTC()) {
@@ -56,4 +59,22 @@ func writeXMLCached(w http.ResponseWriter, r *http.Request, contentType string, 
 	}
 
 	_, _ = w.Write(body)
+}
+
+// etagMatches reports whether the If-None-Match header value matches the
+// given ETag. It handles the wildcard "*" and comma-separated lists of ETags
+// per RFC 7232 §3.2.
+func etagMatches(inmHeader, etag string) bool {
+	if strings.TrimSpace(inmHeader) == "*" {
+		return true
+	}
+	for _, field := range strings.Split(inmHeader, ",") {
+		field = strings.TrimSpace(field)
+		// Strip weak prefix for comparison (RFC 7232 §2.3.2 weak comparison).
+		field = strings.TrimPrefix(field, "W/")
+		if field == etag {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/server/handlers/cache.go
+++ b/internal/server/handlers/cache.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/xml"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// writeXMLCached serialises v as XML and writes it to w with HTTP caching
+// headers (Cache-Control, ETag, Last-Modified). It handles conditional
+// requests (If-None-Match, If-Modified-Since) by returning 304 Not Modified
+// when appropriate.
+func writeXMLCached(w http.ResponseWriter, r *http.Request, contentType string, v any, lastMod time.Time) {
+	var buf bytes.Buffer
+	buf.WriteString(xml.Header)
+	enc := xml.NewEncoder(&buf)
+	enc.Indent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		slog.Error("XML encode failed", "error", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	body := buf.Bytes()
+
+	hash := sha256.Sum256(body)
+	etag := fmt.Sprintf(`"%x"`, hash[:8])
+
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	w.Header().Set("ETag", etag)
+	if !lastMod.IsZero() {
+		w.Header().Set("Last-Modified", lastMod.UTC().Format(http.TimeFormat))
+	}
+
+	// Conditional: If-None-Match
+	if match := r.Header.Get("If-None-Match"); match == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+
+	// Conditional: If-Modified-Since
+	if !lastMod.IsZero() {
+		if ims := r.Header.Get("If-Modified-Since"); ims != "" {
+			if t, err := http.ParseTime(ims); err == nil {
+				if !lastMod.UTC().Truncate(time.Second).After(t.UTC()) {
+					w.WriteHeader(http.StatusNotModified)
+					return
+				}
+			}
+		}
+	}
+
+	_, _ = w.Write(body)
+}

--- a/internal/server/handlers/cache_test.go
+++ b/internal/server/handlers/cache_test.go
@@ -1,0 +1,170 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/khaines/blogflow/internal/server/handlers"
+)
+
+// --------------- Feed caching tests ---------------
+
+func TestFeedHandler_CacheHeaders(t *testing.T) {
+	cfg := testConfig()
+	idx := testIndex(3)
+	h := handlers.NewFeedHandler(cfg, idx)
+
+	req := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "public, max-age=3600" {
+		t.Errorf("Cache-Control = %q, want %q", cc, "public, max-age=3600")
+	}
+	if etag := rec.Header().Get("ETag"); etag == "" {
+		t.Error("ETag header missing")
+	}
+	if lm := rec.Header().Get("Last-Modified"); lm == "" {
+		t.Error("Last-Modified header missing")
+	} else if _, err := http.ParseTime(lm); err != nil {
+		t.Errorf("Last-Modified is not a valid HTTP date: %q", lm)
+	}
+}
+
+func TestFeedHandler_ETag304(t *testing.T) {
+	cfg := testConfig()
+	idx := testIndex(3)
+	h := handlers.NewFeedHandler(cfg, idx)
+
+	// First request to obtain ETag.
+	req1 := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, req1)
+
+	etag := rec1.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("ETag header missing from initial response")
+	}
+
+	// Conditional request with If-None-Match.
+	req2 := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
+	req2.Header.Set("If-None-Match", etag)
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusNotModified {
+		t.Fatalf("expected 304, got %d", rec2.Code)
+	}
+	if rec2.Body.Len() != 0 {
+		t.Error("expected empty body on 304")
+	}
+}
+
+func TestFeedHandler_IfModifiedSince304(t *testing.T) {
+	cfg := testConfig()
+	idx := testIndex(3)
+	h := handlers.NewFeedHandler(cfg, idx)
+
+	// Newest post date is 2025-01-15 12:00:00 UTC (from testIndex).
+	future := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	req := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
+	req.Header.Set("If-Modified-Since", future.UTC().Format(http.TimeFormat))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotModified {
+		t.Fatalf("expected 304, got %d", rec.Code)
+	}
+}
+
+func TestFeedHandler_IfModifiedSince200WhenNewer(t *testing.T) {
+	cfg := testConfig()
+	idx := testIndex(3)
+	h := handlers.NewFeedHandler(cfg, idx)
+
+	// Date well before the newest post.
+	old := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	req := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
+	req.Header.Set("If-Modified-Since", old.UTC().Format(http.TimeFormat))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+// --------------- Sitemap caching tests ---------------
+
+func TestSitemapHandler_CacheHeaders(t *testing.T) {
+	cfg := testConfig()
+	idx := testIndex(2)
+	h := handlers.NewSitemapHandler(cfg, idx)
+
+	req := httptest.NewRequest(http.MethodGet, "/sitemap.xml", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "public, max-age=3600" {
+		t.Errorf("Cache-Control = %q, want %q", cc, "public, max-age=3600")
+	}
+	if etag := rec.Header().Get("ETag"); etag == "" {
+		t.Error("ETag header missing")
+	}
+	if lm := rec.Header().Get("Last-Modified"); lm == "" {
+		t.Error("Last-Modified header missing")
+	}
+}
+
+func TestSitemapHandler_ETag304(t *testing.T) {
+	cfg := testConfig()
+	idx := testIndex(2)
+	h := handlers.NewSitemapHandler(cfg, idx)
+
+	// First request to obtain ETag.
+	req1 := httptest.NewRequest(http.MethodGet, "/sitemap.xml", nil)
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, req1)
+
+	etag := rec1.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("ETag header missing from initial response")
+	}
+
+	// Conditional request.
+	req2 := httptest.NewRequest(http.MethodGet, "/sitemap.xml", nil)
+	req2.Header.Set("If-None-Match", etag)
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusNotModified {
+		t.Fatalf("expected 304, got %d", rec2.Code)
+	}
+}
+
+func TestSitemapHandler_IfModifiedSince304(t *testing.T) {
+	cfg := testConfig()
+	idx := testIndex(2)
+	h := handlers.NewSitemapHandler(cfg, idx)
+
+	future := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	req := httptest.NewRequest(http.MethodGet, "/sitemap.xml", nil)
+	req.Header.Set("If-Modified-Since", future.UTC().Format(http.TimeFormat))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotModified {
+		t.Fatalf("expected 304, got %d", rec.Code)
+	}
+}

--- a/internal/server/handlers/cache_test.go
+++ b/internal/server/handlers/cache_test.go
@@ -168,3 +168,63 @@ func TestSitemapHandler_IfModifiedSince304(t *testing.T) {
 		t.Fatalf("expected 304, got %d", rec.Code)
 	}
 }
+
+// --------------- RFC 7232 compliance tests ---------------
+
+func TestFeedHandler_IfNoneMatchMultiValue(t *testing.T) {
+	cfg := testConfig()
+	idx := testIndex(3)
+	h := handlers.NewFeedHandler(cfg, idx)
+
+	// Get the real ETag.
+	req1 := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, req1)
+	etag := rec1.Header().Get("ETag")
+
+	// Send multi-value If-None-Match containing the real ETag.
+	req2 := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
+	req2.Header.Set("If-None-Match", `"bogus", `+etag+`, "other"`)
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusNotModified {
+		t.Fatalf("expected 304 for multi-value If-None-Match, got %d", rec2.Code)
+	}
+}
+
+func TestFeedHandler_IfNoneMatchWildcard(t *testing.T) {
+	cfg := testConfig()
+	idx := testIndex(3)
+	h := handlers.NewFeedHandler(cfg, idx)
+
+	req := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
+	req.Header.Set("If-None-Match", "*")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotModified {
+		t.Fatalf("expected 304 for wildcard If-None-Match, got %d", rec.Code)
+	}
+}
+
+func TestFeedHandler_IfNoneMatchMiss_IgnoresIfModifiedSince(t *testing.T) {
+	cfg := testConfig()
+	idx := testIndex(3)
+	h := handlers.NewFeedHandler(cfg, idx)
+
+	// Send mismatched ETag AND a future If-Modified-Since.
+	// Per RFC 7232 §3.3, If-Modified-Since MUST be ignored when
+	// If-None-Match is present. So the response MUST be 200.
+	future := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	req := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
+	req.Header.Set("If-None-Match", `"wrong-etag"`)
+	req.Header.Set("If-Modified-Since", future.UTC().Format(http.TimeFormat))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 (ETag miss ignores IMS), got %d", rec.Code)
+	}
+}

--- a/internal/server/handlers/feed.go
+++ b/internal/server/handlers/feed.go
@@ -2,10 +2,8 @@
 package handlers
 
 import (
-	"bytes"
 	"encoding/xml"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"time"
 
@@ -92,10 +90,10 @@ func (h *FeedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	posts := h.limitedPosts()
 
 	if h.cfg.Feed.Type == "rss" {
-		h.serveRSS(w, posts)
+		h.serveRSS(w, r, posts)
 		return
 	}
-	h.serveAtom(w, posts)
+	h.serveAtom(w, r, posts)
 }
 
 func (h *FeedHandler) limitedPosts() []*content.Post {
@@ -110,12 +108,14 @@ func (h *FeedHandler) limitedPosts() []*content.Post {
 	return posts
 }
 
-func (h *FeedHandler) serveAtom(w http.ResponseWriter, posts []*content.Post) {
+func (h *FeedHandler) serveAtom(w http.ResponseWriter, r *http.Request, posts []*content.Post) {
 	baseURL := h.cfg.Site.BaseURL
 
+	var lastMod time.Time
 	updated := time.Now().UTC().Format(time.RFC3339)
 	if len(posts) > 0 {
-		updated = posts[0].Date.UTC().Format(time.RFC3339)
+		lastMod = posts[0].Date.UTC()
+		updated = lastMod.Format(time.RFC3339)
 	}
 
 	entries := make([]AtomEntry, 0, len(posts))
@@ -148,15 +148,17 @@ func (h *FeedHandler) serveAtom(w http.ResponseWriter, posts []*content.Post) {
 		Entries: entries,
 	}
 
-	writeXML(w, "application/atom+xml; charset=utf-8", feed)
+	writeXMLCached(w, r, "application/atom+xml; charset=utf-8", feed, lastMod)
 }
 
-func (h *FeedHandler) serveRSS(w http.ResponseWriter, posts []*content.Post) {
+func (h *FeedHandler) serveRSS(w http.ResponseWriter, r *http.Request, posts []*content.Post) {
 	baseURL := h.cfg.Site.BaseURL
 
+	var lastMod time.Time
 	var pubDate string
 	if len(posts) > 0 {
-		pubDate = posts[0].Date.UTC().Format(time.RFC1123Z)
+		lastMod = posts[0].Date.UTC()
+		pubDate = lastMod.Format(time.RFC1123Z)
 	}
 
 	items := make([]RSSItem, 0, len(posts))
@@ -182,19 +184,5 @@ func (h *FeedHandler) serveRSS(w http.ResponseWriter, posts []*content.Post) {
 		},
 	}
 
-	writeXML(w, "application/rss+xml; charset=utf-8", feed)
-}
-
-func writeXML(w http.ResponseWriter, contentType string, v any) {
-	var buf bytes.Buffer
-	buf.WriteString(xml.Header)
-	enc := xml.NewEncoder(&buf)
-	enc.Indent("", "  ")
-	if err := enc.Encode(v); err != nil {
-		slog.Error("XML encode failed", "error", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-	w.Header().Set("Content-Type", contentType)
-	_, _ = w.Write(buf.Bytes())
+	writeXMLCached(w, r, "application/rss+xml; charset=utf-8", feed, lastMod)
 }

--- a/internal/server/handlers/sitemap.go
+++ b/internal/server/handlers/sitemap.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/khaines/blogflow/internal/config"
 	"github.com/khaines/blogflow/internal/content"
@@ -38,7 +39,7 @@ func NewSitemapHandler(cfg *config.Config, index *content.Index) *SitemapHandler
 	return &SitemapHandler{cfg: cfg, index: index}
 }
 
-func (h *SitemapHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+func (h *SitemapHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	baseURL := h.cfg.Site.BaseURL
 
 	// Derive homepage lastmod from the most recent post.
@@ -83,5 +84,17 @@ func (h *SitemapHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 		URLs:  urls,
 	}
 
-	writeXML(w, "application/xml; charset=utf-8", sitemap)
+	var lastMod time.Time
+	for _, p := range h.index.Posts {
+		if p.Date.After(lastMod) {
+			lastMod = p.Date
+		}
+	}
+	for _, p := range h.index.Pages {
+		if p.Date.After(lastMod) {
+			lastMod = p.Date
+		}
+	}
+
+	writeXMLCached(w, r, "application/xml; charset=utf-8", sitemap, lastMod.UTC())
 }


### PR DESCRIPTION
Adds Cache-Control, ETag, and Last-Modified headers to feed and sitemap responses.

Supports conditional requests (If-None-Match, If-Modified-Since) for efficient polling by feed aggregators.

### Changes
- **`cache.go`**: New `writeXMLCached` helper that serialises XML with caching headers and conditional 304 responses
- **`feed.go`**: Feed handlers now use `writeXMLCached` with `Last-Modified` derived from newest post date
- **`sitemap.go`**: Sitemap handler uses `writeXMLCached` with `Last-Modified` from newest post/page date
- **`cache_test.go`**: Tests for Cache-Control, ETag 304, and If-Modified-Since 304 on both feed and sitemap

Fixes #32