### PR TITLE
feat: add K8s example manifests for sidecar and webhook

### DIFF
--- a/examples/k8s/README.md
+++ b/examples/k8s/README.md
@@ -37,7 +37,9 @@ kubectl apply -k examples/k8s/webhook/
 
 1. Search each manifest for `CHANGE-ME` and replace with your values.
 2. Adjust resource requests/limits to match your traffic profile.
-3. Pin the BlogFlow image tag to a specific version instead of `latest`.
+3. Pin the BlogFlow image to a specific semver version (already set to `0.1.0`).
+   For production, pin by SHA256 digest instead of a tag (see
+   `docs/engineering/container-security.md`).
 4. For production, pin the git-sync image by digest (see comments in the
    sidecar deployment).
 

--- a/examples/k8s/README.md
+++ b/examples/k8s/README.md
@@ -1,0 +1,47 @@
+# BlogFlow Kubernetes Examples
+
+Plain YAML manifests for deploying BlogFlow on Kubernetes without Helm.
+Two deployment patterns are provided — pick the one that matches your content
+workflow.
+
+## Patterns
+
+### Sidecar (`sidecar/`)
+
+A git-sync sidecar container polls your content repository on a fixed interval
+(default 60 s) and writes updates to a shared volume. BlogFlow watches the
+volume for changes and re-renders automatically.
+
+**Best for:** simple setups, private clusters, or environments without an
+ingress controller.
+
+### Webhook (`webhook/`)
+
+BlogFlow exposes a webhook endpoint (`/api/webhook`) that receives push events
+from GitHub (or any Git host). On each event it pulls the latest content and
+re-renders.
+
+**Best for:** public-facing sites where you want instant updates on push.
+
+## Quick start
+
+```bash
+# Sidecar pattern
+kubectl apply -k examples/k8s/sidecar/
+
+# Webhook pattern
+kubectl apply -k examples/k8s/webhook/
+```
+
+## Customisation
+
+1. Search each manifest for `CHANGE-ME` and replace with your values.
+2. Adjust resource requests/limits to match your traffic profile.
+3. Pin the BlogFlow image tag to a specific version instead of `latest`.
+4. For production, pin the git-sync image by digest (see comments in the
+   sidecar deployment).
+
+All manifests follow the security baseline from
+[docs/engineering/container-security.md](../../docs/engineering/container-security.md):
+non-root user (UID 65532), read-only root filesystem, all capabilities dropped,
+seccomp RuntimeDefault profile.

--- a/examples/k8s/sidecar/configmap.yaml
+++ b/examples/k8s/sidecar/configmap.yaml
@@ -1,0 +1,57 @@
+# BlogFlow configuration — sidecar strategy.
+# Replace every CHANGE-ME value with your own settings.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blogflow-config
+  namespace: blogflow
+  labels:
+    app.kubernetes.io/name: blogflow
+data:
+  site.yaml: |
+    # Site identity
+    site:
+      title: "CHANGE-ME"
+      description: "CHANGE-ME"
+      base_url: "https://CHANGE-ME.example.com"
+      language: en
+      author:
+        name: "CHANGE-ME"
+        email: "CHANGE-ME@example.com"
+
+    # Content directories (relative to /data/content)
+    content:
+      posts_dir: posts
+      pages_dir: pages
+      media_dir: media
+      posts_per_page: 10
+      date_format: "January 2, 2006"
+      summary_length: 200
+
+    # Theme
+    theme:
+      name: default
+      path: /data/theme
+
+    # HTTP server
+    server:
+      port: 8080
+      read_timeout: 5s
+      write_timeout: 10s
+      idle_timeout: 120s
+
+    # Rendered page cache
+    cache:
+      enabled: true
+      ttl: 1h
+      max_entries: 1000
+
+    # Sync — sidecar pattern (git-sync writes, BlogFlow watches)
+    sync:
+      strategy: watch
+
+    # RSS/Atom feed
+    feed:
+      enabled: true
+      type: atom
+      items: 20

