### PR TITLE
feat: add Helm chart for BlogFlow deployment

### DIFF
--- a/deploy/helm/blogflow/Chart.yaml
+++ b/deploy/helm/blogflow/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: blogflow
+description: A Helm chart for BlogFlow — a Git-powered static blog engine
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - blog
+  - static-site
+  - git-sync
+home: https://github.com/khaines/blogflow
+sources:
+  - https://github.com/khaines/blogflow
+maintainers:
+  - name: khaines

--- a/deploy/helm/blogflow/templates/NOTES.txt
+++ b/deploy/helm/blogflow/templates/NOTES.txt
@@ -1,0 +1,31 @@
+🚀 BlogFlow has been deployed!
+
+Sync strategy: {{ .Values.sync.strategy }}
+
+{{- if eq .Values.sync.strategy "sidecar" }}
+  git-sync sidecar is pulling from: {{ .Values.sync.sidecar.repo }}
+  Branch: {{ .Values.sync.sidecar.branch }}
+  Sync interval: {{ .Values.sync.sidecar.period }}
+{{- else if eq .Values.sync.strategy "webhook" }}
+  Webhook endpoint: {{ .Values.sync.webhook.path }}
+  Ensure your Git provider is configured to send push events to this endpoint.
+{{- else }}
+  Filesystem watch mode — content changes on the mounted volume are detected automatically.
+{{- end }}
+
+Get the application URL:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else if eq .Values.service.type "NodePort" }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "blogflow.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if eq .Values.service.type "LoadBalancer" }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+  kubectl get --namespace {{ .Release.Namespace }} svc {{ include "blogflow.fullname" . }} -w
+{{- else }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "blogflow.fullname" . }} 8080:{{ .Values.service.port }}
+  echo "Visit http://127.0.0.1:8080"
+{{- end }}

