### PR TITLE
feat: add K8s manifest linting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,15 +76,16 @@ jobs:
   k8s-lint:
     name: K8s Manifest Lint
     runs-on: ubuntu-latest
+    env:
+      KUBECONFORM_VERSION: v0.7.0
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.26'
-
       - name: Install kubeconform
-        run: go install github.com/yannh/kubeconform/cmd/kubeconform@latest
+        run: |
+          curl -sSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" | tar xz
+          sudo mv kubeconform /usr/local/bin/
+          kubeconform -v
 
       - name: Install Helm
         uses: azure/setup-helm@v4
@@ -93,7 +94,21 @@ jobs:
         run: kubeconform -strict -summary -ignore-filename-pattern 'kustomization.yaml' examples/k8s/
 
       - name: Validate Helm template output
-        run: helm template blogflow deploy/helm/blogflow/ | kubeconform -strict -summary
+        run: |
+          helm template blogflow deploy/helm/blogflow/ \
+            | kubeconform -strict -summary
+          helm template blogflow deploy/helm/blogflow/ \
+            --set sync.strategy=webhook \
+            --set sync.webhook.secret=ci-placeholder \
+            | kubeconform -strict -summary
+          helm template blogflow deploy/helm/blogflow/ \
+            --set sync.strategy=sidecar \
+            --set sync.sidecar.repo=https://github.com/example/content.git \
+            | kubeconform -strict -summary
+          helm template blogflow deploy/helm/blogflow/ \
+            --set ingress.enabled=true \
+            --set pdb.enabled=true \
+            | kubeconform -strict -summary
 
   docker:
     name: Docker Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,32 @@ jobs:
       - name: Helm template render
         run: helm template blogflow deploy/helm/blogflow/ > /dev/null
 
+  k8s-lint:
+    name: K8s Manifest Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: Install kubeconform
+        run: go install github.com/yannh/kubeconform/cmd/kubeconform@latest
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Validate K8s manifests
+        run: kubeconform -strict -summary -ignore-filename-pattern 'kustomization.yaml' examples/k8s/
+
+      - name: Validate Helm template output
+        run: helm template blogflow deploy/helm/blogflow/ | kubeconform -strict -summary
+
   docker:
     name: Docker Build
     runs-on: ubuntu-latest
-    needs: [lint, test, helm-lint]
+    needs: [lint, test, helm-lint, k8s-lint]
     steps:
       - uses: actions/checkout@v4
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint fmt docker clean run dev smoke-test e2e
+.PHONY: build test lint fmt docker clean run dev smoke-test e2e k8s-lint
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -87,6 +87,11 @@ e2e:
 clean:
 	rm -rf bin/ dist/ public/ coverage.out coverage.html
 	go clean -cache -testcache
+
+## k8s-lint: Validate K8s manifests and Helm chart with kubeconform
+k8s-lint:
+	kubeconform -strict -summary -ignore-filename-pattern 'kustomization.yaml' examples/k8s/
+	helm template blogflow deploy/helm/blogflow/ | kubeconform -strict -summary
 
 ## help: Show this help
 help:

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,9 @@ clean:
 k8s-lint:
 	kubeconform -strict -summary -ignore-filename-pattern 'kustomization.yaml' examples/k8s/
 	helm template blogflow deploy/helm/blogflow/ | kubeconform -strict -summary
+	helm template blogflow deploy/helm/blogflow/ --set sync.strategy=webhook --set sync.webhook.secret=ci-placeholder | kubeconform -strict -summary
+	helm template blogflow deploy/helm/blogflow/ --set sync.strategy=sidecar --set sync.sidecar.repo=https://github.com/example/content.git | kubeconform -strict -summary
+	helm template blogflow deploy/helm/blogflow/ --set ingress.enabled=true --set pdb.enabled=true | kubeconform -strict -summary
 
 ## help: Show this help
 help:


### PR DESCRIPTION
Validates `examples/k8s/` and Helm template output with kubeconform.

### Changes
- **CI**: New `k8s-lint` job in `.github/workflows/ci.yml` that installs kubeconform and Helm, validates all K8s manifests in `examples/k8s/` (skipping Kustomization files which lack upstream schemas), and validates Helm template output from `deploy/helm/blogflow/`.
- **Makefile**: New `make k8s-lint` target for local use.

All existing manifests pass validation — no fixes were needed.