### PR TITLE
feat: add content repository bootstrap on startup

### DIFF
--- a/cmd/blogflow/bootstrap.go
+++ b/cmd/blogflow/bootstrap.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/khaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/gitops"
+)
+
+// bootstrapContent clones (or pulls) the configured content repository into
+// the content directory before the first content scan. This solves the
+// cold-start problem for webhook deployments where no content exists until
+// the first push event.
+//
+// Clone failures are logged but non-fatal — the server continues with
+// embedded defaults for graceful degradation.
+func bootstrapContent(cfg *config.Config, contentPath string, logger *slog.Logger) {
+	repoURL := cfg.Sync.Repo
+	branch := cfg.Sync.Branch
+	if branch == "" {
+		branch = "main"
+	}
+
+	dest := contentPath
+	if dest == "" {
+		dest = "content"
+	}
+
+	logger.Info("content bootstrap: cloning repository", "repo", repoURL, "branch", branch, "dest", dest)
+
+	authCfg, err := gitops.LoadAuthFromEnv(logger)
+	if err != nil {
+		logger.Error("content bootstrap: failed to load git auth", "error", err)
+		return
+	}
+
+	puller, err := gitops.NewPuller(authCfg, logger)
+	if err != nil {
+		logger.Error("content bootstrap: failed to create git puller", "error", err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	changed, err := puller.CloneOrPull(ctx, repoURL, branch, dest)
+	if err != nil {
+		logger.Error("content bootstrap: clone/pull failed — continuing with defaults",
+			"repo", repoURL, "error", err)
+		return
+	}
+
+	if changed {
+		logger.Info("content bootstrap: repository cloned successfully", "repo", repoURL, "branch", branch)
+	} else {
+		logger.Info("content bootstrap: repository already up to date", "repo", repoURL, "branch", branch)
+	}
+}

--- a/cmd/blogflow/bootstrap.go
+++ b/cmd/blogflow/bootstrap.go
@@ -9,6 +9,9 @@ import (
 	"github.com/khaines/blogflow/internal/gitops"
 )
 
+// safeRepoURL returns a sanitized repo URL safe for logging.
+func safeRepoURL(raw string) string { return gitops.SanitizeURL(raw) }
+
 // bootstrapContent clones (or pulls) the configured content repository into
 // the content directory before the first content scan. This solves the
 // cold-start problem for webhook deployments where no content exists until
@@ -28,7 +31,7 @@ func bootstrapContent(cfg *config.Config, contentPath string, logger *slog.Logge
 		dest = "content"
 	}
 
-	logger.Info("content bootstrap: cloning repository", "repo", repoURL, "branch", branch, "dest", dest)
+	logger.Info("content bootstrap: cloning repository", "repo", safeRepoURL(repoURL), "branch", branch, "dest", dest)
 
 	authCfg, err := gitops.LoadAuthFromEnv(logger)
 	if err != nil {
@@ -48,13 +51,13 @@ func bootstrapContent(cfg *config.Config, contentPath string, logger *slog.Logge
 	changed, err := puller.CloneOrPull(ctx, repoURL, branch, dest)
 	if err != nil {
 		logger.Error("content bootstrap: clone/pull failed — continuing with defaults",
-			"repo", repoURL, "error", err)
+			"repo", safeRepoURL(repoURL), "error", err)
 		return
 	}
 
 	if changed {
-		logger.Info("content bootstrap: repository cloned successfully", "repo", repoURL, "branch", branch)
+		logger.Info("content bootstrap: repository cloned successfully", "repo", safeRepoURL(repoURL), "branch", branch)
 	} else {
-		logger.Info("content bootstrap: repository already up to date", "repo", repoURL, "branch", branch)
+		logger.Info("content bootstrap: repository already up to date", "repo", safeRepoURL(repoURL), "branch", branch)
 	}
 }

--- a/cmd/blogflow/bootstrap_test.go
+++ b/cmd/blogflow/bootstrap_test.go
@@ -22,12 +22,6 @@ func newLocalBareRepo(t *testing.T) string {
 		t.Fatalf("init source repo: %v", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(srcDir, "posts", ".gitkeep"), nil, 0o600); err != nil {
-		if err := os.MkdirAll(filepath.Join(srcDir, "posts"), 0o750); err != nil {
-			t.Fatalf("mkdir: %v", err)
-		}
-	}
-
 	postContent := "---\ntitle: Bootstrap Test\ndate: 2024-01-01T00:00:00Z\n---\nBootstrap content\n"
 	if err := os.MkdirAll(filepath.Join(srcDir, "posts"), 0o750); err != nil {
 		t.Fatalf("mkdir posts: %v", err)
@@ -126,7 +120,7 @@ func TestBootstrapContent_DefaultBranch(t *testing.T) {
 }
 
 func TestBootstrapContent_DefaultContentPath(t *testing.T) {
-	t.Parallel()
+	// NOT parallel: os.Chdir is process-global.
 
 	bareRepo := newLocalBareRepo(t)
 

--- a/cmd/blogflow/bootstrap_test.go
+++ b/cmd/blogflow/bootstrap_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/khaines/blogflow/internal/config"
+)
+
+// newLocalBareRepo creates a bare repo with one commit on "master" for testing.
+func newLocalBareRepo(t *testing.T) string {
+	t.Helper()
+
+	srcDir := filepath.Join(t.TempDir(), "src")
+	repo, err := git.PlainInit(srcDir, false)
+	if err != nil {
+		t.Fatalf("init source repo: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(srcDir, "posts", ".gitkeep"), nil, 0o600); err != nil {
+		if err := os.MkdirAll(filepath.Join(srcDir, "posts"), 0o750); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+
+	postContent := "---\ntitle: Bootstrap Test\ndate: 2024-01-01T00:00:00Z\n---\nBootstrap content\n"
+	if err := os.MkdirAll(filepath.Join(srcDir, "posts"), 0o750); err != nil {
+		t.Fatalf("mkdir posts: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "posts", "test.md"), []byte(postContent), 0o600); err != nil {
+		t.Fatalf("write post: %v", err)
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	if _, err := wt.Add("posts/test.md"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if _, err := wt.Commit("initial commit", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "test",
+			Email: "test@test.com",
+			When:  time.Now(),
+		},
+	}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	bareDir := filepath.Join(t.TempDir(), "bare")
+	if _, err := git.PlainClone(bareDir, true, &git.CloneOptions{URL: srcDir}); err != nil {
+		t.Fatalf("bare clone: %v", err)
+	}
+
+	return bareDir
+}
+
+func TestBootstrapContent_ClonesRepo(t *testing.T) {
+	t.Parallel()
+
+	bareRepo := newLocalBareRepo(t)
+	destDir := filepath.Join(t.TempDir(), "content")
+
+	cfg := config.Default()
+	cfg.Sync.Repo = bareRepo
+	cfg.Sync.Branch = "master"
+
+	logger := slog.Default()
+
+	bootstrapContent(cfg, destDir, logger)
+
+	// Verify the cloned content exists.
+	postPath := filepath.Join(destDir, "posts", "test.md")
+	data, err := os.ReadFile(postPath) //nolint:gosec // G304: test reads known path
+	if err != nil {
+		t.Fatalf("expected cloned post file at %s: %v", postPath, err)
+	}
+	if len(data) == 0 {
+		t.Fatal("cloned post file is empty")
+	}
+}
+
+func TestBootstrapContent_CloneFailureIsNonFatal(t *testing.T) {
+	t.Parallel()
+
+	destDir := filepath.Join(t.TempDir(), "content")
+
+	cfg := config.Default()
+	cfg.Sync.Repo = "https://invalid.example.com/nonexistent/repo.git"
+	cfg.Sync.Branch = "main"
+
+	logger := slog.Default()
+
+	// Should not panic — clone failure is logged but non-fatal.
+	bootstrapContent(cfg, destDir, logger)
+
+	// Dest dir may or may not exist; the important thing is no panic/crash.
+	if _, err := os.Stat(filepath.Join(destDir, ".git")); err == nil {
+		t.Error("did not expect a .git dir after a failed clone")
+	}
+}
+
+func TestBootstrapContent_DefaultBranch(t *testing.T) {
+	t.Parallel()
+
+	bareRepo := newLocalBareRepo(t)
+	destDir := filepath.Join(t.TempDir(), "content")
+
+	cfg := config.Default()
+	cfg.Sync.Repo = bareRepo
+	cfg.Sync.Branch = "" // should default to "main"
+
+	logger := slog.Default()
+
+	// "main" branch doesn't exist in our test repo (it uses "master"),
+	// so this should fail gracefully.
+	bootstrapContent(cfg, destDir, logger)
+
+	// Non-fatal: server would continue.
+}
+
+func TestBootstrapContent_DefaultContentPath(t *testing.T) {
+	t.Parallel()
+
+	bareRepo := newLocalBareRepo(t)
+
+	// Use a temp dir as the working directory to avoid polluting the real cwd.
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	cfg := config.Default()
+	cfg.Sync.Repo = bareRepo
+	cfg.Sync.Branch = "master"
+
+	logger := slog.Default()
+
+	// Empty contentPath should default to "content".
+	bootstrapContent(cfg, "", logger)
+
+	postPath := filepath.Join(tmpDir, "content", "posts", "test.md")
+	if _, err := os.Stat(postPath); err != nil {
+		t.Fatalf("expected cloned post at default content path %s: %v", postPath, err)
+	}
+}
+
+func TestBootstrapContent_PullExisting(t *testing.T) {
+	t.Parallel()
+
+	bareRepo := newLocalBareRepo(t)
+	destDir := filepath.Join(t.TempDir(), "content")
+
+	cfg := config.Default()
+	cfg.Sync.Repo = bareRepo
+	cfg.Sync.Branch = "master"
+
+	logger := slog.Default()
+
+	// First clone.
+	bootstrapContent(cfg, destDir, logger)
+
+	// Second call should pull (not re-clone) and succeed.
+	bootstrapContent(cfg, destDir, logger)
+
+	postPath := filepath.Join(destDir, "posts", "test.md")
+	if _, err := os.Stat(postPath); err != nil {
+		t.Fatalf("expected post file after pull: %v", err)
+	}
+}

--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -51,6 +51,8 @@ func main() {
 	port := flag.Int("port", 0, "HTTP port (overrides config)")
 	dev := flag.Bool("dev", false, "Development mode (verbose logging)")
 	showVersion := flag.Bool("version", false, "Print version and exit")
+	contentRepo := flag.String("content-repo", "", "Git repository URL for content bootstrap")
+	contentBranch := flag.String("content-branch", "", "Branch to clone for content bootstrap (default: main)")
 	flag.Parse()
 
 	if *showVersion {
@@ -103,7 +105,22 @@ func main() {
 		cfgCopy.Server.Port = *port
 		cfg = &cfgCopy
 	}
+	if *contentRepo != "" || *contentBranch != "" {
+		cfgCopy := *cfg
+		if *contentRepo != "" {
+			cfgCopy.Sync.Repo = *contentRepo
+		}
+		if *contentBranch != "" {
+			cfgCopy.Sync.Branch = *contentBranch
+		}
+		cfg = &cfgCopy
+	}
 	logger.Info("configuration loaded", "port", cfg.Server.Port, "theme", cfg.Theme.Name)
+
+	// 2b. Content bootstrap: clone repo before scanning
+	if cfg.Sync.Repo != "" {
+		bootstrapContent(cfg, *contentPath, logger)
+	}
 
 	// 3. Initialize content pipeline
 	renderer := content.NewRenderer()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,6 +72,8 @@ type CacheConfig struct {
 // SyncConfig holds content sync strategy settings.
 type SyncConfig struct {
 	Strategy string        `yaml:"strategy"`
+	Repo     string        `yaml:"repo"`
+	Branch   string        `yaml:"branch"`
 	Webhook  WebhookConfig `yaml:"webhook"`
 }
 
@@ -130,6 +132,7 @@ func Default() *Config {
 		},
 		Sync: SyncConfig{
 			Strategy: "watch",
+			Branch:   "main",
 			Webhook: WebhookConfig{
 				Path:          "/api/webhook",
 				AllowedEvents: []string{"push"},

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -329,6 +329,14 @@ var envMap = map[string]func(*Config, string) error{
 		c.Sync.Strategy = v
 		return nil
 	},
+	"BLOGFLOW_SYNC_REPO": func(c *Config, v string) error {
+		c.Sync.Repo = v
+		return nil
+	},
+	"BLOGFLOW_SYNC_BRANCH": func(c *Config, v string) error {
+		c.Sync.Branch = v
+		return nil
+	},
 	"BLOGFLOW_WEBHOOK_SECRET": func(c *Config, v string) error {
 		c.Sync.Webhook.Secret = v
 		return nil

--- a/internal/gitops/pull.go
+++ b/internal/gitops/pull.go
@@ -67,8 +67,8 @@ func (p *Puller) CloneOrPull(ctx context.Context, repoURL, branch, destPath stri
 	return true, p.clone(ctx, repoURL, branch, destPath)
 }
 
-// sanitizeURL strips embedded credentials from a URL for safe logging.
-func sanitizeURL(raw string) string {
+// SanitizeURL strips embedded credentials from a URL for safe logging.
+func SanitizeURL(raw string) string {
 	u, err := url.Parse(raw)
 	if err != nil || u.User == nil {
 		return raw
@@ -78,7 +78,7 @@ func sanitizeURL(raw string) string {
 }
 
 func (p *Puller) clone(ctx context.Context, repoURL, branch, destPath string) error {
-	p.logger.Info("cloning repository", "url", sanitizeURL(repoURL), "branch", branch, "dest", destPath)
+	p.logger.Info("cloning repository", "url", SanitizeURL(repoURL), "branch", branch, "dest", destPath)
 
 	opts := &git.CloneOptions{
 		URL:           repoURL,
@@ -90,10 +90,10 @@ func (p *Puller) clone(ctx context.Context, repoURL, branch, destPath string) er
 
 	_, err := git.PlainCloneContext(ctx, destPath, false, opts)
 	if err != nil {
-		return fmt.Errorf("gitops: clone %s: %w", sanitizeURL(repoURL), err)
+		return fmt.Errorf("gitops: clone %s: %w", SanitizeURL(repoURL), err)
 	}
 
-	p.logger.Info("clone complete", "url", sanitizeURL(repoURL))
+	p.logger.Info("clone complete", "url", SanitizeURL(repoURL))
 	return nil
 }
 

--- a/internal/gitops/pull_test.go
+++ b/internal/gitops/pull_test.go
@@ -332,9 +332,9 @@ func TestSanitizeURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := sanitizeURL(tt.in)
+			got := SanitizeURL(tt.in)
 			if got != tt.want {
-				t.Errorf("sanitizeURL(%q) = %q, want %q", tt.in, got, tt.want)
+				t.Errorf("SanitizeURL(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
When `sync.repo` is configured, BlogFlow clones the content repository via go-git before starting the server. This solves the cold-start problem for webhook deployments where no content exists until the first push event.

## Changes

- **`internal/config/config.go`**: Added `Repo` and `Branch` fields to `SyncConfig` (YAML: `sync.repo`, `sync.branch`)
- **`internal/config/loader.go`**: Added env var overrides `BLOGFLOW_SYNC_REPO` and `BLOGFLOW_SYNC_BRANCH`
- **`cmd/blogflow/main.go`**: Added `--content-repo` and `--content-branch` CLI flags; calls bootstrap before content scan
- **`cmd/blogflow/bootstrap.go`**: New `bootstrapContent()` function — creates a Puller, calls `CloneOrPull`, logs result; clone failure is non-fatal (graceful degradation)
- **`cmd/blogflow/bootstrap_test.go`**: Tests for clone success, clone failure (non-fatal), default branch/path, and pull-on-existing

## Configuration

```yaml
sync:
  repo: https://github.com/org/blog-content.git
  branch: main  # default
```

Or via CLI flags / env vars:
```
--content-repo=https://github.com/org/blog-content.git
--content-branch=main
BLOGFLOW_SYNC_REPO=https://github.com/org/blog-content.git
BLOGFLOW_SYNC_BRANCH=main
```