### PR TITLE
fix: move content-deploy workflow to examples/

### DIFF
--- a/examples/workflows/content-deploy.yml
+++ b/examples/workflows/content-deploy.yml
@@ -1,3 +1,6 @@
+# ⚠️  TEMPLATE — Copy this file to YOUR CONTENT REPO at .github/workflows/content-deploy.yml
+# Do NOT use this in the BlogFlow engine repo.
+#
 # Content Deploy — Trigger BlogFlow webhook on content push
 # Copy this workflow to your content repository's .github/workflows/
 name: Deploy Content


### PR DESCRIPTION
## Problem
`content-deploy.yml` is a template for **content repos** but was placed in `.github/workflows/`, making it a live workflow that triggers on every push to main in the **engine repo** — sending webhook requests to a non-existent BlogFlow instance.

## Fix
Moved to `examples/workflows/content-deploy.yml` with a header note clarifying it's a copy-paste template. GitHub Actions ignores files outside `.github/workflows/`.