### PR TITLE
feat: add Helm test template and CI lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,25 @@ jobs:
           go test -coverprofile=coverage.out -covermode=atomic ./...
           go tool cover -func=coverage.out
 
+  helm-lint:
+    name: Helm Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Helm lint
+        run: helm lint deploy/helm/blogflow/
+
+      - name: Helm template render
+        run: helm template blogflow deploy/helm/blogflow/ > /dev/null
+
   docker:
     name: Docker Build
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [lint, test, helm-lint]
     steps:
       - uses: actions/checkout@v4
 

--- a/deploy/helm/blogflow/templates/tests/test-connection.yaml
+++ b/deploy/helm/blogflow/templates/tests/test-connection.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "blogflow.fullname" . }}-test-connection"
+  labels:
+    {{- include "blogflow.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  restartPolicy: Never
+  containers:
+    - name: wget
+      image: busybox:1.37
+      command: ['wget']
+      args: ['--spider', 'http://{{ include "blogflow.fullname" . }}:{{ .Values.service.port }}/healthz']
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL

--- a/deploy/helm/blogflow/templates/tests/test-connection.yaml
+++ b/deploy/helm/blogflow/templates/tests/test-connection.yaml
@@ -8,14 +8,19 @@ metadata:
     "helm.sh/hook": test
 spec:
   restartPolicy: Never
+  automountServiceAccountToken: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: wget
-      image: busybox:1.37
+      image: busybox:1.37@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f
       command: ['wget']
       args: ['--spider', 'http://{{ include "blogflow.fullname" . }}:{{ .Values.service.port }}/healthz']
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
         readOnlyRootFilesystem: true
         allowPrivilegeEscalation: false
         capabilities:


### PR DESCRIPTION
Adds a Helm test Pod template (`test-connection.yaml`) that verifies the BlogFlow service is reachable via `/healthz` during `helm test`.

Also adds a **Helm Lint** CI job that runs `helm lint` and `helm template` render validation on every push/PR.

### Changes
- `deploy/helm/blogflow/templates/tests/test-connection.yaml` — Helm test Pod (busybox wget spider)
- `.github/workflows/ci.yml` — new `helm-lint` job with `azure/setup-helm@v4`