### PR TITLE
fix: flush render cache on content reload

### DIFF
--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -121,11 +121,7 @@ func main() {
 	srv := server.New(cfg, logger)
 
 	// 7. Build handler dependencies
-	deps := &handlers.Deps{
-		Config: cfg,
-		Index:  idx,
-		Theme:  themeEngine,
-	}
+	deps := handlers.NewDeps(cfg, idx, themeEngine)
 
 	// 8. Content reloader for sync strategies
 	reloader := newContentReloader(scanner, contentOverlay, deps, renderCache, logger)

--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -15,6 +15,7 @@ import (
 	blogflow "github.com/khaines/blogflow"
 	"github.com/khaines/blogflow/internal/config"
 	"github.com/khaines/blogflow/internal/content"
+	"github.com/khaines/blogflow/internal/gitops"
 	"github.com/khaines/blogflow/internal/overlayfs"
 	"github.com/khaines/blogflow/internal/server"
 	"github.com/khaines/blogflow/internal/server/handlers"
@@ -109,16 +110,34 @@ func main() {
 	}
 	logger.Info("theme engine initialized")
 
-	// 5. Create and configure HTTP server
+	// 5. Initialize render cache (if enabled)
+	var renderCache *content.Cache
+	if cfg.Cache.Enabled {
+		renderCache = content.NewCache(cfg.Cache)
+		logger.Info("render cache initialized", "max_entries", cfg.Cache.MaxEntries, "ttl", cfg.Cache.TTL)
+	}
+
+	// 6. Create and configure HTTP server
 	srv := server.New(cfg, logger)
 
-	// 6. Build handler dependencies and register routes
+	// 7. Build handler dependencies
 	deps := &handlers.Deps{
 		Config: cfg,
 		Index:  idx,
 		Theme:  themeEngine,
 	}
 
+	// 8. Content reloader for sync strategies
+	reloader := newContentReloader(scanner, contentOverlay, deps, renderCache, logger)
+
+	// 9. Initialize sync strategy
+	syncStrategy, err := gitops.NewStrategy(&cfg.Sync, reloader, logger)
+	if err != nil {
+		logger.Error("failed to create sync strategy", "error", err)
+		os.Exit(1)
+	}
+
+	// 10. Register routes
 	staticFS, fsErr := fs.Sub(contentOverlay, "static")
 	if fsErr != nil {
 		logger.Warn("static directory not available — /static/ routes will 404", "error", fsErr)
@@ -128,7 +147,7 @@ func main() {
 	feedHandler := handlers.NewFeedHandler(cfg, idx)
 	sitemapHandler := handlers.NewSitemapHandler(cfg, idx)
 
-	srv.RegisterRoutes(server.RouteOptions{
+	routeOpts := server.RouteOptions{
 		ListHandler:    handlers.ListHandler(deps),
 		PostHandler:    handlers.PostHandler(deps),
 		PageHandler:    handlers.PageHandler(deps),
@@ -136,9 +155,22 @@ func main() {
 		FeedHandler:    feedHandler.ServeHTTP,
 		SitemapHandler: sitemapHandler.ServeHTTP,
 		StaticFS:       staticFS,
-	})
+	}
+	if ws, ok := syncStrategy.(*gitops.WebhookStrategy); ok {
+		routeOpts.WebhookHandler = ws.Handler()
+	}
+	srv.RegisterRoutes(routeOpts)
 
-	// 7. Graceful shutdown on SIGINT/SIGTERM
+	// 11. Start sync strategy
+	syncCtx, syncCancel := context.WithCancel(context.Background())
+	if err := syncStrategy.Start(syncCtx); err != nil {
+		logger.Error("failed to start sync strategy", "error", err)
+		syncCancel()
+		os.Exit(1)
+	}
+	logger.Info("sync strategy started", "strategy", syncStrategy.Name())
+
+	// 12. Graceful shutdown on SIGINT/SIGTERM
 	go func() {
 		sigCh := make(chan os.Signal, 1)
 		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
@@ -146,6 +178,13 @@ func main() {
 		logger.Info("shutdown signal received", "signal", sig)
 
 		srv.SetReady(false)
+
+		syncCancel()
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		if stopErr := syncStrategy.Stop(stopCtx); stopErr != nil {
+			logger.Error("sync strategy stop error", "error", stopErr)
+		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
@@ -155,7 +194,7 @@ func main() {
 		}
 	}()
 
-	// 8. Start server and mark ready after bind confirmation
+	// 13. Start server and mark ready after bind confirmation
 	logger.Info("server starting", "addr", fmt.Sprintf(":%d", cfg.Server.Port))
 
 	errCh := make(chan error, 1)

--- a/cmd/blogflow/reload.go
+++ b/cmd/blogflow/reload.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"log/slog"
+
+	"github.com/khaines/blogflow/internal/content"
+	"github.com/khaines/blogflow/internal/gitops"
+	"github.com/khaines/blogflow/internal/server/handlers"
+)
+
+// newContentReloader builds a ContentReloader that re-scans content from fsys
+// and flushes the render cache (if non-nil). The deps.Index pointer is updated
+// in place so existing HTTP handlers see fresh content on subsequent requests.
+func newContentReloader(
+	scanner *content.Scanner,
+	fsys fs.FS,
+	deps *handlers.Deps,
+	cache *content.Cache,
+	logger *slog.Logger,
+) gitops.ContentReloader {
+	return func() error {
+		newIdx, err := scanner.Scan(fsys)
+		if err != nil {
+			return fmt.Errorf("content reload: %w", err)
+		}
+		deps.Index = newIdx
+		logger.Info("content reloaded", "posts", len(newIdx.Posts), "pages", len(newIdx.Pages))
+
+		if cache != nil {
+			cache.InvalidateAll()
+			slog.Info("render cache flushed after content reload")
+		}
+		return nil
+	}
+}

--- a/cmd/blogflow/reload.go
+++ b/cmd/blogflow/reload.go
@@ -11,8 +11,8 @@ import (
 )
 
 // newContentReloader builds a ContentReloader that re-scans content from fsys
-// and flushes the render cache (if non-nil). The deps.Index pointer is updated
-// in place so existing HTTP handlers see fresh content on subsequent requests.
+// and flushes the render cache (if non-nil). The deps index is swapped
+// atomically so existing HTTP handlers see fresh content on subsequent requests.
 func newContentReloader(
 	scanner *content.Scanner,
 	fsys fs.FS,
@@ -25,12 +25,12 @@ func newContentReloader(
 		if err != nil {
 			return fmt.Errorf("content reload: %w", err)
 		}
-		deps.Index = newIdx
+		deps.SetIndex(newIdx)
 		logger.Info("content reloaded", "posts", len(newIdx.Posts), "pages", len(newIdx.Pages))
 
 		if cache != nil {
 			cache.InvalidateAll()
-			slog.Info("render cache flushed after content reload")
+			logger.Info("render cache flushed after content reload")
 		}
 		return nil
 	}

--- a/cmd/blogflow/reload_test.go
+++ b/cmd/blogflow/reload_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"log/slog"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/khaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/content"
+	"github.com/khaines/blogflow/internal/server/handlers"
+)
+
+// testFS returns a minimal content filesystem for reload tests.
+func testFS() fstest.MapFS {
+	return fstest.MapFS{
+		"posts/hello.md": &fstest.MapFile{
+			Data: []byte("---\ntitle: Hello\ndate: 2024-01-01T00:00:00Z\n---\nHello world\n"),
+		},
+	}
+}
+
+func TestContentReloaderFlushesCache(t *testing.T) {
+	t.Parallel()
+
+	cache := content.NewCache(config.CacheConfig{
+		Enabled:    true,
+		TTL:        time.Hour,
+		MaxEntries: 100,
+	})
+	cache.Set("post:hello", []byte("<p>stale</p>"))
+	cache.Set("post:world", []byte("<p>also stale</p>"))
+	if cache.Len() != 2 {
+		t.Fatalf("expected 2 cache entries, got %d", cache.Len())
+	}
+
+	fs := testFS()
+	renderer := content.NewRenderer()
+	scanner := content.NewScanner(renderer, "posts", "pages", 200)
+
+	idx, err := scanner.Scan(fs)
+	if err != nil {
+		t.Fatalf("initial scan: %v", err)
+	}
+
+	deps := &handlers.Deps{Index: idx}
+	reloader := newContentReloader(scanner, fs, deps, cache, slog.Default())
+
+	if err := reloader(); err != nil {
+		t.Fatalf("reloader returned error: %v", err)
+	}
+
+	if cache.Len() != 0 {
+		t.Errorf("expected cache to be empty after reload, got %d entries", cache.Len())
+	}
+}
+
+func TestContentReloaderNilCache(t *testing.T) {
+	t.Parallel()
+
+	fs := testFS()
+	renderer := content.NewRenderer()
+	scanner := content.NewScanner(renderer, "posts", "pages", 200)
+
+	idx, err := scanner.Scan(fs)
+	if err != nil {
+		t.Fatalf("initial scan: %v", err)
+	}
+
+	deps := &handlers.Deps{Index: idx}
+	reloader := newContentReloader(scanner, fs, deps, nil, slog.Default())
+
+	// Must not panic with nil cache.
+	if err := reloader(); err != nil {
+		t.Fatalf("reloader returned error: %v", err)
+	}
+}
+
+func TestContentReloaderUpdatesIndex(t *testing.T) {
+	t.Parallel()
+
+	fs := testFS()
+	renderer := content.NewRenderer()
+	scanner := content.NewScanner(renderer, "posts", "pages", 200)
+
+	idx, err := scanner.Scan(fs)
+	if err != nil {
+		t.Fatalf("initial scan: %v", err)
+	}
+
+	deps := &handlers.Deps{Index: idx}
+	reloader := newContentReloader(scanner, fs, deps, nil, slog.Default())
+
+	if err := reloader(); err != nil {
+		t.Fatalf("reloader returned error: %v", err)
+	}
+
+	// deps.Index should be a fresh index (different pointer).
+	if deps.Index == idx {
+		t.Error("expected deps.Index to be updated to a new pointer after reload")
+	}
+
+	if len(deps.Index.Posts) != 1 {
+		t.Errorf("expected 1 post after reload, got %d", len(deps.Index.Posts))
+	}
+}

--- a/cmd/blogflow/reload_test.go
+++ b/cmd/blogflow/reload_test.go
@@ -43,7 +43,7 @@ func TestContentReloaderFlushesCache(t *testing.T) {
 		t.Fatalf("initial scan: %v", err)
 	}
 
-	deps := &handlers.Deps{Index: idx}
+	deps := handlers.NewDeps(nil, idx, nil)
 	reloader := newContentReloader(scanner, fs, deps, cache, slog.Default())
 
 	if err := reloader(); err != nil {
@@ -67,7 +67,7 @@ func TestContentReloaderNilCache(t *testing.T) {
 		t.Fatalf("initial scan: %v", err)
 	}
 
-	deps := &handlers.Deps{Index: idx}
+	deps := handlers.NewDeps(nil, idx, nil)
 	reloader := newContentReloader(scanner, fs, deps, nil, slog.Default())
 
 	// Must not panic with nil cache.
@@ -88,19 +88,19 @@ func TestContentReloaderUpdatesIndex(t *testing.T) {
 		t.Fatalf("initial scan: %v", err)
 	}
 
-	deps := &handlers.Deps{Index: idx}
+	deps := handlers.NewDeps(nil, idx, nil)
 	reloader := newContentReloader(scanner, fs, deps, nil, slog.Default())
 
 	if err := reloader(); err != nil {
 		t.Fatalf("reloader returned error: %v", err)
 	}
 
-	// deps.Index should be a fresh index (different pointer).
-	if deps.Index == idx {
-		t.Error("expected deps.Index to be updated to a new pointer after reload")
+	// deps index should be a fresh index (different pointer).
+	if deps.LoadIndex() == idx {
+		t.Error("expected deps index to be updated to a new pointer after reload")
 	}
 
-	if len(deps.Index.Posts) != 1 {
-		t.Errorf("expected 1 post after reload, got %d", len(deps.Index.Posts))
+	if len(deps.LoadIndex().Posts) != 1 {
+		t.Errorf("expected 1 post after reload, got %d", len(deps.LoadIndex().Posts))
 	}
 }

--- a/docs/content-authoring-guide.md
+++ b/docs/content-authoring-guide.md
@@ -431,33 +431,31 @@ The cache exposes two invalidation methods:
 | `Invalidate(key)`| Removes a single entry by key.      |
 | `InvalidateAll()`| Drops every entry from the cache.   |
 
-#### Current Behavior: Cache Is Not Flushed on Reload
+#### Current Behavior: Cache Is Flushed on Reload
 
-> ⚠️ **Known gap.** As of this writing, none of the sync strategies
-> (watch, webhook, sidecar) call `InvalidateAll()` or `Invalidate()` when
-> content is reloaded. The render cache is flushed only by **TTL expiry**.
+When a sync strategy triggers a content reload, `InvalidateAll()` is called
+automatically after the content index is rebuilt. This ensures that stale
+rendered HTML is never served after a content change.
 
 This means that after a content reload:
 
-1. **Updated posts** may continue to serve stale rendered HTML until their cache
-   entries expire (up to `cache.ttl`, default 1 hour).
-2. **New posts** are immediately available because they have no prior cache entry.
-3. **Deleted posts** will return 404 once their cache entry expires, but may
-   briefly serve stale content if the entry is still valid.
+1. **Updated posts** are re-rendered on the next request with fresh content.
+2. **New posts** are immediately available (cache miss → rendered on demand).
+3. **Deleted posts** return 404 immediately because the cache entry is removed
+   and the content index no longer contains the post.
 
 #### TTL Expiry vs Reload-Triggered Flush
 
 | Scenario                     | Cache behavior                                    |
 |------------------------------|---------------------------------------------------|
-| Post edited, TTL not expired | **Stale content served** until TTL expires         |
-| Post edited, TTL expired     | Fresh content rendered and cached on next request  |
+| Post edited, reload triggers | Cache flushed → fresh render on next request       |
 | New post added               | Cache miss → rendered and cached immediately       |
-| Post deleted                 | Stale HTML served until TTL expiry, then 404       |
+| Post deleted                 | Cache flushed → 404 on next request                |
 | `cache.enabled` set to `false` | Every request re-renders (no caching)           |
 
 #### In-Flight Requests During a Flush
 
-If `InvalidateAll()` were called (e.g., by a future reload implementation):
+When `InvalidateAll()` is called during a content reload:
 
 - Requests that already retrieved a cache entry **before** the flush will
   complete normally with the (now-stale) data. The cache returns a defensive
@@ -469,30 +467,29 @@ If `InvalidateAll()` were called (e.g., by a future reload implementation):
 
 #### Operator Guidance
 
-**When to expect stale content:**
+**Cache behavior after content changes:**
 
-- After any content change delivered via watch, webhook, or sidecar, previously
-  rendered pages may remain stale for up to `cache.ttl`.
+- Content changes delivered via watch, webhook, or sidecar trigger an automatic
+  cache flush. No manual intervention is required.
 
-**How to minimize stale windows:**
+**Additional cache management options:**
 
 1. **Lower the TTL.** Set `cache.ttl` to a shorter duration (e.g., `"5m"`) if
-   freshness matters more than render performance:
+   you want cache entries to expire sooner between reloads:
    ```yaml
    cache:
      ttl: "5m"
    ```
 2. **Disable the cache entirely.** Set `cache.enabled: false` or
    `BLOGFLOW_CACHE_ENABLED=false`. Every request will re-render from the
-   content index, which is always up to date after a reload.
+   content index.
 3. **Restart the process.** A full restart rebuilds the content index and starts
-   with an empty cache. This is the most reliable way to guarantee zero stale
-   content.
+   with an empty cache.
 
-**Forcing a cache flush (workaround):**
+**Forcing a manual cache flush:**
 
-Until cache invalidation is wired into the reload path, the only way to force an
-immediate flush of all cached content is to restart the BlogFlow process:
+If you need to force a cache flush outside of the normal reload path, restart
+the BlogFlow process:
 
 ```bash
 # Docker

--- a/internal/server/handlers/handlers.go
+++ b/internal/server/handlers/handlers.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net/http"
 	"strconv"
+	"sync/atomic"
 
 	"github.com/khaines/blogflow/internal/config"
 	"github.com/khaines/blogflow/internal/content"
@@ -15,11 +16,26 @@ import (
 )
 
 // Deps holds shared dependencies for all handlers.
+// The content index is stored as an atomic pointer so that background
+// sync-strategy reloaders can swap it without racing with HTTP handlers.
 type Deps struct {
 	Config *config.Config
-	Index  *content.Index
+	index  atomic.Pointer[content.Index]
 	Theme  *theme.Engine
 }
+
+// NewDeps creates a Deps with the given dependencies.
+func NewDeps(cfg *config.Config, idx *content.Index, themeEngine *theme.Engine) *Deps {
+	d := &Deps{Config: cfg, Theme: themeEngine}
+	d.index.Store(idx)
+	return d
+}
+
+// LoadIndex returns the current content index. Safe for concurrent use.
+func (d *Deps) LoadIndex() *content.Index { return d.index.Load() }
+
+// SetIndex atomically replaces the content index. Safe for concurrent use.
+func (d *Deps) SetIndex(idx *content.Index) { d.index.Store(idx) }
 
 // PageData is the top-level data passed to all templates.
 type PageData struct {
@@ -47,10 +63,11 @@ type Pagination struct {
 // Route: GET /{$}
 func ListHandler(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		idx := deps.LoadIndex()
 		page := queryInt(r, "page", 1)
 		perPage := deps.Config.Content.PostsPerPage
 
-		paged, pag := paginate(deps.Index.Posts, page, perPage)
+		paged, pag := paginate(idx.Posts, page, perPage)
 
 		data := &PageData{
 			Site:       deps.Config.Site,
@@ -70,7 +87,8 @@ func PostHandler(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		slug := r.PathValue("slug")
 
-		post, ok := deps.Index.BySlug[slug]
+		idx := deps.LoadIndex()
+		post, ok := idx.BySlug[slug]
 		if !ok {
 			NotFoundHandler(deps)(w, r)
 			return
@@ -93,7 +111,8 @@ func PageHandler(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		slug := r.PathValue("slug")
 
-		page, ok := deps.Index.PageBySlug[slug]
+		idx := deps.LoadIndex()
+		page, ok := idx.PageBySlug[slug]
 		if !ok {
 			NotFoundHandler(deps)(w, r)
 			return
@@ -116,7 +135,8 @@ func TagHandler(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tag := r.PathValue("tag")
 
-		posts, ok := deps.Index.ByTag[tag]
+		idx := deps.LoadIndex()
+		posts, ok := idx.ByTag[tag]
 		if !ok || len(posts) == 0 {
 			NotFoundHandler(deps)(w, r)
 			return

--- a/internal/server/handlers/handlers_test.go
+++ b/internal/server/handlers/handlers_test.go
@@ -64,11 +64,7 @@ func testDeps(t *testing.T, posts, pages []*content.Post) *handlers.Deps {
 	cfg := config.Default()
 	cfg.Content.PostsPerPage = 2
 
-	return &handlers.Deps{
-		Config: cfg,
-		Index:  idx,
-		Theme:  eng,
-	}
+	return handlers.NewDeps(cfg, idx, eng)
 }
 
 func makePost(slug, title string, tags []string) *content.Post {
@@ -392,11 +388,7 @@ func TestRenderTemplate_500(t *testing.T) {
 		PageBySlug: map[string]*content.Post{"about": pages[0]},
 	}
 
-	deps := &handlers.Deps{
-		Config: cfg,
-		Index:  idx,
-		Theme:  eng,
-	}
+	deps := handlers.NewDeps(cfg, idx, eng)
 
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Problem

When content is reloaded via watch, webhook, or sidecar sync strategies, the render cache is NOT flushed. This means stale HTML can be served for up to `cache.ttl` (default 1 hour) after a content change.

## Solution

- Extract `newContentReloader()` in `cmd/blogflow/reload.go` that re-scans content and calls `cache.InvalidateAll()` after a successful re-scan
- Wire the render cache, content reloader, and sync strategy lifecycle into `main.go`
- Handle the nil-cache case (when `cache.enabled: false`)
- Wire webhook handler into route registration when strategy is `webhook`
- Add sync strategy graceful shutdown

## Tests

- `TestContentReloaderFlushesCache` — verifies cache is emptied after reload
- `TestContentReloaderNilCache` — verifies no panic when cache is disabled
- `TestContentReloaderUpdatesIndex` — verifies deps.Index is updated
- All existing tests pass with `-race`

## Docs

Updated `docs/content-authoring-guide.md` cache invalidation section to reflect that the cache is now flushed automatically on content reload.