### PR TITLE
feat: add runtime config reloading

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -60,6 +60,7 @@ type Loader struct {
 	configFS  fs.FS
 	current   atomic.Pointer[Config]
 	configDir string       // OS path for fsnotify watching
+	reloadMu  sync.Mutex   // serializes Reload to prevent stale-callback races
 	mu        sync.RWMutex // protects callbacks
 	callbacks []func(*Config)
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -56,15 +57,30 @@ func (e *SecretInYAMLError) Error() string {
 
 // Loader loads, validates, and manages configuration.
 type Loader struct {
-	configFS fs.FS
-	current  atomic.Pointer[Config]
+	configFS  fs.FS
+	current   atomic.Pointer[Config]
+	configDir string       // OS path for fsnotify watching
+	mu        sync.RWMutex // protects callbacks
+	callbacks []func(*Config)
+}
+
+// LoaderOption configures optional Loader behaviour.
+type LoaderOption func(*Loader)
+
+// WithWatchDir sets the OS-level directory that Watch() monitors for
+// site.yaml changes. Required only if Watch() will be called.
+func WithWatchDir(dir string) LoaderOption {
+	return func(l *Loader) { l.configDir = dir }
 }
 
 // NewLoader creates a config loader backed by the given filesystem.
 // The FS should be a 2-layer overlay (config + defaults) or a single
 // defaults FS. NewLoader eagerly loads defaults so Get() never returns nil.
-func NewLoader(configFS fs.FS) *Loader {
+func NewLoader(configFS fs.FS, opts ...LoaderOption) *Loader {
 	l := &Loader{configFS: configFS}
+	for _, opt := range opts {
+		opt(l)
+	}
 	// Eagerly store defaults so Get() is never nil.
 	l.current.Store(Default())
 	return l
@@ -73,6 +89,11 @@ func NewLoader(configFS fs.FS) *Loader {
 // Get returns the current immutable Config. Safe for concurrent use.
 // Never returns nil — defaults are loaded eagerly in NewLoader.
 func (l *Loader) Get() *Config {
+	return l.current.Load()
+}
+
+// Config returns the current immutable Config atomically. Alias for Get().
+func (l *Loader) Config() *Config {
 	return l.current.Load()
 }
 
@@ -112,8 +133,6 @@ func (l *Loader) Load() (*Config, error) {
 		return nil, fmt.Errorf("applying environment overrides: %w", err)
 	}
 
-	// TODO(P1): Add Reload() for runtime config reloading and OnChange() callback
-	// registration. See GitHub issue for design.
 	// TODO(P1): Add structured logging (slog) and metrics for config operations.
 	// See GitHub issue for design.
 

--- a/internal/config/reload.go
+++ b/internal/config/reload.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+const debounceDuration = 500 * time.Millisecond
+
+// Reload re-reads site.yaml through the configured FS, re-applies
+// environment variable overrides, re-validates, and atomically stores
+// the new config. On success it fires all registered OnChange callbacks.
+// On validation (or parse) failure the previous config is preserved and
+// the error is returned.
+func (l *Loader) Reload() (*Config, error) {
+	cfg, err := l.Load()
+	if err != nil {
+		return nil, err
+	}
+	l.fireCallbacks(cfg)
+	return cfg, nil
+}
+
+// OnChange registers a callback that is invoked after every successful
+// Reload (including Watch-triggered reloads). The callback receives the
+// newly loaded config. Safe for concurrent use.
+func (l *Loader) OnChange(fn func(*Config)) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.callbacks = append(l.callbacks, fn)
+}
+
+// Watch starts an fsnotify watcher on the config directory and reloads
+// site.yaml whenever it is written or recreated. File-change events are
+// debounced by 500 ms so rapid successive writes result in a single
+// Reload + OnChange cycle. Watch blocks until ctx is cancelled.
+//
+// Requires WithWatchDir to have been passed to NewLoader.
+func (l *Loader) Watch(ctx context.Context) error {
+	if l.configDir == "" {
+		return fmt.Errorf("config: Watch requires a watch directory (use WithWatchDir option)")
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("config: creating file watcher: %w", err)
+	}
+	defer func() { _ = watcher.Close() }()
+
+	// Watch the directory (not the file directly) so we pick up
+	// editor atomic-save renames and file recreations.
+	if err := watcher.Add(l.configDir); err != nil {
+		return fmt.Errorf("config: watching %s: %w", l.configDir, err)
+	}
+
+	configFile := filepath.Join(l.configDir, "site.yaml")
+	var debounceTimer *time.Timer
+	var debounceCh <-chan time.Time
+
+	for {
+		select {
+		case <-ctx.Done():
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			return ctx.Err()
+
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+			if filepath.Clean(event.Name) != filepath.Clean(configFile) {
+				continue
+			}
+			if !event.Has(fsnotify.Write) && !event.Has(fsnotify.Create) {
+				continue
+			}
+			// Reset debounce timer on every qualifying event.
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			debounceTimer = time.NewTimer(debounceDuration)
+			debounceCh = debounceTimer.C
+
+		case <-debounceCh:
+			debounceCh = nil
+			// Best-effort reload: validation failures preserve old config.
+			_, _ = l.Reload()
+
+		case _, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			// TODO: surface via structured logging once slog is wired in.
+		}
+	}
+}
+
+func (l *Loader) fireCallbacks(cfg *Config) {
+	l.mu.RLock()
+	cbs := make([]func(*Config), len(l.callbacks))
+	copy(cbs, l.callbacks)
+	l.mu.RUnlock()
+
+	for _, cb := range cbs {
+		cb(cfg)
+	}
+}

--- a/internal/config/reload.go
+++ b/internal/config/reload.go
@@ -17,6 +17,9 @@ const debounceDuration = 500 * time.Millisecond
 // On validation (or parse) failure the previous config is preserved and
 // the error is returned.
 func (l *Loader) Reload() (*Config, error) {
+	l.reloadMu.Lock()
+	defer l.reloadMu.Unlock()
+
 	cfg, err := l.Load()
 	if err != nil {
 		return nil, err

--- a/internal/config/reload_test.go
+++ b/internal/config/reload_test.go
@@ -1,0 +1,279 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// --- Reload ---
+
+func TestReload_PicksUpFileChanges(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, `site:
+  title: "Original"
+  base_url: "http://localhost:8080"
+`)
+	loader := NewLoader(os.DirFS(dir))
+	cfg, err := loader.Load()
+	if err != nil {
+		t.Fatalf("initial Load failed: %v", err)
+	}
+	if cfg.Site.Title != "Original" {
+		t.Fatalf("expected title 'Original', got %q", cfg.Site.Title)
+	}
+
+	// Change the file on disk.
+	writeYAML(t, dir, `site:
+  title: "Updated"
+  base_url: "http://localhost:8080"
+`)
+	cfg, err = loader.Reload()
+	if err != nil {
+		t.Fatalf("Reload failed: %v", err)
+	}
+	if cfg.Site.Title != "Updated" {
+		t.Errorf("expected title 'Updated' after Reload, got %q", cfg.Site.Title)
+	}
+	// Get/Config must reflect the new value.
+	if loader.Get().Site.Title != "Updated" {
+		t.Error("Get() did not return reloaded config")
+	}
+	if loader.Config().Site.Title != "Updated" {
+		t.Error("Config() did not return reloaded config")
+	}
+}
+
+// --- OnChange ---
+
+func TestOnChange_CallbacksFireAfterReload(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, `site:
+  title: "V1"
+  base_url: "http://localhost:8080"
+`)
+	loader := NewLoader(os.DirFS(dir))
+	if _, err := loader.Load(); err != nil {
+		t.Fatal(err)
+	}
+
+	var received []*Config
+	loader.OnChange(func(c *Config) { received = append(received, c) })
+
+	// Second callback to prove multiple work.
+	var count int
+	loader.OnChange(func(_ *Config) { count++ })
+
+	writeYAML(t, dir, `site:
+  title: "V2"
+  base_url: "http://localhost:8080"
+`)
+	cfg, err := loader.Reload()
+	if err != nil {
+		t.Fatalf("Reload failed: %v", err)
+	}
+	if len(received) != 1 {
+		t.Fatalf("expected 1 callback invocation, got %d", len(received))
+	}
+	if received[0].Site.Title != "V2" {
+		t.Errorf("callback received wrong title: %q", received[0].Site.Title)
+	}
+	if received[0] != cfg {
+		t.Error("callback config pointer differs from Reload return")
+	}
+	if count != 1 {
+		t.Errorf("second callback expected count=1, got %d", count)
+	}
+}
+
+func TestOnChange_NotFiredOnLoadOnly(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, `site:
+  title: "Init"
+  base_url: "http://localhost:8080"
+`)
+	loader := NewLoader(os.DirFS(dir))
+
+	var fired bool
+	loader.OnChange(func(_ *Config) { fired = true })
+
+	if _, err := loader.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if fired {
+		t.Error("OnChange should not fire on Load(), only Reload()")
+	}
+}
+
+// --- Validation errors preserve old config ---
+
+func TestReload_ValidationErrorPreservesOldConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, `site:
+  title: "Good"
+  base_url: "http://localhost:8080"
+`)
+	loader := NewLoader(os.DirFS(dir))
+	if _, err := loader.Load(); err != nil {
+		t.Fatal(err)
+	}
+
+	var callbackFired bool
+	loader.OnChange(func(_ *Config) { callbackFired = true })
+
+	// Write an invalid config (port out of range).
+	writeYAML(t, dir, `site:
+  title: "Bad"
+  base_url: "http://localhost:8080"
+server:
+  port: 0
+`)
+	_, err := loader.Reload()
+	if err == nil {
+		t.Fatal("expected Reload to fail on invalid config")
+	}
+	// Old config must be preserved.
+	if loader.Config().Site.Title != "Good" {
+		t.Errorf("expected old title 'Good' preserved, got %q", loader.Config().Site.Title)
+	}
+	if callbackFired {
+		t.Error("OnChange should not fire when Reload fails validation")
+	}
+}
+
+// --- Watch: debounce ---
+
+func TestWatch_Debounce(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Watch test in short mode")
+	}
+
+	dir := t.TempDir()
+	writeYAML(t, dir, `site:
+  title: "Start"
+  base_url: "http://localhost:8080"
+`)
+	loader := NewLoader(os.DirFS(dir), WithWatchDir(dir))
+	if _, err := loader.Load(); err != nil {
+		t.Fatal(err)
+	}
+
+	var reloadCount atomic.Int32
+	loader.OnChange(func(_ *Config) { reloadCount.Add(1) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	watchErr := make(chan error, 1)
+	go func() { watchErr <- loader.Watch(ctx) }()
+
+	// Give the watcher time to start.
+	time.Sleep(100 * time.Millisecond)
+
+	// Rapid successive writes — should debounce into one reload.
+	for i := range 5 {
+		writeYAML(t, dir, `site:
+  title: "Rapid`+string(rune('A'+i))+`"
+  base_url: "http://localhost:8080"
+`)
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Wait for debounce (500ms) + margin.
+	time.Sleep(800 * time.Millisecond)
+
+	count := reloadCount.Load()
+	if count < 1 {
+		t.Error("expected at least 1 reload after rapid writes, got 0")
+	}
+	if count > 2 {
+		t.Errorf("debounce failed: expected ≤2 reloads, got %d", count)
+	}
+
+	cancel()
+	select {
+	case err := <-watchErr:
+		if err != nil && err != context.Canceled {
+			t.Errorf("Watch returned unexpected error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Watch did not return after context cancellation")
+	}
+}
+
+// --- Watch: context cancellation ---
+
+func TestWatch_ContextCancellation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Watch test in short mode")
+	}
+
+	dir := t.TempDir()
+	writeYAML(t, dir, `site:
+  title: "Cancel"
+  base_url: "http://localhost:8080"
+`)
+	loader := NewLoader(os.DirFS(dir), WithWatchDir(dir))
+	if _, err := loader.Load(); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	watchErr := make(chan error, 1)
+	go func() { watchErr <- loader.Watch(ctx) }()
+
+	// Give watcher time to start then cancel immediately.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-watchErr:
+		if err != context.Canceled {
+			t.Errorf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Watch did not return after context cancellation")
+	}
+}
+
+// --- Watch: missing watch dir ---
+
+func TestWatch_MissingWatchDir(t *testing.T) {
+	loader := NewLoader(os.DirFS(t.TempDir()))
+	err := loader.Watch(context.Background())
+	if err == nil {
+		t.Fatal("expected error when Watch called without WithWatchDir")
+	}
+}
+
+// --- Config() getter ---
+
+func TestConfig_ReturnsCurrentConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, `site:
+  title: "Getter"
+  base_url: "http://localhost:8080"
+`)
+	loader := NewLoader(os.DirFS(dir))
+	// Before Load, Config returns defaults.
+	if loader.Config().Site.Title != "My Blog" {
+		t.Errorf("expected default title before Load, got %q", loader.Config().Site.Title)
+	}
+	if _, err := loader.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if loader.Config().Site.Title != "Getter" {
+		t.Errorf("expected 'Getter' after Load, got %q", loader.Config().Site.Title)
+	}
+}
+
+// writeYAML is a test helper that writes site.yaml to dir.
+func writeYAML(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "site.yaml"), []byte(content), 0o600); err != nil {
+		t.Fatalf("writing site.yaml: %v", err)
+	}
+}

