### PR TITLE
feat: add background poll strategy for content sync

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,10 +71,11 @@ type CacheConfig struct {
 
 // SyncConfig holds content sync strategy settings.
 type SyncConfig struct {
-	Strategy string        `yaml:"strategy"`
-	Repo     string        `yaml:"repo"`
-	Branch   string        `yaml:"branch"`
-	Webhook  WebhookConfig `yaml:"webhook"`
+	Strategy     string        `yaml:"strategy"`
+	Repo         string        `yaml:"repo"`
+	Branch       string        `yaml:"branch"`
+	PollInterval string        `yaml:"poll_interval"` // Go duration (e.g. "5m"); empty = disabled
+	Webhook      WebhookConfig `yaml:"webhook"`
 }
 
 // WebhookConfig holds webhook receiver settings.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -354,7 +354,7 @@ func TestConfigError_ErrorIncludesFields(t *testing.T) {
 
 func TestValidate_InvalidStrategy(t *testing.T) {
 	cfg := Default()
-	cfg.Sync.Strategy = "poll"
+	cfg.Sync.Strategy = "magic"
 	err := Validate(cfg)
 	if err == nil {
 		t.Fatal("expected validation error for invalid strategy")

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -349,6 +349,10 @@ var envMap = map[string]func(*Config, string) error{
 		c.Sync.Webhook.RateLimit = n
 		return nil
 	},
+	"BLOGFLOW_SYNC_POLL_INTERVAL": func(c *Config, v string) error {
+		c.Sync.PollInterval = v
+		return nil
+	},
 	"BLOGFLOW_FEED_TYPE": func(c *Config, v string) error {
 		c.Feed.Type = v
 		return nil
@@ -393,7 +397,7 @@ func applyEnvOverrides(cfg *Config) ([]string, error) {
 
 // Package-level validation maps.
 var (
-	validStrategies    = map[string]bool{"watch": true, "webhook": true, "sidecar": true}
+	validStrategies    = map[string]bool{"watch": true, "webhook": true, "sidecar": true, "poll": true}
 	validFeedTypes     = map[string]bool{"atom": true, "rss": true}
 	validAllowedEvents = map[string]bool{
 		"push": true, "ping": true, "pull_request": true,
@@ -536,12 +540,39 @@ func Validate(cfg *Config) error {
 		}
 	}
 
-	// Sync.Strategy: must be watch, webhook, or sidecar
+	// Sync.Strategy: must be watch, webhook, sidecar, or poll
 	if !validStrategies[cfg.Sync.Strategy] {
 		errs = append(errs, FieldError{
 			Field:   "sync.strategy",
 			Value:   cfg.Sync.Strategy,
-			Message: "must be one of: watch, webhook, sidecar",
+			Message: "must be one of: watch, webhook, sidecar, poll",
+		})
+	}
+
+	// Sync.PollInterval: if set, must be a valid duration >= 30s
+	if cfg.Sync.PollInterval != "" {
+		d, err := time.ParseDuration(cfg.Sync.PollInterval)
+		if err != nil {
+			errs = append(errs, FieldError{
+				Field:   "sync.poll_interval",
+				Value:   cfg.Sync.PollInterval,
+				Message: "must be a valid Go duration (e.g. \"5m\")",
+			})
+		} else if d < 30*time.Second {
+			errs = append(errs, FieldError{
+				Field:   "sync.poll_interval",
+				Value:   cfg.Sync.PollInterval,
+				Message: "must be >= 30s to avoid excessive load",
+			})
+		}
+	}
+
+	// Sync.Strategy "poll" requires poll_interval
+	if cfg.Sync.Strategy == "poll" && cfg.Sync.PollInterval == "" {
+		errs = append(errs, FieldError{
+			Field:   "sync.poll_interval",
+			Value:   cfg.Sync.PollInterval,
+			Message: "must be set when strategy is \"poll\"",
 		})
 	}
 

--- a/internal/gitops/poll.go
+++ b/internal/gitops/poll.go
@@ -19,8 +19,11 @@ type PollStrategy struct {
 	repoURL  string
 	branch   string
 	destPath string
+	cancel   context.CancelFunc
 	stopOnce sync.Once
 	done     chan struct{}
+	mu       sync.Mutex
+	started  bool
 }
 
 // PullExecutor abstracts the git pull operation for testing.
@@ -58,19 +61,36 @@ func (p *PollStrategy) SetPuller(puller PullExecutor, repoURL, branch, destPath 
 
 // Start begins periodic polling in a background goroutine.
 func (p *PollStrategy) Start(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.started {
+		return fmt.Errorf("gitops: poll strategy already started")
+	}
 	if p.puller == nil {
 		return fmt.Errorf("gitops: poll strategy has no puller configured — call SetPuller before Start")
 	}
+	ctx, p.cancel = context.WithCancel(ctx) //nolint:gosec // G118: cancel is stored and called in Stop()
+	p.started = true
 	p.logger.Info("poll strategy started", "interval", p.interval)
 	go p.loop(ctx)
 	return nil
 }
 
 // Stop gracefully shuts down polling. Idempotent via sync.Once.
+// Blocks until the background goroutine exits.
 func (p *PollStrategy) Stop(_ context.Context) error {
 	p.stopOnce.Do(func() {
+		if p.cancel != nil {
+			p.cancel()
+		}
 		p.logger.Info("poll strategy stopped")
 	})
+	p.mu.Lock()
+	started := p.started
+	p.mu.Unlock()
+	if started {
+		<-p.done
+	}
 	return nil
 }
 

--- a/internal/gitops/poll.go
+++ b/internal/gitops/poll.go
@@ -1,0 +1,131 @@
+package gitops
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// PollStrategy periodically pulls from a git remote and reloads content
+// when changes are detected. This ensures all replicas eventually sync,
+// even when webhook delivery only reaches one pod.
+type PollStrategy struct {
+	puller   PullExecutor
+	reloader ContentReloader
+	logger   *slog.Logger
+	interval time.Duration
+	repoURL  string
+	branch   string
+	destPath string
+	stopOnce sync.Once
+	done     chan struct{}
+}
+
+// PullExecutor abstracts the git pull operation for testing.
+type PullExecutor interface {
+	CloneOrPull(ctx context.Context, repoURL, branch, destPath string) (changed bool, err error)
+}
+
+// NewPollStrategy creates a poll-based sync strategy.
+// The puller and repo details can be wired after construction via SetPuller.
+func NewPollStrategy(interval time.Duration, reloader ContentReloader, logger *slog.Logger) (*PollStrategy, error) {
+	if reloader == nil {
+		return nil, fmt.Errorf("gitops: poll strategy requires a content reloader")
+	}
+	if interval < 30*time.Second {
+		return nil, fmt.Errorf("gitops: poll interval must be >= 30s, got %s", interval)
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &PollStrategy{
+		reloader: reloader,
+		logger:   logger,
+		interval: interval,
+		done:     make(chan struct{}),
+	}, nil
+}
+
+// SetPuller configures the git puller and repo details. Must be called before Start.
+func (p *PollStrategy) SetPuller(puller PullExecutor, repoURL, branch, destPath string) {
+	p.puller = puller
+	p.repoURL = repoURL
+	p.branch = branch
+	p.destPath = destPath
+}
+
+// Start begins periodic polling in a background goroutine.
+func (p *PollStrategy) Start(ctx context.Context) error {
+	if p.puller == nil {
+		return fmt.Errorf("gitops: poll strategy has no puller configured — call SetPuller before Start")
+	}
+	p.logger.Info("poll strategy started", "interval", p.interval)
+	go p.loop(ctx)
+	return nil
+}
+
+// Stop gracefully shuts down polling. Idempotent via sync.Once.
+func (p *PollStrategy) Stop(_ context.Context) error {
+	p.stopOnce.Do(func() {
+		p.logger.Info("poll strategy stopped")
+	})
+	return nil
+}
+
+// Name returns the strategy name.
+func (p *PollStrategy) Name() string { return "poll" }
+
+// NewPollStrategyForTest creates a PollStrategy with no minimum interval
+// guard. Intended for unit tests that need sub-second tick intervals.
+func NewPollStrategyForTest(interval time.Duration, reloader ContentReloader, logger *slog.Logger) (*PollStrategy, error) {
+	if reloader == nil {
+		return nil, fmt.Errorf("gitops: poll strategy requires a content reloader")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &PollStrategy{
+		reloader: reloader,
+		logger:   logger,
+		interval: interval,
+		done:     make(chan struct{}),
+	}, nil
+}
+
+func (p *PollStrategy) loop(ctx context.Context) {
+	defer close(p.done)
+
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.tick(ctx)
+		}
+	}
+}
+
+func (p *PollStrategy) tick(ctx context.Context) {
+	p.logger.Debug("poll tick: pulling content")
+
+	changed, err := p.puller.CloneOrPull(ctx, p.repoURL, p.branch, p.destPath)
+	if err != nil {
+		p.logger.Error("poll pull failed", "error", err)
+		return
+	}
+
+	if !changed {
+		p.logger.Debug("poll tick: no changes")
+		return
+	}
+
+	p.logger.Info("poll tick: content changed, reloading")
+	if err := p.reloader(); err != nil {
+		p.logger.Error("poll content reload failed", "error", err)
+	}
+}

--- a/internal/gitops/poll_test.go
+++ b/internal/gitops/poll_test.go
@@ -1,0 +1,293 @@
+package gitops_test
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/khaines/blogflow/internal/gitops"
+)
+
+// fakePuller implements gitops.PullExecutor for testing.
+type fakePuller struct {
+	changed atomic.Bool
+	err     atomic.Value // stores error
+	calls   atomic.Int64
+}
+
+func (f *fakePuller) CloneOrPull(_ context.Context, _, _, _ string) (bool, error) {
+	f.calls.Add(1)
+	if v := f.err.Load(); v != nil {
+		return false, v.(error)
+	}
+	return f.changed.Load(), nil
+}
+
+func newTestPollStrategy(t *testing.T, interval time.Duration, puller gitops.PullExecutor, reloader gitops.ContentReloader) *gitops.PollStrategy {
+	t.Helper()
+	s, err := gitops.NewPollStrategy(interval, reloader, logger())
+	if err != nil {
+		t.Fatalf("NewPollStrategy: %v", err)
+	}
+	s.SetPuller(puller, "https://example.com/repo.git", "main", t.TempDir())
+	return s
+}
+
+func TestPollStrategy_TriggersAtInterval(t *testing.T) {
+	t.Parallel()
+
+	puller := &fakePuller{}
+	puller.changed.Store(false)
+
+	s := newTestPollStrategy(t, 30*time.Second, puller, noop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := s.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait for at least one tick (we can't wait 30s in a test, so we
+	// verify the goroutine started and cancel promptly).
+	// The real interval test uses a short interval via direct construction.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	if err := s.Stop(ctx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+}
+
+func TestPollStrategy_ChangedContentTriggersReload(t *testing.T) {
+	t.Parallel()
+
+	puller := &fakePuller{}
+	puller.changed.Store(true)
+
+	var reloadCount atomic.Int64
+	reloader := func() error {
+		reloadCount.Add(1)
+		return nil
+	}
+
+	// Use minimum allowed interval; we'll tick manually via context timing.
+	s := newTestPollStrategy(t, 30*time.Second, puller, reloader)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := s.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Directly invoke tick via exported-for-test helper isn't available,
+	// so we test the behaviour end-to-end by exercising Tick through
+	// the internal poll loop. Since 30s is too slow for tests, we verify
+	// the contract by constructing a strategy with a fast ticker.
+	cancel()
+	_ = s.Stop(ctx)
+
+	// Verify contract: construct with fast interval and check reload fires.
+	puller2 := &fakePuller{}
+	puller2.changed.Store(true)
+	var reloadCount2 atomic.Int64
+	reloader2 := func() error {
+		reloadCount2.Add(1)
+		return nil
+	}
+
+	// Build directly with a fast interval (below the public constructor's
+	// 30s guard, so we use an internal helper approach):
+	// We test the tick logic by exercising the full strategy at 30s minimum.
+	// For a fast test, we bypass the min-interval guard.
+	s2, err := gitops.NewPollStrategyForTest(100*time.Millisecond, reloader2, logger())
+	if err != nil {
+		t.Fatalf("NewPollStrategyForTest: %v", err)
+	}
+	s2.SetPuller(puller2, "https://example.com/repo.git", "main", t.TempDir())
+
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	if err := s2.Start(ctx2); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait for a few ticks
+	time.Sleep(350 * time.Millisecond)
+	cancel2()
+	_ = s2.Stop(ctx2)
+
+	if n := reloadCount2.Load(); n == 0 {
+		t.Error("expected reload to be called at least once when content changed")
+	}
+	if n := puller2.calls.Load(); n == 0 {
+		t.Error("expected puller to be called at least once")
+	}
+}
+
+func TestPollStrategy_UnchangedContentSkipsReload(t *testing.T) {
+	t.Parallel()
+
+	puller := &fakePuller{}
+	puller.changed.Store(false)
+
+	var reloadCount atomic.Int64
+	reloader := func() error {
+		reloadCount.Add(1)
+		return nil
+	}
+
+	s, err := gitops.NewPollStrategyForTest(100*time.Millisecond, reloader, logger())
+	if err != nil {
+		t.Fatalf("NewPollStrategyForTest: %v", err)
+	}
+	s.SetPuller(puller, "https://example.com/repo.git", "main", t.TempDir())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := s.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	time.Sleep(350 * time.Millisecond)
+	cancel()
+	_ = s.Stop(ctx)
+
+	if n := puller.calls.Load(); n == 0 {
+		t.Error("expected puller to be called at least once")
+	}
+	if n := reloadCount.Load(); n != 0 {
+		t.Errorf("expected reload to NOT be called when unchanged, got %d calls", n)
+	}
+}
+
+func TestPollStrategy_ContextCancellationStops(t *testing.T) {
+	t.Parallel()
+
+	puller := &fakePuller{}
+	puller.changed.Store(false)
+
+	s, err := gitops.NewPollStrategyForTest(100*time.Millisecond, noop, logger())
+	if err != nil {
+		t.Fatalf("NewPollStrategyForTest: %v", err)
+	}
+	s.SetPuller(puller, "https://example.com/repo.git", "main", t.TempDir())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := s.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Let a few ticks happen
+	time.Sleep(250 * time.Millisecond)
+	callsBefore := puller.calls.Load()
+	cancel()
+
+	// Give goroutine time to exit
+	time.Sleep(200 * time.Millisecond)
+	callsAfter := puller.calls.Load()
+
+	// After cancellation, no more calls should happen (allow at most 1 in-flight)
+	if callsAfter-callsBefore > 1 {
+		t.Errorf("expected polling to stop after cancel, but calls went from %d to %d", callsBefore, callsAfter)
+	}
+}
+
+func TestPollStrategy_StopIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	puller := &fakePuller{}
+
+	s := newTestPollStrategy(t, 30*time.Second, puller, noop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := s.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	cancel()
+
+	// Stop twice — should not panic or return error
+	if err := s.Stop(ctx); err != nil {
+		t.Errorf("first Stop: %v", err)
+	}
+	if err := s.Stop(ctx); err != nil {
+		t.Errorf("second Stop: %v", err)
+	}
+}
+
+func TestPollStrategy_PullErrorDoesNotReload(t *testing.T) {
+	t.Parallel()
+
+	puller := &fakePuller{}
+	puller.err.Store(fmt.Errorf("network error"))
+
+	var reloadCount atomic.Int64
+	reloader := func() error {
+		reloadCount.Add(1)
+		return nil
+	}
+
+	s, err := gitops.NewPollStrategyForTest(100*time.Millisecond, reloader, logger())
+	if err != nil {
+		t.Fatalf("NewPollStrategyForTest: %v", err)
+	}
+	s.SetPuller(puller, "https://example.com/repo.git", "main", t.TempDir())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := s.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	time.Sleep(350 * time.Millisecond)
+	cancel()
+
+	if n := reloadCount.Load(); n != 0 {
+		t.Errorf("expected reload NOT to be called on pull error, got %d calls", n)
+	}
+}
+
+func TestPollStrategy_StartWithoutPuller(t *testing.T) {
+	t.Parallel()
+
+	s, err := gitops.NewPollStrategy(30*time.Second, noop, logger())
+	if err != nil {
+		t.Fatalf("NewPollStrategy: %v", err)
+	}
+	// Don't call SetPuller
+
+	err = s.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected error when starting without puller")
+	}
+}
+
+func TestPollStrategy_Name(t *testing.T) {
+	t.Parallel()
+
+	s := newTestPollStrategy(t, 30*time.Second, &fakePuller{}, noop)
+	if got := s.Name(); got != "poll" {
+		t.Errorf("Name() = %q, want %q", got, "poll")
+	}
+}
+
+func TestNewPollStrategy_IntervalTooShort(t *testing.T) {
+	t.Parallel()
+
+	_, err := gitops.NewPollStrategy(10*time.Second, noop, logger())
+	if err == nil {
+		t.Fatal("expected error for interval < 30s")
+	}
+}
+
+func TestNewPollStrategy_NilReloader(t *testing.T) {
+	t.Parallel()
+
+	_, err := gitops.NewPollStrategy(30*time.Second, nil, logger())
+	if err == nil {
+		t.Fatal("expected error for nil reloader")
+	}
+}

--- a/internal/gitops/poll_test.go
+++ b/internal/gitops/poll_test.go
@@ -291,3 +291,38 @@ func TestNewPollStrategy_NilReloader(t *testing.T) {
 		t.Fatal("expected error for nil reloader")
 	}
 }
+
+func TestPollStrategy_DoubleStartReturnsError(t *testing.T) {
+	t.Parallel()
+
+	puller := &fakePuller{}
+	s := newTestPollStrategy(t, 30*time.Second, puller, noop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := s.Start(ctx); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+
+	if err := s.Start(ctx); err == nil {
+		t.Fatal("expected error on second Start")
+	}
+
+	cancel()
+	_ = s.Stop(ctx)
+}
+
+func TestPollStrategy_StopWithoutStart(t *testing.T) {
+	t.Parallel()
+
+	s, err := gitops.NewPollStrategy(30*time.Second, noop, logger())
+	if err != nil {
+		t.Fatalf("NewPollStrategy: %v", err)
+	}
+
+	// Stop without Start should not block or error
+	if err := s.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop without Start: %v", err)
+	}
+}

--- a/internal/gitops/sync.go
+++ b/internal/gitops/sync.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/khaines/blogflow/internal/config"
 )
@@ -46,7 +47,19 @@ func NewStrategy(cfg *config.SyncConfig, reloader ContentReloader, logger *slog.
 		return NewWebhookStrategy(cfg.Webhook, reloader, logger)
 	case "sidecar":
 		return NewSidecarStrategy(reloader, logger), nil
+	case "poll":
+		return newPollFromConfig(cfg, reloader, logger)
 	default:
-		return nil, fmt.Errorf("gitops: unknown sync strategy %q (must be watch, webhook, or sidecar)", cfg.Strategy)
+		return nil, fmt.Errorf("gitops: unknown sync strategy %q (must be watch, webhook, sidecar, or poll)", cfg.Strategy)
 	}
+}
+
+// newPollFromConfig parses PollInterval and constructs a PollStrategy.
+// The puller must be wired post-construction via SetPuller before Start.
+func newPollFromConfig(cfg *config.SyncConfig, reloader ContentReloader, logger *slog.Logger) (*PollStrategy, error) {
+	interval, err := time.ParseDuration(cfg.PollInterval)
+	if err != nil {
+		return nil, fmt.Errorf("gitops: invalid poll_interval %q: %w", cfg.PollInterval, err)
+	}
+	return NewPollStrategy(interval, reloader, logger)
 }

--- a/internal/gitops/sync_test.go
+++ b/internal/gitops/sync_test.go
@@ -69,6 +69,24 @@ func TestNewStrategy_Unknown(t *testing.T) {
 	}
 }
 
+func TestNewStrategy_Poll(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.SyncConfig{
+		Strategy:     "poll",
+		PollInterval: "5m",
+	}
+
+	s, err := gitops.NewStrategy(cfg, noop, logger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := s.(*gitops.PollStrategy); !ok {
+		t.Fatalf("expected *PollStrategy, got %T", s)
+	}
+}
+
 func TestNewStrategy_NilConfig(t *testing.T) {
 	t.Parallel()
 
@@ -125,6 +143,7 @@ func TestStrategy_Name(t *testing.T) {
 		{"watch", "watch"},
 		{"webhook", "webhook"},
 		{"sidecar", "sidecar"},
+		{"poll", "poll"},
 	}
 
 	for _, tc := range cases {
@@ -134,6 +153,9 @@ func TestStrategy_Name(t *testing.T) {
 			cfg := &config.SyncConfig{Strategy: tc.strategy}
 			if tc.strategy == "webhook" {
 				cfg.Webhook = config.WebhookConfig{Path: "/_hook", Secret: "test-secret"}
+			}
+			if tc.strategy == "poll" {
+				cfg.PollInterval = "5m"
 			}
 
 			s, err := gitops.NewStrategy(cfg, noop, logger())
@@ -158,6 +180,7 @@ func TestStrategy_StartStop(t *testing.T) {
 		{"watch", &config.SyncConfig{Strategy: "watch"}},
 		{"webhook", &config.SyncConfig{Strategy: "webhook", Webhook: config.WebhookConfig{Path: "/_hook", Secret: "test-secret"}}},
 		{"sidecar", &config.SyncConfig{Strategy: "sidecar"}},
+		{"poll", &config.SyncConfig{Strategy: "poll", PollInterval: "5m"}},
 	}
 
 	for _, tc := range strategies {
@@ -175,6 +198,9 @@ func TestStrategy_StartStop(t *testing.T) {
 			}
 			if ss, ok := s.(*gitops.SidecarStrategy); ok {
 				ss.SetDir(t.TempDir())
+			}
+			if ps, ok := s.(*gitops.PollStrategy); ok {
+				ps.SetPuller(&fakePuller{}, "https://example.com/repo.git", "main", t.TempDir())
 			}
 
 			if err := s.Start(ctx); err != nil {
@@ -198,6 +224,7 @@ func TestStrategy_DoubleStop(t *testing.T) {
 		{"watch", &config.SyncConfig{Strategy: "watch"}},
 		{"webhook", &config.SyncConfig{Strategy: "webhook", Webhook: config.WebhookConfig{Path: "/_hook", Secret: "test-secret"}}},
 		{"sidecar", &config.SyncConfig{Strategy: "sidecar"}},
+		{"poll", &config.SyncConfig{Strategy: "poll", PollInterval: "5m"}},
 	}
 
 	for _, tc := range strategies {
@@ -215,6 +242,9 @@ func TestStrategy_DoubleStop(t *testing.T) {
 			}
 			if ss, ok := s.(*gitops.SidecarStrategy); ok {
 				ss.SetDir(t.TempDir())
+			}
+			if ps, ok := s.(*gitops.PollStrategy); ok {
+				ps.SetPuller(&fakePuller{}, "https://example.com/repo.git", "main", t.TempDir())
 			}
 
 			if err := s.Start(ctx); err != nil {


### PR DESCRIPTION
## Summary

Adds a **PollStrategy** to the gitops sync subsystem — a background goroutine that periodically calls `CloneOrPull()` and triggers a content reload when changes are detected.

### Problem
In multi-replica K8s deployments using the webhook strategy, only one pod receives the webhook. Other replicas stay stale until restarted. A background poll ensures all pods eventually converge.

### Changes
- **`internal/config/config.go`** — Added `PollInterval` field to `SyncConfig` (Go duration string, e.g. `"5m"`)
- **`internal/config/loader.go`** — Added `BLOGFLOW_SYNC_POLL_INTERVAL` env var override, `"poll"` to valid strategies, validation (must parse as `time.Duration`, must be ≥ 30s)
- **`internal/gitops/poll.go`** — New `PollStrategy` implementing the `Strategy` interface (Start/Stop/Name), with `PullExecutor` interface for testability
- **`internal/gitops/sync.go`** — Wired `"poll"` case in `NewStrategy` factory
- **Tests** — Comprehensive poll_test.go (interval triggers, changed/unchanged reload behavior, context cancellation, idempotent stop, error handling) + updated sync_test.go and config_test.go

### Design
- Follows existing patterns (SetPuller like SetDir on SidecarStrategy)
- `PullExecutor` interface decouples from concrete `Puller` for testing
- `sync.Once` for idempotent Stop
- Minimum 30s interval enforced at config validation and constructor level