### PR TITLE
feat: replace nuclear rate limiter reset with TTL eviction

### DIFF
--- a/internal/gitops/ratelimiter_test.go
+++ b/internal/gitops/ratelimiter_test.go
@@ -1,0 +1,185 @@
+package gitops
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRateLimiter_BasicAllow(t *testing.T) {
+	t.Parallel()
+
+	rl := newRateLimiter(3)
+	rl.now = func() time.Time { return time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC) }
+
+	for i := range 3 {
+		if !rl.allow("10.0.0.1") {
+			t.Fatalf("request %d should be allowed", i+1)
+		}
+	}
+
+	if rl.allow("10.0.0.1") {
+		t.Fatal("4th request should be denied")
+	}
+}
+
+func TestRateLimiter_TTLEviction(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	rl := newRateLimiter(2)
+	rl.now = func() time.Time { return now }
+
+	// Fill the limiter for two IPs.
+	rl.allow("10.0.0.1")
+	rl.allow("10.0.0.2")
+
+	// Advance time past the window — entries should be lazily evicted.
+	now = now.Add(rl.window + time.Second)
+
+	if got := rl.lru.Len(); got != 2 {
+		t.Fatalf("before eviction: entries = %d, want 2", got)
+	}
+
+	// Next request triggers lazy eviction of expired entries.
+	if !rl.allow("10.0.0.3") {
+		t.Fatal("new IP after expiry should be allowed")
+	}
+
+	// Old entries should have been evicted.
+	if _, ok := rl.entries["10.0.0.1"]; ok {
+		t.Fatal("10.0.0.1 should have been evicted (TTL expired)")
+	}
+	if _, ok := rl.entries["10.0.0.2"]; ok {
+		t.Fatal("10.0.0.2 should have been evicted (TTL expired)")
+	}
+	if rl.lru.Len() != 1 {
+		t.Fatalf("after eviction: entries = %d, want 1", rl.lru.Len())
+	}
+}
+
+func TestRateLimiter_TTLRestoresQuota(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	rl := newRateLimiter(2)
+	rl.now = func() time.Time { return now }
+
+	// Exhaust quota.
+	rl.allow("10.0.0.1")
+	rl.allow("10.0.0.1")
+	if rl.allow("10.0.0.1") {
+		t.Fatal("should be rate limited")
+	}
+
+	// Advance past the window.
+	now = now.Add(rl.window + time.Second)
+
+	// Quota should be restored.
+	if !rl.allow("10.0.0.1") {
+		t.Fatal("after TTL expiry, IP should be allowed again")
+	}
+}
+
+func TestRateLimiter_LRUEvictionNotNuclear(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	rl := newRateLimiter(5)
+	rl.maxSize = 4 // small capacity for testing
+	rl.now = func() time.Time { return now }
+
+	// Fill to capacity with 4 IPs.
+	for i := range 4 {
+		ip := fmt.Sprintf("10.0.0.%d", i+1)
+		if !rl.allow(ip) {
+			t.Fatalf("IP %s should be allowed", ip)
+		}
+	}
+	if len(rl.entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(rl.entries))
+	}
+
+	// Add a 5th IP — should evict the LRU entry (10.0.0.1, first inserted).
+	if !rl.allow("10.0.0.5") {
+		t.Fatal("new IP should be allowed after LRU eviction")
+	}
+
+	// Exactly one entry should have been evicted (not nuclear reset).
+	if len(rl.entries) != 4 {
+		t.Fatalf("expected 4 entries after LRU eviction, got %d", len(rl.entries))
+	}
+
+	// The first IP (least recently used) should have been evicted.
+	if _, ok := rl.entries["10.0.0.1"]; ok {
+		t.Fatal("10.0.0.1 should have been evicted as LRU")
+	}
+
+	// More recent IPs should still be present.
+	for i := 2; i <= 5; i++ {
+		ip := fmt.Sprintf("10.0.0.%d", i)
+		if _, ok := rl.entries[ip]; !ok {
+			t.Fatalf("%s should still be present", ip)
+		}
+	}
+}
+
+func TestRateLimiter_LRUOrderUpdatedOnAccess(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	rl := newRateLimiter(10)
+	rl.maxSize = 3
+	rl.now = func() time.Time { return now }
+
+	// Insert A, B, C. LRU order (front→back): C, B, A.
+	rl.allow("A")
+	rl.allow("B")
+	rl.allow("C")
+
+	// Access A to move it to front. LRU order: A, C, B.
+	rl.allow("A")
+
+	// Add D — should evict B (now the LRU).
+	rl.allow("D")
+
+	if _, ok := rl.entries["B"]; ok {
+		t.Fatal("B should have been evicted as LRU")
+	}
+	if _, ok := rl.entries["A"]; !ok {
+		t.Fatal("A should still be present (was recently accessed)")
+	}
+}
+
+func TestRateLimiter_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	rl := newRateLimiter(100)
+	var wg sync.WaitGroup
+
+	for i := range 50 {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			ip := fmt.Sprintf("10.0.0.%d", id)
+			for range 10 {
+				rl.allow(ip)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	// No race condition — test passes if -race doesn't fire.
+}
+
+func TestRateLimiter_NilWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	if rl := newRateLimiter(0); rl != nil {
+		t.Fatal("expected nil for limit <= 0")
+	}
+	if rl := newRateLimiter(-1); rl != nil {
+		t.Fatal("expected nil for limit <= 0")
+	}
+}

