### PR TITLE
feat: enhance /readyz with content availability check

### DIFF
--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -175,6 +175,7 @@ func main() {
 		routeOpts.WebhookHandler = ws.Handler()
 	}
 	srv.RegisterRoutes(routeOpts)
+	srv.SetContentChecker(deps)
 
 	// 11. Start sync strategy (non-fatal: a blog with embedded defaults has nothing to watch)
 	syncCtx, syncCancel := context.WithCancel(context.Background())

--- a/internal/server/handlers/handlers.go
+++ b/internal/server/handlers/handlers.go
@@ -37,6 +37,15 @@ func (d *Deps) LoadIndex() *content.Index { return d.index.Load() }
 // SetIndex atomically replaces the content index. Safe for concurrent use.
 func (d *Deps) SetIndex(idx *content.Index) { d.index.Store(idx) }
 
+// PostCount returns the number of posts in the current index.
+// Implements server.ContentChecker.
+func (d *Deps) PostCount() int {
+	if idx := d.index.Load(); idx != nil {
+		return len(idx.Posts)
+	}
+	return 0
+}
+
 // PageData is the top-level data passed to all templates.
 type PageData struct {
 	Site       config.SiteConfig

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,16 +18,23 @@ import (
 	"github.com/khaines/blogflow/internal/config"
 )
 
+// ContentChecker reports how many posts are available. Implementations must
+// be safe for concurrent use (the handler calls PostCount on every request).
+type ContentChecker interface {
+	PostCount() int
+}
+
 // Server is the BlogFlow HTTP server.
 type Server struct {
-	httpServer *http.Server
-	mux        *http.ServeMux
-	config     *config.Config
-	logger     *slog.Logger
-	ready      atomic.Bool
-	readyCh    chan struct{}
-	readyOnce  sync.Once
-	ipResolver *ClientIPResolver
+	httpServer     *http.Server
+	mux            *http.ServeMux
+	config         *config.Config
+	logger         *slog.Logger
+	ready          atomic.Bool
+	readyCh        chan struct{}
+	readyOnce      sync.Once
+	ipResolver     *ClientIPResolver
+	contentChecker atomic.Pointer[ContentChecker]
 }
 
 // New creates a new BlogFlow server.
@@ -116,6 +123,7 @@ func (s *Server) RegisterRoutes(opts RouteOptions) {
 	// Health checks
 	s.mux.HandleFunc("GET /healthz", s.healthHandler)
 	s.mux.HandleFunc("GET /readyz", s.readyHandler)
+	s.mux.HandleFunc("GET /readyz/content", s.contentReadyHandler)
 
 	// Prometheus metrics (registered directly on the mux, outside metrics middleware)
 	s.mux.Handle("GET /metrics", MetricsHandler())
@@ -266,6 +274,10 @@ func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
 // SetReady marks the server as ready (or not) for traffic.
 func (s *Server) SetReady(v bool) { s.ready.Store(v) }
 
+// SetContentChecker installs a ContentChecker used by /readyz and
+// /readyz/content to report content availability. Safe for concurrent use.
+func (s *Server) SetContentChecker(cc ContentChecker) { s.contentChecker.Store(&cc) }
+
 func (s *Server) readyHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain")
 	w.Header().Set("Cache-Control", "no-store")
@@ -274,8 +286,33 @@ func (s *Server) readyHandler(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprint(w, "not ready")
 		return
 	}
+
+	strict := r.URL.Query().Get("strict") == "true"
+	if cc := s.contentChecker.Load(); cc != nil && (*cc).PostCount() == 0 {
+		if strict {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = fmt.Fprint(w, "not ready (no content)")
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "ready (no content)")
+		return
+	}
+
 	w.WriteHeader(http.StatusOK)
 	_, _ = fmt.Fprint(w, "ready")
+}
+
+func (s *Server) contentReadyHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set("Cache-Control", "no-store")
+	if cc := s.contentChecker.Load(); cc != nil && (*cc).PostCount() > 0 {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "content available")
+		return
+	}
+	w.WriteHeader(http.StatusServiceUnavailable)
+	_, _ = fmt.Fprint(w, "no content")
 }
 
 // responseWriter wraps http.ResponseWriter to capture the status code.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -276,7 +276,14 @@ func (s *Server) SetReady(v bool) { s.ready.Store(v) }
 
 // SetContentChecker installs a ContentChecker used by /readyz and
 // /readyz/content to report content availability. Safe for concurrent use.
-func (s *Server) SetContentChecker(cc ContentChecker) { s.contentChecker.Store(&cc) }
+// Passing nil clears the checker (readyz falls back to basic ready/not-ready).
+func (s *Server) SetContentChecker(cc ContentChecker) {
+	if cc == nil {
+		s.contentChecker.Store(nil)
+		return
+	}
+	s.contentChecker.Store(&cc)
+}
 
 func (s *Server) readyHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -129,6 +129,146 @@ func TestReadyEndpoint(t *testing.T) {
 	}
 }
 