--- a/internal/config/reload_test.go
+++ b/internal/config/reload_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -267,6 +268,85 @@ func TestConfig_ReturnsCurrentConfig(t *testing.T) {
 	}
 	if loader.Config().Site.Title != "Getter" {
 		t.Errorf("expected 'Getter' after Load, got %q", loader.Config().Site.Title)
+	}
+}
+
+// --- Concurrent access ---
+
+func TestReload_ConcurrentReadDuringReload(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, `site:
+  title: "Concurrent"
+  base_url: "http://localhost:8080"
+`)
+	loader := NewLoader(os.DirFS(dir))
+	if _, err := loader.Load(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Spin up readers that continuously call Config().
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for range 4 {
+		go func() {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					cfg := loader.Config()
+					if cfg == nil {
+						t.Error("Config() returned nil")
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	// Concurrent reloads while readers are active.
+	for range 20 {
+		if _, err := loader.Reload(); err != nil {
+			t.Fatalf("Reload failed: %v", err)
+		}
+	}
+}
+
+func TestReload_ConcurrentReloads(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, `site:
+  title: "Race"
+  base_url: "http://localhost:8080"
+`)
+	loader := NewLoader(os.DirFS(dir))
+	if _, err := loader.Load(); err != nil {
+		t.Fatal(err)
+	}
+
+	var callbackCount atomic.Int32
+	loader.OnChange(func(cfg *Config) {
+		// Callback must receive non-nil, valid config.
+		if cfg == nil {
+			t.Error("callback received nil config")
+		}
+	})
+	loader.OnChange(func(_ *Config) { callbackCount.Add(1) })
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 10 {
+				_, _ = loader.Reload()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if c := callbackCount.Load(); c != 80 {
+		t.Errorf("expected 80 callback invocations, got %d", c)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds runtime config reloading to the `Loader` with file-watch support.

### New API

- **`Reload() (*Config, error)`** — re-reads `site.yaml`, re-applies env overrides, re-validates, atomically stores. Fires OnChange callbacks on success.
- **`OnChange(func(*Config))`** — registers callbacks invoked after every successful reload.
- **`Watch(ctx context.Context) error`** — starts fsnotify watcher on config directory, debounces writes (500ms), triggers Reload + callbacks. Blocks until ctx cancelled.
- **`Config() *Config`** — atomic getter alias for `Get()`.
- **`WithWatchDir(dir string)`** — functional option to set the OS path for Watch.

### Safety

- Validation failures preserve the previous config (no swap).
- `atomic.Pointer` for lock-free config reads.
- `sync.RWMutex` protects callback registration.
- Debounce prevents reload storms from rapid editor saves.

### Tests

- Reload picks up file changes
- OnChange callbacks fire after reload (multiple callbacks)
- Validation errors don't swap config (old preserved)
- Debounce works (rapid writes → single reload)
- Watch respects context cancellation
- All pass with `-race`

Fixes #14