### PR TITLE
feat: add version injection and --version flag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=sha-${{ github.sha }}
+            COMMIT=${{ github.sha }}
+            DATE=${{ github.event.head_commit.timestamp }}
 
       - name: Scan image for critical/high vulnerabilities
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,10 @@ jobs:
             type=raw,value=main
             type=sha,prefix=sha-,format=short
 
+      - name: Get build date
+        id: date
+        run: echo "value=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -59,7 +63,7 @@ jobs:
           build-args: |
             VERSION=sha-${{ github.sha }}
             COMMIT=${{ github.sha }}
-            DATE=${{ github.event.head_commit.timestamp }}
+            DATE=${{ steps.date.outputs.value }}
 
       - name: Scan image for critical/high vulnerabilities
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,10 @@ jobs:
         id: version
         run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Get build date
+        id: date
+        run: echo "value=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -59,7 +63,7 @@ jobs:
           build-args: |
             VERSION=${{ steps.version.outputs.value }}
             COMMIT=${{ github.sha }}
-            DATE=${{ github.event.head_commit.timestamp }}
+            DATE=${{ steps.date.outputs.value }}
 
       - name: Scan image for critical/high vulnerabilities
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,10 @@ jobs:
             type=raw,value=latest
             type=sha
 
+      - name: Extract version from tag
+        id: version
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -52,6 +56,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ steps.version.outputs.value }}
+            COMMIT=${{ github.sha }}
+            DATE=${{ github.event.head_commit.timestamp }}
 
       - name: Scan image for critical/high vulnerabilities
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
 # Build stage
 FROM golang:1.26-bookworm AS build
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG DATE=unknown
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /app ./cmd/blogflow
+RUN CGO_ENABLED=0 go build -trimpath \
+    -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" \
+    -o /app ./cmd/blogflow
 
 # Runtime stage — distroless, rootless, no shell
 # gcr.io/distroless/static-debian12:nonroot

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
 .PHONY: build test lint fmt docker clean run dev
 
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+DATE    ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
+
 ## build: Compile blogflow binary
 build:
-	go build -trimpath -ldflags="-s -w" -o bin/blogflow ./cmd/blogflow
+	go build -trimpath -ldflags="$(LDFLAGS)" -o bin/blogflow ./cmd/blogflow
 
 ## test: Run unit tests with race detector
 test:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ fmt:
 
 ## docker: Build Docker image
 docker:
-	docker build -t blogflow .
+	docker build --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) --build-arg DATE=$(DATE) -t blogflow .
 
 ## run: Run blogflow with defaults only (no external content needed)
 run: build

--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -22,12 +22,26 @@ import (
 	"github.com/khaines/blogflow/internal/theme"
 )
 
-var version = "dev"
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
+)
+
+func versionString() string {
+	return fmt.Sprintf("blogflow version %s (commit: %s, built: %s)", version, commit, date)
+}
 
 func main() {
-	// Subcommand: healthcheck (must run before flag.Parse)
-	if len(os.Args) > 1 && os.Args[1] == "healthcheck" {
-		os.Exit(runHealthcheck(os.Args[2:]))
+	// Subcommands that must run before flag.Parse
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "healthcheck":
+			os.Exit(runHealthcheck(os.Args[2:]))
+		case "version":
+			fmt.Println(versionString())
+			os.Exit(0)
+		}
 	}
 
 	// CLI flags
@@ -40,7 +54,7 @@ func main() {
 	flag.Parse()
 
 	if *showVersion {
-		fmt.Printf("blogflow %s\n", version)
+		fmt.Println(versionString())
 		os.Exit(0)
 	}
 

--- a/cmd/blogflow/version_test.go
+++ b/cmd/blogflow/version_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVersionString(t *testing.T) {
+	got := versionString()
+	if !strings.HasPrefix(got, "blogflow version ") {
+		t.Errorf("expected version string to start with 'blogflow version ', got: %s", got)
+	}
+	if !strings.Contains(got, "commit:") {
+		t.Errorf("expected version string to contain 'commit:', got: %s", got)
+	}
+	if !strings.Contains(got, "built:") {
+		t.Errorf("expected version string to contain 'built:', got: %s", got)
+	}
+}
+
+func TestVersionStringDefaults(t *testing.T) {
+	expected := "blogflow version dev (commit: unknown, built: unknown)"
+	got := versionString()
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}


### PR DESCRIPTION
## Summary

Injects version, commit SHA, and build date via `-ldflags` at build time.

### Changes
- **`cmd/blogflow/main.go`**: Added `commit` and `date` build variables, `version` subcommand, and updated `--version` flag output format
- **`Makefile`**: Added `VERSION`, `COMMIT`, `DATE` variables with `-ldflags` injection
- **`Dockerfile`**: Added `VERSION`, `COMMIT`, `DATE` build args passed to `go build`
- **`release.yml`**: Extracts version from git tag (strips `v` prefix) and passes as Docker build arg
- **`publish.yml`**: Uses `sha-<commit>` as version for main branch builds
- **`version_test.go`**: Tests for the `versionString()` function

### Usage
```
blogflow version
# blogflow version 1.2.3 (commit: abc1234, built: 2025-01-01T00:00:00Z)

blogflow --version
# same output
```