### PR TITLE
fix: use semver tag for Trivy scan in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Scan image for critical/high vulnerabilities
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
-          image-ref: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          image-ref: ghcr.io/${{ github.repository }}:${{ steps.version.outputs.value }}
           format: 'table'
           severity: 'CRITICAL,HIGH'
           exit-code: '1'
@@ -77,7 +77,7 @@ jobs:
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         if: always()
         with:
-          image-ref: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          image-ref: ghcr.io/${{ github.repository }}:${{ steps.version.outputs.value }}
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH,MEDIUM'


### PR DESCRIPTION
The release workflow Trivy scan used `github.ref_name` (e.g. `v0.1.0`) but `docker/metadata-action` strips the `v` prefix for semver tags (producing `0.1.0`). Trivy was scanning a non-existent image tag, causing the v0.1.0 release workflow to fail.

Fix: use `steps.version.outputs.value` (the stripped version) instead.