### PR TITLE
feat: add sparse checkout support for content repos

### DIFF
--- a/cmd/blogflow/bootstrap.go
+++ b/cmd/blogflow/bootstrap.go
@@ -44,6 +44,7 @@ func bootstrapContent(cfg *config.Config, contentPath string, logger *slog.Logge
 		logger.Error("content bootstrap: failed to create git puller", "error", err)
 		return
 	}
+	puller.SparseDirs = cfg.Sync.SparseDirs
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,6 +75,7 @@ type SyncConfig struct {
 	Repo         string        `yaml:"repo"`
 	Branch       string        `yaml:"branch"`
 	PollInterval string        `yaml:"poll_interval"` // Go duration (e.g. "5m"); empty = disabled
+	SparseDirs   []string      `yaml:"sparse_dirs"`   // limit checkout to these dirs; empty = full checkout
 	Webhook      WebhookConfig `yaml:"webhook"`
 }
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -353,6 +353,21 @@ var envMap = map[string]func(*Config, string) error{
 		c.Sync.PollInterval = v
 		return nil
 	},
+	"BLOGFLOW_SYNC_SPARSE_DIRS": func(c *Config, v string) error {
+		if v == "" {
+			c.Sync.SparseDirs = nil
+			return nil
+		}
+		parts := strings.Split(v, ",")
+		dirs := make([]string, 0, len(parts))
+		for _, p := range parts {
+			if d := strings.TrimSpace(p); d != "" {
+				dirs = append(dirs, d)
+			}
+		}
+		c.Sync.SparseDirs = dirs
+		return nil
+	},
 	"BLOGFLOW_FEED_TYPE": func(c *Config, v string) error {
 		c.Feed.Type = v
 		return nil

--- a/internal/gitops/pull.go
+++ b/internal/gitops/pull.go
@@ -19,8 +19,9 @@ import (
 
 // Puller handles git clone and pull operations for content/theme repos.
 type Puller struct {
-	auth   transport.AuthMethod
-	logger *slog.Logger
+	auth       transport.AuthMethod
+	logger     *slog.Logger
+	SparseDirs []string // if non-empty, only these directories are checked out
 }
 
 // NewPuller creates a git puller with the given auth configuration.
@@ -80,17 +81,34 @@ func SanitizeURL(raw string) string {
 func (p *Puller) clone(ctx context.Context, repoURL, branch, destPath string) error {
 	p.logger.Info("cloning repository", "url", SanitizeURL(repoURL), "branch", branch, "dest", destPath)
 
+	sparse := len(p.SparseDirs) > 0
+
 	opts := &git.CloneOptions{
 		URL:           repoURL,
 		Auth:          p.auth,
 		ReferenceName: plumbing.NewBranchReferenceName(branch),
 		SingleBranch:  true,
 		Depth:         1, // shallow clone for efficiency
+		NoCheckout:    sparse,
 	}
 
-	_, err := git.PlainCloneContext(ctx, destPath, false, opts)
+	repo, err := git.PlainCloneContext(ctx, destPath, false, opts)
 	if err != nil {
 		return fmt.Errorf("gitops: clone %s: %w", SanitizeURL(repoURL), err)
+	}
+
+	if sparse {
+		wt, wtErr := repo.Worktree()
+		if wtErr != nil {
+			return fmt.Errorf("gitops: worktree after clone %s: %w", SanitizeURL(repoURL), wtErr)
+		}
+		if coErr := wt.Checkout(&git.CheckoutOptions{
+			Branch:                    plumbing.NewBranchReferenceName(branch),
+			SparseCheckoutDirectories: p.SparseDirs,
+		}); coErr != nil {
+			return fmt.Errorf("gitops: sparse checkout %s: %w", SanitizeURL(repoURL), coErr)
+		}
+		p.logger.Info("sparse checkout applied", "dirs", p.SparseDirs)
 	}
 
 	p.logger.Info("clone complete", "url", SanitizeURL(repoURL))
@@ -144,10 +162,46 @@ func (p *Puller) pull(ctx context.Context, repoURL, branch, destPath string) (bo
 	}
 
 	changed := headBefore.Hash() != headAfter.Hash()
+
+	// Re-apply sparse checkout after pull — PullContext checks out all files,
+	// so we remove entries outside the sparse set.
+	if changed && len(p.SparseDirs) > 0 {
+		if cleanErr := p.cleanNonSparsePaths(destPath); cleanErr != nil {
+			return false, fmt.Errorf("gitops: sparse cleanup after pull %s: %w", destPath, cleanErr)
+		}
+		p.logger.Info("sparse checkout re-applied after pull", "dirs", p.SparseDirs)
+	}
+
 	if changed {
 		p.logger.Info("pull complete — content updated", "dest", destPath)
 	} else {
 		p.logger.Debug("already up to date", "dest", destPath)
 	}
 	return changed, nil
+}
+
+// cleanNonSparsePaths removes top-level files and directories from destPath
+// that are not in the configured SparseDirs set. The .git directory is always
+// preserved.
+func (p *Puller) cleanNonSparsePaths(destPath string) error {
+	allowed := make(map[string]bool, len(p.SparseDirs))
+	for _, d := range p.SparseDirs {
+		allowed[d] = true
+	}
+
+	entries, err := os.ReadDir(destPath)
+	if err != nil {
+		return fmt.Errorf("read dir %s: %w", destPath, err)
+	}
+
+	for _, e := range entries {
+		name := e.Name()
+		if name == ".git" || allowed[name] {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(destPath, name)); err != nil {
+			return fmt.Errorf("remove %s: %w", name, err)
+		}
+	}
+	return nil
 }

--- a/internal/gitops/pull.go
+++ b/internal/gitops/pull.go
@@ -8,7 +8,9 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -62,10 +64,39 @@ func NewPuller(authCfg *AuthConfig, logger *slog.Logger) (*Puller, error) {
 // fallback re-clone path is triggered (e.g. shallow-clone corruption). To
 // intentionally switch URLs, delete destPath first and let CloneOrPull re-clone.
 func (p *Puller) CloneOrPull(ctx context.Context, repoURL, branch, destPath string) (changed bool, err error) {
+	if len(p.SparseDirs) > 0 {
+		cleaned, valErr := validateSparseDirs(p.SparseDirs)
+		if valErr != nil {
+			return false, fmt.Errorf("gitops: %w", valErr)
+		}
+		p.SparseDirs = cleaned
+	}
+
 	if _, err := os.Stat(filepath.Join(destPath, ".git")); err == nil {
 		return p.pull(ctx, repoURL, branch, destPath)
 	}
 	return true, p.clone(ctx, repoURL, branch, destPath)
+}
+
+// validateSparseDirs sanitizes and validates sparse directory entries.
+// It rejects absolute paths and path-traversal components, and normalizes
+// each entry (trailing slashes, redundant separators).
+func validateSparseDirs(dirs []string) ([]string, error) {
+	cleaned := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		d = path.Clean(d)
+		if d == "." || d == "" {
+			continue
+		}
+		if path.IsAbs(d) {
+			return nil, fmt.Errorf("sparse dir must be relative, got %q", d)
+		}
+		if d == ".." || strings.HasPrefix(d, "../") || strings.Contains(d, "/../") {
+			return nil, fmt.Errorf("sparse dir must not contain path traversal, got %q", d)
+		}
+		cleaned = append(cleaned, d)
+	}
+	return cleaned, nil
 }
 
 // SanitizeURL strips embedded credentials from a URL for safe logging.
@@ -182,11 +213,14 @@ func (p *Puller) pull(ctx context.Context, repoURL, branch, destPath string) (bo
 
 // cleanNonSparsePaths removes top-level files and directories from destPath
 // that are not in the configured SparseDirs set. The .git directory is always
-// preserved.
+// preserved. Nested sparse dirs (e.g. "posts/drafts") are handled by
+// extracting the top-level component for the allow-list.
 func (p *Puller) cleanNonSparsePaths(destPath string) error {
 	allowed := make(map[string]bool, len(p.SparseDirs))
 	for _, d := range p.SparseDirs {
-		allowed[d] = true
+		// Extract top-level component so "posts/drafts" preserves "posts".
+		top := strings.SplitN(d, "/", 2)[0]
+		allowed[top] = true
 	}
 
 	entries, err := os.ReadDir(destPath)

--- a/internal/gitops/pull_test.go
+++ b/internal/gitops/pull_test.go
@@ -339,3 +339,160 @@ func TestSanitizeURL(t *testing.T) {
 		})
 	}
 }
+
+// newBareRepoWithDirs creates a local bare repo with files in multiple directories
+// (posts/, pages/, scripts/, and a root README.md). Useful for sparse checkout tests.
+func newBareRepoWithDirs(t *testing.T) string {
+	t.Helper()
+
+	srcDir := filepath.Join(t.TempDir(), "src")
+	repo, err := git.PlainInit(srcDir, false)
+	if err != nil {
+		t.Fatalf("init source repo: %v", err)
+	}
+
+	// Create directory structure with files.
+	files := map[string]string{
+		"README.md":         "# root readme\n",
+		"posts/hello.md":    "# Hello\n",
+		"pages/about.md":    "# About\n",
+		"scripts/deploy.sh": "#!/bin/sh\necho deploy\n",
+		"static/style.css":  "body { color: #333; }\n",
+	}
+
+	for name, content := range files {
+		fullPath := filepath.Join(srcDir, name)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o750); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(fullPath), err)
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	if _, err := wt.Add("."); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if _, err = wt.Commit("initial commit with dirs", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "test",
+			Email: "test@test.com",
+			When:  time.Now(),
+		},
+	}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	bareDir := filepath.Join(t.TempDir(), "bare")
+	if _, err := git.PlainClone(bareDir, true, &git.CloneOptions{URL: srcDir}); err != nil {
+		t.Fatalf("bare clone: %v", err)
+	}
+
+	return bareDir
+}
+
+func TestCloneOrPull_SparseClone(t *testing.T) {
+	bareRepo := newBareRepoWithDirs(t)
+
+	p, err := NewPuller(&AuthConfig{Method: AuthNone}, nil)
+	if err != nil {
+		t.Fatalf("new puller: %v", err)
+	}
+	p.SparseDirs = []string{"posts", "pages"}
+
+	destDir := filepath.Join(t.TempDir(), "sparse-clone")
+
+	changed, err := p.CloneOrPull(context.Background(), bareRepo, "master", destDir)
+	if err != nil {
+		t.Fatalf("CloneOrPull (sparse clone): %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true on fresh sparse clone")
+	}
+
+	// Verify sparse dirs are present.
+	if _, err := os.Stat(filepath.Join(destDir, "posts", "hello.md")); err != nil {
+		t.Fatalf("expected posts/hello.md to exist: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "pages", "about.md")); err != nil {
+		t.Fatalf("expected pages/about.md to exist: %v", err)
+	}
+
+	// Verify excluded dirs are absent.
+	if _, err := os.Stat(filepath.Join(destDir, "scripts", "deploy.sh")); !os.IsNotExist(err) {
+		t.Fatal("expected scripts/deploy.sh to be absent in sparse checkout")
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "static", "style.css")); !os.IsNotExist(err) {
+		t.Fatal("expected static/style.css to be absent in sparse checkout")
+	}
+}
+
+func TestCloneOrPull_FullCloneWhenSparseDirsEmpty(t *testing.T) {
+	bareRepo := newBareRepoWithDirs(t)
+
+	p, err := NewPuller(&AuthConfig{Method: AuthNone}, nil)
+	if err != nil {
+		t.Fatalf("new puller: %v", err)
+	}
+	// SparseDirs is nil — full checkout expected.
+
+	destDir := filepath.Join(t.TempDir(), "full-clone")
+
+	changed, err := p.CloneOrPull(context.Background(), bareRepo, "master", destDir)
+	if err != nil {
+		t.Fatalf("CloneOrPull (full clone): %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true on fresh clone")
+	}
+
+	// All files should be present.
+	for _, path := range []string{"README.md", "posts/hello.md", "pages/about.md", "scripts/deploy.sh", "static/style.css"} {
+		if _, err := os.Stat(filepath.Join(destDir, path)); err != nil {
+			t.Fatalf("expected %s to exist in full checkout: %v", path, err)
+		}
+	}
+}
+
+func TestCloneOrPull_PullWithSparseDirs(t *testing.T) {
+	bareRepo := newBareRepoWithDirs(t)
+
+	p, err := NewPuller(&AuthConfig{Method: AuthNone}, nil)
+	if err != nil {
+		t.Fatalf("new puller: %v", err)
+	}
+	p.SparseDirs = []string{"posts", "pages"}
+
+	destDir := filepath.Join(t.TempDir(), "sparse-pull")
+
+	// Initial sparse clone.
+	if _, err := p.CloneOrPull(context.Background(), bareRepo, "master", destDir); err != nil {
+		t.Fatalf("initial sparse clone: %v", err)
+	}
+
+	// Push a new commit with files in both sparse and non-sparse dirs.
+	addCommitToBareRepo(t, bareRepo, "posts/new-post.md", "# New\n")
+
+	// Pull should detect the change and maintain sparse state.
+	changed, err := p.CloneOrPull(context.Background(), bareRepo, "master", destDir)
+	if err != nil {
+		t.Fatalf("sparse pull: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true after new commit")
+	}
+
+	// New post in sparse dir should be present.
+	if _, err := os.Stat(filepath.Join(destDir, "posts", "new-post.md")); err != nil {
+		t.Fatalf("expected posts/new-post.md to exist after pull: %v", err)
+	}
+
+	// Excluded dirs should still be absent.
+	if _, err := os.Stat(filepath.Join(destDir, "scripts", "deploy.sh")); !os.IsNotExist(err) {
+		t.Fatal("expected scripts/deploy.sh to remain absent after sparse pull")
+	}
+}