+// stubContentChecker implements ContentChecker for tests.
+type stubContentChecker struct {
+	posts int
+}
+
+func (s *stubContentChecker) PostCount() int { return s.posts }
+
+func TestReadyEndpoint_WithContent(t *testing.T) {
+	s := newTestServer(t)
+	s.SetReady(true)
+	s.SetContentChecker(&stubContentChecker{posts: 5})
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != "ready" {
+		t.Errorf("body = %q, want %q", body, "ready")
+	}
+}
+
+func TestReadyEndpoint_NoContent_Graceful(t *testing.T) {
+	s := newTestServer(t)
+	s.SetReady(true)
+	s.SetContentChecker(&stubContentChecker{posts: 0})
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != "ready (no content)" {
+		t.Errorf("body = %q, want %q", body, "ready (no content)")
+	}
+}
+
+func TestReadyEndpoint_NoContent_Strict(t *testing.T) {
+	s := newTestServer(t)
+	s.SetReady(true)
+	s.SetContentChecker(&stubContentChecker{posts: 0})
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz?strict=true", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "no content") {
+		t.Errorf("body = %q, want containing %q", body, "no content")
+	}
+}
+
+func TestReadyEndpoint_StrictWithContent(t *testing.T) {
+	s := newTestServer(t)
+	s.SetReady(true)
+	s.SetContentChecker(&stubContentChecker{posts: 3})
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz?strict=true", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != "ready" {
+		t.Errorf("body = %q, want %q", body, "ready")
+	}
+}
+
+func TestReadyEndpoint_NoContentChecker(t *testing.T) {
+	s := newTestServer(t)
+	s.SetReady(true)
+	// No content checker set — should behave as before
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != "ready" {
+		t.Errorf("body = %q, want %q", body, "ready")
+	}
+}
+
+func TestContentReadyEndpoint_WithContent(t *testing.T) {
+	s := newTestServer(t)
+	s.SetContentChecker(&stubContentChecker{posts: 5})
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz/content", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != "content available" {
+		t.Errorf("body = %q, want %q", body, "content available")
+	}
+}
+
+func TestContentReadyEndpoint_NoContent(t *testing.T) {
+	s := newTestServer(t)
+	s.SetContentChecker(&stubContentChecker{posts: 0})
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz/content", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	if body := rec.Body.String(); body != "no content" {
+		t.Errorf("body = %q, want %q", body, "no content")
+	}
+}
+
+func TestContentReadyEndpoint_NoChecker(t *testing.T) {
+	s := newTestServer(t)
+	// No content checker set
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz/content", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	if body := rec.Body.String(); body != "no content" {
+		t.Errorf("body = %q, want %q", body, "no content")
+	}
+}
+
 func TestSecurityHeaders(t *testing.T) {
 	s := newTestServer(t)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -221,6 +221,40 @@ func TestReadyEndpoint_NoContentChecker(t *testing.T) {
 	}
 }
 
+func TestReadyEndpoint_NoContentChecker_Strict(t *testing.T) {
+	s := newTestServer(t)
+	s.SetReady(true)
+	// No content checker — strict should be ignored (backward compat)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz?strict=true", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != "ready" {
+		t.Errorf("body = %q, want %q", body, "ready")
+	}
+}
+
+func TestReadyEndpoint_NilContentChecker(t *testing.T) {
+	s := newTestServer(t)
+	s.SetReady(true)
+	s.SetContentChecker(nil) // must not panic on subsequent requests
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != "ready" {
+		t.Errorf("body = %q, want %q", body, "ready")
+	}
+}
+
 func TestContentReadyEndpoint_WithContent(t *testing.T) {
 	s := newTestServer(t)
 	s.SetContentChecker(&stubContentChecker{posts: 5})


### PR DESCRIPTION
Enhances `/readyz` to reflect content availability, enabling K8s probes to distinguish between "server ready" and "server ready with content."

## Changes

- **`/readyz`** now reports content status:
  - `200 "ready"` — server ready, posts available
  - `200 "ready (no content)"` — server ready, zero posts (graceful)
  - `503 "not ready"` — server not ready
  - `?strict=true` → returns `503` when no content (for probes that require content)

- **`/readyz/content`** (new endpoint):
  - `200 "content available"` — posts > 0
  - `503 "no content"` — zero posts
  - K8s probes can choose `/readyz` (lenient) or `/readyz/content` (strict)

- **`ContentChecker` interface** in the server package decouples health checks from content internals
- **`handlers.Deps`** implements `ContentChecker` via `PostCount()` method
- **10 new tests** covering all readyz and content-readyz scenarios

## K8s Usage

```yaml
readinessProbe:
  httpGet:
    path: /readyz              # lenient: ready even without content
    # path: /readyz?strict=true  # strict: 503 until content loads
    # path: /readyz/content      # content-only check
    port: 8080
```