--- a/examples/k8s/sidecar/deployment.yaml
+++ b/examples/k8s/sidecar/deployment.yaml
@@ -1,0 +1,155 @@
+# BlogFlow Deployment — sidecar pattern.
+# A git-sync sidecar pulls content on a fixed interval and writes to a shared
+# volume. BlogFlow watches the volume and re-renders on change.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: blogflow
+  namespace: blogflow
+  labels:
+    app.kubernetes.io/name: blogflow
+    app.kubernetes.io/component: server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: blogflow
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: blogflow
+        app.kubernetes.io/component: server
+    spec:
+      # BlogFlow does not call the Kubernetes API — do not mount a token.
+      automountServiceAccountToken: false
+
+      # Pod-level security context applied to every container.
+      securityContext:
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+
+      containers:
+        # --- BlogFlow application container ---
+        - name: blogflow
+          image: ghcr.io/khaines/blogflow:latest
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+
+          # Container-level security hardening.
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+
+          # Mount the BlogFlow configuration from the ConfigMap.
+          envFrom:
+            - configMapRef:
+                name: blogflow-config-env
+                optional: true
+
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+
+          # Kubernetes restarts the pod if liveness fails.
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+
+          # Traffic is only routed to ready pods.
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+
+          volumeMounts:
+            - name: content
+              mountPath: /data/content
+            - name: theme
+              mountPath: /data/theme
+            - name: config
+              mountPath: /data/config
+              readOnly: true
+            - name: cache
+              mountPath: /data/cache
+            - name: tmp
+              mountPath: /tmp
+
+        # --- git-sync sidecar ---
+        # Pulls content from a Git repo on a fixed interval.
+        # Pin by digest for production: crane digest registry.k8s.io/git-sync/git-sync:v4.4.0
+        - name: git-sync
+          image: registry.k8s.io/git-sync/git-sync:v4.4.0
+          args:
+            - --repo=https://github.com/CHANGE-ME/blog-content.git
+            - --root=/data/content
+            - --period=60s
+
+          env:
+            - name: GITSYNC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: blogflow-secrets
+                  key: BLOGFLOW_GIT_TOKEN
+                  optional: true  # not needed for public repos
+
+          securityContext:
+            runAsUser: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+
+          volumeMounts:
+            - name: content
+              mountPath: /data/content
+            - name: tmp
+              mountPath: /tmp
+
+      volumes:
+        # Shared volume for blog content (written by git-sync, read by blogflow).
+        - name: content
+          emptyDir: {}
+        # Theme files — replace with a PVC or ConfigMap if shipping custom themes.
+        - name: theme
+          emptyDir: {}
+        # BlogFlow site.yaml from the ConfigMap.
+        - name: config
+          configMap:
+            name: blogflow-config
+        # Rendered page cache (ephemeral).
+        - name: cache
+          emptyDir: {}
+        # Scratch space — memory-backed to avoid disk writes.
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Mi

--- a/examples/k8s/sidecar/deployment.yaml
+++ b/examples/k8s/sidecar/deployment.yaml
@@ -35,7 +35,8 @@ spec:
       containers:
         # --- BlogFlow application container ---
         - name: blogflow
-          image: ghcr.io/khaines/blogflow:latest
+          # Pin by digest for production — see docs/engineering/container-security.md
+          image: ghcr.io/khaines/blogflow:0.1.0
           ports:
             - name: http
               containerPort: 8080

--- a/examples/k8s/sidecar/kustomization.yaml
+++ b/examples/k8s/sidecar/kustomization.yaml
@@ -1,0 +1,15 @@
+# Kustomize entrypoint for the sidecar deployment pattern.
+# Usage: kubectl apply -k examples/k8s/sidecar/
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: blogflow
+
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - configmap.yaml
+
+commonLabels:
+  app.kubernetes.io/part-of: blogflow

--- a/examples/k8s/sidecar/namespace.yaml
+++ b/examples/k8s/sidecar/namespace.yaml
@@ -1,0 +1,7 @@
+# Namespace isolates BlogFlow resources from the rest of the cluster.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: blogflow
+  labels:
+    app.kubernetes.io/part-of: blogflow

--- a/examples/k8s/sidecar/service.yaml
+++ b/examples/k8s/sidecar/service.yaml
@@ -1,0 +1,17 @@
+# ClusterIP Service exposes BlogFlow inside the cluster on port 8080.
+apiVersion: v1
+kind: Service
+metadata:
+  name: blogflow
+  namespace: blogflow
+  labels:
+    app.kubernetes.io/name: blogflow
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: blogflow
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP

--- a/examples/k8s/webhook/configmap.yaml
+++ b/examples/k8s/webhook/configmap.yaml
@@ -1,0 +1,63 @@
+# BlogFlow configuration — webhook strategy.
+# Replace every CHANGE-ME value with your own settings.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blogflow-config
+  namespace: blogflow
+  labels:
+    app.kubernetes.io/name: blogflow
+data:
+  site.yaml: |
+    # Site identity
+    site:
+      title: "CHANGE-ME"
+      description: "CHANGE-ME"
+      base_url: "https://CHANGE-ME.example.com"
+      language: en
+      author:
+        name: "CHANGE-ME"
+        email: "CHANGE-ME@example.com"
+
+    # Content directories (relative to /data/content)
+    content:
+      posts_dir: posts
+      pages_dir: pages
+      media_dir: media
+      posts_per_page: 10
+      date_format: "January 2, 2006"
+      summary_length: 200
+
+    # Theme
+    theme:
+      name: default
+      path: /data/theme
+
+    # HTTP server
+    server:
+      port: 8080
+      read_timeout: 5s
+      write_timeout: 10s
+      idle_timeout: 120s
+
+    # Rendered page cache
+    cache:
+      enabled: true
+      ttl: 1h
+      max_entries: 1000
+
+    # Sync — webhook pattern (BlogFlow pulls on push events)
+    sync:
+      strategy: webhook
+      webhook:
+        path: /api/webhook
+        allowed_events:
+          - push
+        branch_filter: main
+        rate_limit: 10
+
+    # RSS/Atom feed
+    feed:
+      enabled: true
+      type: atom
+      items: 20

--- a/examples/k8s/webhook/deployment.yaml
+++ b/examples/k8s/webhook/deployment.yaml
@@ -34,7 +34,8 @@ spec:
 
       containers:
         - name: blogflow
-          image: ghcr.io/khaines/blogflow:latest
+          # Pin by digest for production — see docs/engineering/container-security.md
+          image: ghcr.io/khaines/blogflow:0.1.0
           ports:
             - name: http
               containerPort: 8080

--- a/examples/k8s/webhook/deployment.yaml
+++ b/examples/k8s/webhook/deployment.yaml
@@ -1,0 +1,115 @@
+# BlogFlow Deployment — webhook pattern.
+# BlogFlow receives push events via its /api/webhook endpoint, pulls the latest
+# content, and re-renders. No sidecar is needed.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: blogflow
+  namespace: blogflow
+  labels:
+    app.kubernetes.io/name: blogflow
+    app.kubernetes.io/component: server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: blogflow
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: blogflow
+        app.kubernetes.io/component: server
+    spec:
+      # BlogFlow does not call the Kubernetes API — do not mount a token.
+      automountServiceAccountToken: false
+
+      # Pod-level security context applied to every container.
+      securityContext:
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+
+      containers:
+        - name: blogflow
+          image: ghcr.io/khaines/blogflow:latest
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+
+          # Container-level security hardening.
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+
+          env:
+            # Webhook HMAC secret — injected from the Secret resource.
+            - name: BLOGFLOW_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: blogflow-webhook-secret
+                  key: webhook-secret
+
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+
+          # Kubernetes restarts the pod if liveness fails.
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+
+          # Traffic is only routed to ready pods.
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+
+          volumeMounts:
+            # Content volume is read-write — BlogFlow pulls on webhook trigger.
+            - name: content
+              mountPath: /data/content
+            - name: theme
+              mountPath: /data/theme
+            - name: config
+              mountPath: /data/config
+              readOnly: true
+            - name: cache
+              mountPath: /data/cache
+            - name: tmp
+              mountPath: /tmp
+
+      volumes:
+        # Content volume — read-write so BlogFlow can pull updates itself.
+        - name: content
+          emptyDir: {}
+        # Theme files — replace with a PVC or ConfigMap if shipping custom themes.
+        - name: theme
+          emptyDir: {}
+        # BlogFlow site.yaml from the ConfigMap.
+        - name: config
+          configMap:
+            name: blogflow-config
+        # Rendered page cache (ephemeral).
+        - name: cache
+          emptyDir: {}
+        # Scratch space — memory-backed to avoid disk writes.
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Mi