--- a/internal/gitops/pull_test.go
+++ b/internal/gitops/pull_test.go
@@ -496,3 +496,58 @@ func TestCloneOrPull_PullWithSparseDirs(t *testing.T) {
 		t.Fatal("expected scripts/deploy.sh to remain absent after sparse pull")
 	}
 }
+
+func TestCloneOrPull_RejectsPathTraversal(t *testing.T) {
+	bareRepo := newBareRepoWithDirs(t)
+
+	cases := []struct {
+		name string
+		dirs []string
+	}{
+		{"dotdot", []string{"../etc"}},
+		{"absolute", []string{"/etc/passwd"}},
+		{"embedded dotdot", []string{"posts/../../etc"}},
+		{"bare dotdot", []string{".."}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := NewPuller(&AuthConfig{Method: AuthNone}, nil)
+			if err != nil {
+				t.Fatalf("new puller: %v", err)
+			}
+			p.SparseDirs = tc.dirs
+
+			destDir := filepath.Join(t.TempDir(), "traversal-"+tc.name)
+			_, err = p.CloneOrPull(context.Background(), bareRepo, "master", destDir)
+			if err == nil {
+				t.Fatal("expected error for path-traversal sparse dir")
+			}
+		})
+	}
+}
+
+func TestCloneOrPull_SparseTrailingSlashNormalized(t *testing.T) {
+	bareRepo := newBareRepoWithDirs(t)
+
+	p, err := NewPuller(&AuthConfig{Method: AuthNone}, nil)
+	if err != nil {
+		t.Fatalf("new puller: %v", err)
+	}
+	// Trailing slash should be normalized to "posts".
+	p.SparseDirs = []string{"posts/", "pages/"}
+
+	destDir := filepath.Join(t.TempDir(), "trailing-slash")
+
+	_, err = p.CloneOrPull(context.Background(), bareRepo, "master", destDir)
+	if err != nil {
+		t.Fatalf("CloneOrPull with trailing slash sparse dirs: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(destDir, "posts", "hello.md")); err != nil {
+		t.Fatalf("expected posts/hello.md to exist: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "scripts", "deploy.sh")); !os.IsNotExist(err) {
+		t.Fatal("expected scripts/ to be absent in sparse checkout")
+	}
+}


### PR DESCRIPTION
When `sync.sparse_dirs` is configured, only specified directories are checked out from the content repo. Reduces disk and bandwidth for repos with CI, scripts, or other non-blog artifacts.

## Changes
- **`SyncConfig.SparseDirs`** — new `[]string` field (`yaml:sparse_dirs`, env: `BLOGFLOW_SYNC_SPARSE_DIRS` comma-separated)
- **`Puller.clone()`** — when SparseDirs is set, clones with `NoCheckout: true` then applies sparse checkout via `Checkout(SparseCheckoutDirectories)`
- **`Puller.pull()`** — after pull with new content, removes files outside sparse dirs to maintain sparse state
- **`bootstrap.go`** — wires `cfg.Sync.SparseDirs` to the Puller
- **Tests** — sparse clone, full clone (empty SparseDirs), pull with sparse dirs

## Config example
```yaml
sync:
  sparse_dirs: ["posts", "pages", "static"]
```

Or via env: `BLOGFLOW_SYNC_SPARSE_DIRS=posts,pages,static`