--- a/deploy/helm/blogflow/templates/_helpers.tpl
+++ b/deploy/helm/blogflow/templates/_helpers.tpl
@@ -1,0 +1,68 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "blogflow.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "blogflow.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "blogflow.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "blogflow.labels" -}}
+helm.sh/chart: {{ include "blogflow.chart" . }}
+{{ include "blogflow.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "blogflow.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "blogflow.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Container image reference.
+*/}}
+{{- define "blogflow.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- end }}
+
+{{/*
+Webhook secret name — use existing or generated.
+*/}}
+{{- define "blogflow.webhookSecretName" -}}
+{{- if .Values.sync.webhook.existingSecret }}
+{{- .Values.sync.webhook.existingSecret }}
+{{- else }}
+{{- include "blogflow.fullname" . }}-webhook
+{{- end }}
+{{- end }}

--- a/deploy/helm/blogflow/templates/_helpers.tpl
+++ b/deploy/helm/blogflow/templates/_helpers.tpl
@@ -66,3 +66,15 @@ Webhook secret name — use existing or generated.
 {{- include "blogflow.fullname" . }}-webhook
 {{- end }}
 {{- end }}
+
+{{/*
+Validate sync configuration at render time.
+*/}}
+{{- define "blogflow.validateSync" -}}
+{{- if and (eq .Values.sync.strategy "webhook") (not .Values.sync.webhook.existingSecret) (not .Values.sync.webhook.secret) }}
+  {{- fail "sync.strategy is 'webhook' but neither sync.webhook.secret nor sync.webhook.existingSecret is set" }}
+{{- end }}
+{{- if and (eq .Values.sync.strategy "sidecar") (not .Values.sync.sidecar.repo) }}
+  {{- fail "sync.strategy is 'sidecar' but sync.sidecar.repo is not set" }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/blogflow/templates/configmap.yaml
+++ b/deploy/helm/blogflow/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "blogflow.fullname" . }}
+  labels:
+    {{- include "blogflow.labels" . | nindent 4 }}
+data:
+  site.yaml: |
+    {{- .Values.siteConfig | toYaml | nindent 4 }}

--- a/deploy/helm/blogflow/templates/deployment.yaml
+++ b/deploy/helm/blogflow/templates/deployment.yaml
@@ -1,0 +1,142 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "blogflow.fullname" . }}
+  labels:
+    {{- include "blogflow.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "blogflow.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "blogflow.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: blogflow
+          image: {{ include "blogflow.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if or (eq .Values.sync.strategy "webhook") .Values.env }}
+          env:
+            {{- if eq .Values.sync.strategy "webhook" }}
+            - name: BLOGFLOW_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "blogflow.webhookSecretName" . }}
+                  key: BLOGFLOW_WEBHOOK_SECRET
+            {{- end }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: content
+              mountPath: /data/content
+            - name: theme
+              mountPath: /data/theme
+            - name: config
+              mountPath: /data/config
+              readOnly: true
+            - name: cache
+              mountPath: /data/cache
+            - name: tmp
+              mountPath: /tmp
+        {{- if eq .Values.sync.strategy "sidecar" }}
+        - name: git-sync
+          image: "{{ .Values.sync.sidecar.image.repository }}:{{ .Values.sync.sidecar.image.tag }}"
+          imagePullPolicy: {{ .Values.sync.sidecar.image.pullPolicy }}
+          args:
+            - --repo={{ .Values.sync.sidecar.repo }}
+            - --ref={{ .Values.sync.sidecar.branch }}
+            - --root=/data/content
+            - --period={{ .Values.sync.sidecar.period }}
+          securityContext:
+            runAsUser: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            {{- toYaml .Values.sync.sidecar.resources | nindent 12 }}
+          volumeMounts:
+            - name: content
+              mountPath: /data/content
+            - name: tmp
+              mountPath: /tmp
+        {{- end }}
+      volumes:
+        - name: content
+          {{- if eq .Values.sync.strategy "sidecar" }}
+          emptyDir: {}
+          {{- else if and .Values.persistence.content.enabled .Values.persistence.content.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.content.existingClaim }}
+          {{- else if .Values.persistence.content.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "blogflow.fullname" . }}-content
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: theme
+          {{- if and .Values.persistence.theme.enabled .Values.persistence.theme.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.theme.existingClaim }}
+          {{- else if .Values.persistence.theme.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "blogflow.fullname" . }}-theme
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: config
+          configMap:
+            name: {{ include "blogflow.fullname" . }}
+        - name: cache
+          emptyDir: {}
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Mi
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/blogflow/templates/deployment.yaml
+++ b/deploy/helm/blogflow/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "blogflow.validateSync" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -17,7 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "blogflow.labels" . | nindent 8 }}
+        {{- include "blogflow.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deploy/helm/blogflow/templates/ingress.yaml
+++ b/deploy/helm/blogflow/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "blogflow.fullname" . }}
+  labels:
+    {{- include "blogflow.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "blogflow.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/blogflow/templates/secret.yaml
+++ b/deploy/helm/blogflow/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if and (eq .Values.sync.strategy "webhook") (not .Values.sync.webhook.existingSecret) .Values.sync.webhook.secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "blogflow.fullname" . }}-webhook
+  labels:
+    {{- include "blogflow.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  BLOGFLOW_WEBHOOK_SECRET: {{ .Values.sync.webhook.secret | quote }}
+{{- end }}

--- a/deploy/helm/blogflow/templates/service.yaml
+++ b/deploy/helm/blogflow/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "blogflow.fullname" . }}
+  labels:
+    {{- include "blogflow.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "blogflow.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/blogflow/values.yaml
+++ b/deploy/helm/blogflow/values.yaml
@@ -1,0 +1,190 @@
+# -- Number of BlogFlow replicas
+replicaCount: 1
+
+image:
+  # -- BlogFlow container image repository
+  repository: ghcr.io/khaines/blogflow
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+  # -- Overrides the image tag (default is the chart appVersion)
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# -- Content sync strategy: "watch" (filesystem watcher), "sidecar" (git-sync), or "webhook"
+sync:
+  strategy: watch
+
+  # -- git-sync sidecar configuration (used when sync.strategy == sidecar)
+  sidecar:
+    image:
+      repository: registry.k8s.io/git-sync/git-sync
+      tag: v4.4.0
+      pullPolicy: IfNotPresent
+    # -- Git repository URL to sync content from
+    repo: ""
+    # -- Branch to sync
+    branch: main
+    # -- Sync interval
+    period: 60s
+    resources:
+      requests:
+        cpu: 25m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+
+  # -- Webhook configuration (used when sync.strategy == webhook)
+  webhook:
+    # -- Webhook endpoint path
+    path: /api/webhook
+    # -- Name of an existing Secret containing the webhook secret under key BLOGFLOW_WEBHOOK_SECRET
+    existingSecret: ""
+    # -- Webhook secret value (ignored if existingSecret is set; stored in a generated Secret)
+    secret: ""
+    # -- Allowed webhook events
+    allowedEvents:
+      - push
+    # -- Branch filter for webhook events
+    branchFilter: main
+    # -- Maximum webhook requests per second
+    rateLimit: 10
+
+# -- BlogFlow site configuration rendered into a ConfigMap and mounted at /data/config/site.yaml
+siteConfig:
+  site:
+    title: "My Blog"
+    description: "A blog powered by BlogFlow"
+    base_url: "http://localhost:8080"
+    language: en
+    author:
+      name: ""
+      email: ""
+  content:
+    posts_dir: posts
+    pages_dir: pages
+    media_dir: media
+    posts_per_page: 10
+    date_format: "January 2, 2006"
+    summary_length: 200
+  theme:
+    name: default
+  server:
+    port: 8080
+    read_timeout: 5s
+    write_timeout: 10s
+    idle_timeout: 120s
+  cache:
+    enabled: true
+    ttl: 1h
+    max_entries: 1000
+  sync:
+    strategy: watch
+    webhook:
+      path: /api/webhook
+      allowed_events:
+        - push
+      branch_filter: main
+      rate_limit: 10
+  feed:
+    enabled: true
+    type: atom
+    items: 20
+
+service:
+  # -- Kubernetes Service type
+  type: ClusterIP
+  # -- Service port
+  port: 8080
+
+ingress:
+  # -- Enable ingress resource
+  enabled: false
+  # -- Ingress class name
+  className: ""
+  # -- Ingress annotations
+  annotations: {}
+  hosts:
+    - host: blogflow.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi
+
+# -- Pod-level security context
+podSecurityContext:
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Container-level security context
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+# -- Liveness probe configuration
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+# -- Readiness probe configuration
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: http
+  initialDelaySeconds: 3
+  periodSeconds: 5
+
+# -- Additional environment variables for the BlogFlow container
+env: []
+
+# -- Annotations to add to the pod
+podAnnotations: {}
+
+# -- Labels to add to the pod
+podLabels: {}
+
+# -- Node selector constraints
+nodeSelector: {}
+
+# -- Tolerations for pod scheduling
+tolerations: []
+
+# -- Affinity rules for pod scheduling
+affinity: {}
+
+# -- Disable automatic mounting of the service account token
+automountServiceAccountToken: false
+
+# -- Persistent volume claim for content (used when sync.strategy != sidecar)
+persistence:
+  content:
+    enabled: false
+    existingClaim: ""
+    storageClass: ""
+    size: 1Gi
+  theme:
+    enabled: false
+    existingClaim: ""
+    storageClass: ""
+    size: 256Mi


### PR DESCRIPTION
## Summary

Production-ready Helm chart for deploying BlogFlow to Kubernetes.

### Features
- **Three sync strategies**: watch (default), git-sync sidecar, webhook
- **Security hardened**: nonroot UID 65532, read-only root filesystem, all capabilities dropped, seccomp RuntimeDefault
- **ConfigMap** for site.yaml with full config coverage from `internal/config/config.go`
- **Optional ingress** gated by `ingress.enabled`
- **Optional webhook secret** (generated or existing)
- **Health probes** on `/healthz` and `/readyz`
- **Resource requests/limits** matching the container-security doc spec
- `helm lint` passes cleanly

### Files added
| File | Purpose |
|------|---------|
| `Chart.yaml` | Chart metadata (v0.1.0) |
| `values.yaml` | All configurable values with sensible defaults |
| `templates/deployment.yaml` | Deployment with conditional git-sync sidecar |
| `templates/service.yaml` | ClusterIP service on port 8080 |
| `templates/configmap.yaml` | site.yaml from values |
| `templates/secret.yaml` | Optional webhook secret |
| `templates/ingress.yaml` | Optional ingress resource |
| `templates/_helpers.tpl` | Standard name/label helpers |
| `templates/NOTES.txt` | Post-install instructions |