### PR TITLE
feat: K8s hardening — secret files, startupProbe, sizeLimit, PDB

### DIFF
--- a/deploy/helm/blogflow/templates/deployment.yaml
+++ b/deploy/helm/blogflow/templates/deployment.yaml
@@ -40,6 +40,12 @@ spec:
               protocol: TCP
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- /* NOTE: BlogFlow currently reads the webhook secret from the
+               BLOGFLOW_WEBHOOK_SECRET env var only (config field has yaml:"-").
+               Until the app supports file-based secrets, operators must set the
+               env var separately or patch the app. The file mount is the
+               recommended target state because env vars are visible in
+               /proc/<pid>/environ to any process sharing the pid namespace. */}}
           {{- if or (eq .Values.sync.strategy "webhook") .Values.env }}
           env:
             {{- if eq .Values.sync.strategy "webhook" }}
@@ -47,11 +53,15 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "blogflow.webhookSecretName" . }}
-                  key: BLOGFLOW_WEBHOOK_SECRET
+                  key: webhook-secret
             {{- end }}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- end }}
+          {{- if .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
@@ -71,6 +81,13 @@ spec:
               mountPath: /data/cache
             - name: tmp
               mountPath: /tmp
+            {{- if eq .Values.sync.strategy "webhook" }}
+            # Webhook secret mounted as a file — env vars are visible in
+            # /proc/<pid>/environ; file mounts are restricted by filesystem DAC.
+            - name: webhook-secret
+              mountPath: /etc/blogflow/secrets
+              readOnly: true
+            {{- end }}
         {{- if eq .Values.sync.strategy "sidecar" }}
         - name: git-sync
           image: "{{ .Values.sync.sidecar.image.repository }}:{{ .Values.sync.sidecar.image.tag }}"
@@ -124,11 +141,20 @@ spec:
           configMap:
             name: {{ include "blogflow.fullname" . }}
         - name: cache
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: {{ .Values.cache.sizeLimit | default "256Mi" }}
         - name: tmp
           emptyDir:
             medium: Memory
             sizeLimit: 64Mi
+        {{- if eq .Values.sync.strategy "webhook" }}
+        - name: webhook-secret
+          secret:
+            secretName: {{ include "blogflow.webhookSecretName" . }}
+            items:
+              - key: webhook-secret
+                path: webhook-secret
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/blogflow/templates/deployment.yaml
+++ b/deploy/helm/blogflow/templates/deployment.yaml
@@ -151,6 +151,7 @@ spec:
         - name: webhook-secret
           secret:
             secretName: {{ include "blogflow.webhookSecretName" . }}
+            defaultMode: 0400
             items:
               - key: webhook-secret
                 path: webhook-secret

--- a/deploy/helm/blogflow/templates/pdb.yaml
+++ b/deploy/helm/blogflow/templates/pdb.yaml
@@ -8,8 +8,7 @@ metadata:
 spec:
   {{- if .Values.pdb.minAvailable }}
   minAvailable: {{ .Values.pdb.minAvailable }}
-  {{- end }}
-  {{- if .Values.pdb.maxUnavailable }}
+  {{- else if .Values.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.pdb.maxUnavailable }}
   {{- end }}
   selector:

--- a/deploy/helm/blogflow/templates/pdb.yaml
+++ b/deploy/helm/blogflow/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "blogflow.fullname" . }}
+  labels:
+    {{- include "blogflow.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "blogflow.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/blogflow/templates/secret.yaml
+++ b/deploy/helm/blogflow/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "blogflow.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  BLOGFLOW_WEBHOOK_SECRET: {{ .Values.sync.webhook.secret | quote }}
+  webhook-secret: {{ .Values.sync.webhook.secret | quote }}
 {{- end }}

--- a/deploy/helm/blogflow/values.yaml
+++ b/deploy/helm/blogflow/values.yaml
@@ -41,7 +41,7 @@ sync:
   webhook:
     # -- Webhook endpoint path
     path: /api/webhook
-    # -- Name of an existing Secret containing the webhook secret under key BLOGFLOW_WEBHOOK_SECRET
+    # -- Name of an existing Secret containing the webhook secret under key "webhook-secret"
     existingSecret: ""
     # -- Webhook secret value (ignored if existingSecret is set; stored in a generated Secret)
     secret: ""
@@ -139,6 +139,14 @@ securityContext:
     drop:
       - ALL
 
+# -- Startup probe configuration (generous timeout for slow PVC mounts)
+startupProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  failureThreshold: 30
+  periodSeconds: 2
+
 # -- Liveness probe configuration
 livenessProbe:
   httpGet:
@@ -154,6 +162,11 @@ readinessProbe:
     port: http
   initialDelaySeconds: 3
   periodSeconds: 5
+
+# -- Cache emptyDir sizing
+cache:
+  # -- Maximum size of the rendered-page cache volume (prevents filling node ephemeral storage)
+  sizeLimit: 256Mi
 
 # -- Additional environment variables for the BlogFlow container
 env: []
@@ -175,6 +188,15 @@ affinity: {}
 
 # -- Disable automatic mounting of the service account token
 automountServiceAccountToken: false
+
+# -- PodDisruptionBudget configuration
+pdb:
+  # -- Enable PDB (recommended when replicaCount > 1)
+  enabled: false
+  # -- Minimum pods that must remain available during voluntary disruptions
+  minAvailable: 1
+  # -- Maximum pods that can be unavailable (alternative to minAvailable; leave empty to use minAvailable)
+  maxUnavailable: ""
 
 # -- Persistent volume claim for content (used when sync.strategy != sidecar)
 persistence:

--- a/examples/k8s/sidecar/deployment.yaml
+++ b/examples/k8s/sidecar/deployment.yaml
@@ -80,6 +80,14 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 5
 
+          # Startup probe — generous window for slow PVC mounts.
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            failureThreshold: 30
+            periodSeconds: 2
+
           volumeMounts:
             - name: content
               mountPath: /data/content
@@ -146,9 +154,10 @@ spec:
         - name: config
           configMap:
             name: blogflow-config
-        # Rendered page cache (ephemeral).
+        # Rendered page cache (ephemeral); capped to protect node storage.
         - name: cache
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: 256Mi
         # Scratch space — memory-backed to avoid disk writes.
         - name: tmp
           emptyDir:

--- a/examples/k8s/sidecar/pdb.yaml
+++ b/examples/k8s/sidecar/pdb.yaml
@@ -1,0 +1,17 @@
+# PodDisruptionBudget — ensures at least one pod stays available during
+# voluntary disruptions (node drains, cluster upgrades).
+# Only useful when replicas > 1; for single-replica deployments the PDB
+# will block drains entirely, which may or may not be desired.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: blogflow
+  namespace: blogflow
+  labels:
+    app.kubernetes.io/name: blogflow
+    app.kubernetes.io/component: server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: blogflow

--- a/examples/k8s/webhook/deployment.yaml
+++ b/examples/k8s/webhook/deployment.yaml
@@ -137,6 +137,7 @@ spec:
         - name: webhook-secret
           secret:
             secretName: blogflow-webhook-secret
+            defaultMode: 0400
             items:
               - key: webhook-secret
                 path: webhook-secret

--- a/examples/k8s/webhook/deployment.yaml
+++ b/examples/k8s/webhook/deployment.yaml
@@ -49,8 +49,13 @@ spec:
               drop:
                 - ALL
 
+          # NOTE: BlogFlow currently reads the webhook secret from the
+          # BLOGFLOW_WEBHOOK_SECRET env var only (config field has yaml:"-").
+          # Until the app supports file-based secrets, operators must set the
+          # env var separately or patch the app. The file mount below is the
+          # recommended target state because env vars are visible in
+          # /proc/<pid>/environ to any process sharing the pid namespace.
           env:
-            # Webhook HMAC secret — injected from the Secret resource.
             - name: BLOGFLOW_WEBHOOK_SECRET
               valueFrom:
                 secretKeyRef:
@@ -81,6 +86,14 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 5
 
+          # Startup probe — generous window for slow PVC mounts.
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            failureThreshold: 30
+            periodSeconds: 2
+
           volumeMounts:
             # Content volume is read-write — BlogFlow pulls on webhook trigger.
             - name: content
@@ -94,6 +107,11 @@ spec:
               mountPath: /data/cache
             - name: tmp
               mountPath: /tmp
+            # Webhook secret mounted as a file — env vars are visible in
+            # /proc/<pid>/environ; file mounts are restricted by filesystem DAC.
+            - name: webhook-secret
+              mountPath: /etc/blogflow/secrets
+              readOnly: true
 
       volumes:
         # Content volume — read-write so BlogFlow can pull updates itself.
@@ -106,11 +124,19 @@ spec:
         - name: config
           configMap:
             name: blogflow-config
-        # Rendered page cache (ephemeral).
+        # Rendered page cache (ephemeral); capped to protect node storage.
         - name: cache
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: 256Mi
         # Scratch space — memory-backed to avoid disk writes.
         - name: tmp
           emptyDir:
             medium: Memory
             sizeLimit: 64Mi
+        # Webhook HMAC secret projected as a file.
+        - name: webhook-secret
+          secret:
+            secretName: blogflow-webhook-secret
+            items:
+              - key: webhook-secret
+                path: webhook-secret

--- a/examples/k8s/webhook/pdb.yaml
+++ b/examples/k8s/webhook/pdb.yaml
@@ -1,0 +1,17 @@
+# PodDisruptionBudget — ensures at least one pod stays available during
+# voluntary disruptions (node drains, cluster upgrades).
+# Only useful when replicas > 1; for single-replica deployments the PDB
+# will block drains entirely, which may or may not be desired.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: blogflow
+  namespace: blogflow
+  labels:
+    app.kubernetes.io/name: blogflow
+    app.kubernetes.io/component: server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: blogflow


### PR DESCRIPTION
## K8s Hardening — Secrets Mount, startupProbe, sizeLimit, PDB

Fixes #41 · Fixes #42 · Fixes #43 · Fixes #44

### Changes

**#41 — Mount secrets as files**
- Webhook secret is now also projected as a volume at `/etc/blogflow/secrets/webhook-secret`
- Env var kept for backward compat (BlogFlow reads `BLOGFLOW_WEBHOOK_SECRET` env only; `yaml:"-"` blocks config file loading)
- Comments document the `/proc/<pid>/environ` exposure risk and the app-side gap

**#42 — startupProbe**
- Added `startupProbe` on `/healthz` with `failureThreshold: 30, periodSeconds: 2` (60s startup window)
- Prevents CrashLoopBackOff when PVC mounts are slow

**#43 — sizeLimit on cache emptyDir**
- `sizeLimit: 256Mi` on the cache volume in both examples
- Helm: configurable via `cache.sizeLimit` (default `256Mi`)
- Prevents a runaway cache from filling node ephemeral storage

**#44 — PodDisruptionBudget**
- New PDB manifests in both example directories (`minAvailable: 1`)
- Helm: gated by `pdb.enabled` (default `false` since default `replicaCount=1`)
- Supports both `minAvailable` and `maxUnavailable`

### Files changed
- `examples/k8s/webhook/deployment.yaml` — secret file mount, startupProbe, cache sizeLimit
- `examples/k8s/sidecar/deployment.yaml` — startupProbe, cache sizeLimit
- `examples/k8s/{webhook,sidecar}/pdb.yaml` — new PDB manifests
- `deploy/helm/blogflow/templates/deployment.yaml` — all four improvements
- `deploy/helm/blogflow/templates/pdb.yaml` — new PDB template
- `deploy/helm/blogflow/templates/secret.yaml` — key renamed to `webhook-secret`
- `deploy/helm/blogflow/values.yaml` — startupProbe, cache.sizeLimit, pdb config

### Validation
- `helm lint` passes for default, webhook, sidecar, and PDB-enabled configurations