--- a/examples/k8s/webhook/ingress.yaml
+++ b/examples/k8s/webhook/ingress.yaml
@@ -1,0 +1,41 @@
+# Ingress exposes the webhook endpoint (and optionally the site) externally.
+# Adjust the annotations for your ingress controller (nginx, Traefik, etc.).
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: blogflow
+  namespace: blogflow
+  labels:
+    app.kubernetes.io/name: blogflow
+  annotations:
+    # TLS — uncomment and set the issuer for cert-manager, or use your own certs.
+    # cert-manager.io/cluster-issuer: "CHANGE-ME-issuer"
+    #
+    # nginx-specific — adjust or remove for other controllers.
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  ingressClassName: nginx  # CHANGE-ME if using a different controller
+  tls:
+    - hosts:
+        - CHANGE-ME.example.com
+      secretName: blogflow-tls  # CHANGE-ME — TLS certificate Secret name
+  rules:
+    - host: CHANGE-ME.example.com
+      http:
+        paths:
+          # Webhook endpoint — receives push events from your Git host.
+          - path: /api/webhook
+            pathType: Exact
+            backend:
+              service:
+                name: blogflow
+                port:
+                  name: http
+          # Main site — serves the blog.
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: blogflow
+                port:
+                  name: http

--- a/examples/k8s/webhook/kustomization.yaml
+++ b/examples/k8s/webhook/kustomization.yaml
@@ -1,0 +1,16 @@
+# Kustomize entrypoint for the webhook deployment pattern.
+# Usage: kubectl apply -k examples/k8s/webhook/
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: blogflow
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - secret.yaml
+  - configmap.yaml
+
+commonLabels:
+  app.kubernetes.io/part-of: blogflow

--- a/examples/k8s/webhook/kustomization.yaml
+++ b/examples/k8s/webhook/kustomization.yaml
@@ -6,6 +6,7 @@ kind: Kustomization
 namespace: blogflow
 
 resources:
+  - namespace.yaml
   - deployment.yaml
   - service.yaml
   - ingress.yaml

--- a/examples/k8s/webhook/namespace.yaml
+++ b/examples/k8s/webhook/namespace.yaml
@@ -1,0 +1,7 @@
+# Namespace isolates BlogFlow resources from the rest of the cluster.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: blogflow
+  labels:
+    app.kubernetes.io/part-of: blogflow

--- a/examples/k8s/webhook/secret.yaml
+++ b/examples/k8s/webhook/secret.yaml
@@ -1,0 +1,16 @@
+# Webhook HMAC secret used to verify incoming webhook payloads.
+# Replace the placeholder with a strong random value:
+#   openssl rand -hex 32
+#
+# For production, use a Secret store (e.g., Sealed Secrets, External Secrets
+# Operator, or SOPS) instead of committing the value to version control.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: blogflow-webhook-secret
+  namespace: blogflow
+  labels:
+    app.kubernetes.io/name: blogflow
+type: Opaque
+stringData:
+  webhook-secret: "CHANGE-ME"  # replace with: openssl rand -hex 32

--- a/examples/k8s/webhook/service.yaml
+++ b/examples/k8s/webhook/service.yaml
@@ -1,0 +1,17 @@
+# ClusterIP Service exposes BlogFlow inside the cluster on port 8080.
+apiVersion: v1
+kind: Service
+metadata:
+  name: blogflow
+  namespace: blogflow
+  labels:
+    app.kubernetes.io/name: blogflow
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: blogflow
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP


### PR DESCRIPTION
Plain YAML examples for users who don't use Helm.

## What's included

### `examples/k8s/sidecar/`
- **namespace.yaml** — blogflow namespace
- **deployment.yaml** — BlogFlow + git-sync sidecar, shared volume, full security contexts
- **service.yaml** — ClusterIP on port 8080
- **configmap.yaml** — site.yaml with watch (sidecar) strategy
- **kustomization.yaml** — for kustomize users

### `examples/k8s/webhook/`
- **deployment.yaml** — BlogFlow only, R/W content volume
- **service.yaml** — ClusterIP on port 8080
- **ingress.yaml** — exposes webhook path with TLS annotation placeholders
- **secret.yaml** — webhook HMAC secret (placeholder)
- **configmap.yaml** — site.yaml with webhook strategy
- **kustomization.yaml** — for kustomize users

### Security baseline
All manifests follow `docs/engineering/container-security.md`:
- Non-root user (UID 65532), read-only root filesystem
- All capabilities dropped, seccomp RuntimeDefault
- `automountServiceAccountToken: false`
- Resource requests/limits on every container
- Readiness & liveness probes on `/healthz` and `/readyz`

### Usage
```bash
kubectl apply -k examples/k8s/sidecar/
# or
kubectl apply -k examples/k8s/webhook/
```

Search for `CHANGE-ME` to find all user-specific placeholders.