--- a/internal/gitops/ratelimiter_test.go
+++ b/internal/gitops/ratelimiter_test.go
@@ -155,10 +155,11 @@ func TestRateLimiter_LRUOrderUpdatedOnAccess(t *testing.T) {
 func TestRateLimiter_ConcurrentAccess(t *testing.T) {
 	t.Parallel()
 
-	rl := newRateLimiter(100)
+	rl := newRateLimiter(5) // low limit → some requests denied
+	rl.maxSize = 50         // 100 unique IPs forces concurrent LRU eviction
 	var wg sync.WaitGroup
 
-	for i := range 50 {
+	for i := range 100 {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()

--- a/internal/gitops/webhook.go
+++ b/internal/gitops/webhook.go
@@ -1,6 +1,7 @@
 package gitops
 
 import (
+	"container/list"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -20,14 +21,25 @@ import (
 
 const defaultMaxPayloadSize int64 = 1 << 20 // 1 MB
 
+// IPResolver extracts the client IP from an HTTP request.
+// The server.ClientIPResolver type satisfies this interface.
+type IPResolver interface {
+	ClientIP(r *http.Request) string
+}
+
 // WebhookStrategy listens for HTTP webhook callbacks to trigger content reload.
 // Validates HMAC-SHA256 signatures, filters by branch, and rate-limits.
 type WebhookStrategy struct {
-	config   config.WebhookConfig
-	reloader ContentReloader
-	logger   *slog.Logger
-	handler  http.HandlerFunc
+	config     config.WebhookConfig
+	reloader   ContentReloader
+	logger     *slog.Logger
+	handler    http.HandlerFunc
+	ipResolver IPResolver
 }
+
+// SetIPResolver configures a custom IP resolver (e.g. server.ClientIPResolver)
+// for extracting client IPs. When nil, the built-in remoteIP function is used.
+func (w *WebhookStrategy) SetIPResolver(r IPResolver) { w.ipResolver = r }
 
 // NewWebhookStrategy creates a new webhook-based sync strategy.
 // Path must be non-empty and start with "/". Secret must be non-empty.
@@ -79,7 +91,7 @@ func (w *WebhookStrategy) buildHandler(rl *rateLimiter) http.HandlerFunc {
 		}
 
 		// Rate-limit by remote IP.
-		ip := remoteIP(r)
+		ip := w.resolveIP(r)
 		if rl != nil && !rl.allow(ip) {
 			w.logger.Warn("rate limited", "ip", ip)
 			http.Error(rw, "rate limit exceeded", http.StatusTooManyRequests)
@@ -174,12 +186,18 @@ func verifySignature(secret, payload []byte, sigHeader string) bool {
 	return hmac.Equal(decoded, expected)
 }
 
-// remoteIP extracts the client IP from the request, stripping the port.
+// resolveIP returns the client IP using the configured resolver, or the
+// built-in remoteIP heuristic when no resolver is set.
+func (w *WebhookStrategy) resolveIP(r *http.Request) string {
+	if w.ipResolver != nil {
+		return w.ipResolver.ClientIP(r)
+	}
+	return remoteIP(r)
+}
+
 // remoteIP extracts the client IP from the request.
 // Checks X-Forwarded-For first (for reverse-proxy deployments), falls back to RemoteAddr.
 func remoteIP(r *http.Request) string {
-	// Trust X-Forwarded-For if present (standard reverse proxy header).
-	// Takes the first (leftmost) IP — the original client.
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
 		if idx := strings.Index(xff, ","); idx != -1 {
 			return strings.TrimSpace(xff[:idx])
@@ -193,12 +211,25 @@ func remoteIP(r *http.Request) string {
 	return addr
 }
 
-// rateLimiter implements a sliding-window rate limiter per IP.
+const defaultMaxClients = 10000
+
+// rateLimiter implements a sliding-window rate limiter per IP with LRU
+// eviction. Entries whose timestamps are all older than the rate window are
+// lazily evicted on each request. When the map reaches capacity, the
+// least-recently-seen IP is evicted instead of clearing the entire map.
 type rateLimiter struct {
 	mu      sync.Mutex
 	limit   int
 	window  time.Duration
-	clients map[string][]time.Time
+	maxSize int
+	entries map[string]*list.Element
+	lru     *list.List // front = most-recently-seen
+	now     func() time.Time
+}
+
+type rlEntry struct {
+	ip         string
+	timestamps []time.Time
 }
 
 func newRateLimiter(limit int) *rateLimiter {
@@ -209,7 +240,10 @@ func newRateLimiter(limit int) *rateLimiter {
 	return &rateLimiter{
 		limit:   limit,
 		window:  time.Minute,
-		clients: make(map[string][]time.Time),
+		maxSize: defaultMaxClients,
+		entries: make(map[string]*list.Element),
+		lru:     list.New(),
+		now:     time.Now,
 	}
 }
 
@@ -217,32 +251,62 @@ func (rl *rateLimiter) allow(ip string) bool {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
-	now := time.Now()
+	now := rl.now()
 	cutoff := now.Add(-rl.window)
 
-	// Periodic eviction: sweep stale entries when map grows large.
-	if len(rl.clients) > 1000 {
-		for k, timestamps := range rl.clients {
-			if len(timestamps) == 0 || timestamps[len(timestamps)-1].Before(cutoff) {
-				delete(rl.clients, k)
+	// Lazy TTL eviction: remove expired entries from the back of the LRU list.
+	rl.evictExpired(cutoff)
+
+	if elem, ok := rl.entries[ip]; ok {
+		rl.lru.MoveToFront(elem)
+		entry := elem.Value.(*rlEntry)
+
+		valid := entry.timestamps[:0]
+		for _, ts := range entry.timestamps {
+			if ts.After(cutoff) {
+				valid = append(valid, ts)
 			}
 		}
-	}
 
-	timestamps := rl.clients[ip]
-	valid := timestamps[:0]
-
-	for _, ts := range timestamps {
-		if ts.After(cutoff) {
-			valid = append(valid, ts)
+		if len(valid) >= rl.limit {
+			entry.timestamps = valid
+			return false
 		}
+
+		entry.timestamps = append(valid, now)
+		return true
 	}
 
-	if len(valid) >= rl.limit {
-		rl.clients[ip] = valid
-		return false
+	// New IP — evict least-recently-seen if at capacity.
+	for len(rl.entries) >= rl.maxSize {
+		rl.evictOldest()
 	}
 
-	rl.clients[ip] = append(valid, now)
+	entry := &rlEntry{ip: ip, timestamps: []time.Time{now}}
+	elem := rl.lru.PushFront(entry)
+	rl.entries[ip] = elem
 	return true
+}
+
+// evictExpired removes entries from the back of the LRU whose latest
+// timestamp is before cutoff.
+func (rl *rateLimiter) evictExpired(cutoff time.Time) {
+	for rl.lru.Len() > 0 {
+		back := rl.lru.Back()
+		entry := back.Value.(*rlEntry)
+		if len(entry.timestamps) > 0 && entry.timestamps[len(entry.timestamps)-1].After(cutoff) {
+			break
+		}
+		rl.lru.Remove(back)
+		delete(rl.entries, entry.ip)
+	}
+}
+
+// evictOldest removes the least-recently-seen entry.
+func (rl *rateLimiter) evictOldest() {
+	if back := rl.lru.Back(); back != nil {
+		entry := back.Value.(*rlEntry)
+		rl.lru.Remove(back)
+		delete(rl.entries, entry.ip)
+	}
 }


### PR DESCRIPTION
## Summary

Replace the nuclear rate limiter reset in `internal/gitops/webhook.go` with TTL-based lazy eviction and LRU capacity management.

### Changes

- **TTL eviction**: Entries whose timestamps are all older than the rate window (1 min) are lazily evicted from the back of the LRU list on each request — no more clearing the entire map.
- **LRU capacity**: When the map reaches capacity (10K), only the least-recently-seen IP is evicted, preserving state for all active clients.
- **`IPResolver` interface**: Added an optional `IPResolver` interface (satisfied by `server.ClientIPResolver`) so the webhook can use CIDR-aware IP resolution when configured. Falls back to the existing `remoteIP()` X-Forwarded-For parser.
- **Tests**: Added unit tests for TTL expiry, LRU eviction order, capacity limits, concurrent access, and quota restoration after window expiry.

### Testing

- `go test -race ./...` — all pass
- `golangci-lint run ./...` — 0 issues

Fixes #60