### PR TITLE
feat: add no-tags fetch and configurable clone depth

### DIFF
--- a/cmd/blogflow/bootstrap.go
+++ b/cmd/blogflow/bootstrap.go
@@ -39,7 +39,7 @@ func bootstrapContent(cfg *config.Config, contentPath string, logger *slog.Logge
 		return
 	}
 
-	puller, err := gitops.NewPuller(authCfg, logger)
+	puller, err := gitops.NewPuller(authCfg, logger, gitops.WithCloneDepth(cfg.Sync.CloneDepth))
 	if err != nil {
 		logger.Error("content bootstrap: failed to create git puller", "error", err)
 		return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,6 +74,7 @@ type SyncConfig struct {
 	Strategy     string        `yaml:"strategy"`
 	Repo         string        `yaml:"repo"`
 	Branch       string        `yaml:"branch"`
+	CloneDepth   int           `yaml:"clone_depth"`   // git clone/pull depth; default 1, recommended 10
 	PollInterval string        `yaml:"poll_interval"` // Go duration (e.g. "5m"); empty = disabled
 	SparseDirs   []string      `yaml:"sparse_dirs"`   // limit checkout to these dirs; empty = full checkout
 	Webhook      WebhookConfig `yaml:"webhook"`
@@ -133,8 +134,9 @@ func Default() *Config {
 			MaxEntries: 1000,
 		},
 		Sync: SyncConfig{
-			Strategy: "watch",
-			Branch:   "main",
+			Strategy:   "watch",
+			Branch:     "main",
+			CloneDepth: 1,
 			Webhook: WebhookConfig{
 				Path:          "/api/webhook",
 				AllowedEvents: []string{"push"},

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -368,6 +368,14 @@ var envMap = map[string]func(*Config, string) error{
 		c.Sync.SparseDirs = dirs
 		return nil
 	},
+	"BLOGFLOW_SYNC_CLONE_DEPTH": func(c *Config, v string) error {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("cannot parse env var BLOGFLOW_SYNC_CLONE_DEPTH as int: %w", err)
+		}
+		c.Sync.CloneDepth = n
+		return nil
+	},
 	"BLOGFLOW_FEED_TYPE": func(c *Config, v string) error {
 		c.Feed.Type = v
 		return nil
@@ -588,6 +596,15 @@ func Validate(cfg *Config) error {
 			Field:   "sync.poll_interval",
 			Value:   cfg.Sync.PollInterval,
 			Message: "must be set when strategy is \"poll\"",
+		})
+	}
+
+	// Sync.CloneDepth: must be >= 1
+	if cfg.Sync.CloneDepth < 1 {
+		errs = append(errs, FieldError{
+			Field:   "sync.clone_depth",
+			Value:   cfg.Sync.CloneDepth,
+			Message: "must be >= 1",
 		})
 	}
 

--- a/internal/gitops/pull.go
+++ b/internal/gitops/pull.go
@@ -24,10 +24,19 @@ type Puller struct {
 	auth       transport.AuthMethod
 	logger     *slog.Logger
 	SparseDirs []string // if non-empty, only these directories are checked out
+	depth      int      // git clone/pull depth; 0 means full clone
+}
+
+// PullerOption configures optional Puller behaviour.
+type PullerOption func(*Puller)
+
+// WithCloneDepth sets the shallow clone/pull depth. Must be >= 1.
+func WithCloneDepth(depth int) PullerOption {
+	return func(p *Puller) { p.depth = depth }
 }
 
 // NewPuller creates a git puller with the given auth configuration.
-func NewPuller(authCfg *AuthConfig, logger *slog.Logger) (*Puller, error) {
+func NewPuller(authCfg *AuthConfig, logger *slog.Logger, opts ...PullerOption) (*Puller, error) {
 	if authCfg == nil {
 		authCfg = &AuthConfig{Method: AuthNone}
 	}
@@ -53,7 +62,11 @@ func NewPuller(authCfg *AuthConfig, logger *slog.Logger) (*Puller, error) {
 		auth = nil // public repos
 	}
 
-	return &Puller{auth: auth, logger: logger}, nil
+	p := &Puller{auth: auth, logger: logger, depth: 1}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p, nil
 }
 
 // CloneOrPull clones a repo to destPath if it doesn't exist, or pulls if it does.
@@ -119,7 +132,8 @@ func (p *Puller) clone(ctx context.Context, repoURL, branch, destPath string) er
 		Auth:          p.auth,
 		ReferenceName: plumbing.NewBranchReferenceName(branch),
 		SingleBranch:  true,
-		Depth:         1, // shallow clone for efficiency
+		Depth:         p.depth,
+		Tags:          git.NoTags, // content repos don't need tags
 		NoCheckout:    sparse,
 	}
 
@@ -154,30 +168,32 @@ func (p *Puller) pull(ctx context.Context, repoURL, branch, destPath string) (bo
 		return false, fmt.Errorf("gitops: open repo %s: %w", destPath, err)
 	}
 
-	// Record HEAD before pull so we can detect actual content changes.
-	// Force-pull may not return NoErrAlreadyUpToDate even when nothing changed.
+	// Record HEAD before fetch so we can detect actual content changes.
 	headBefore, err := repo.Head()
 	if err != nil {
 		return false, fmt.Errorf("gitops: head %s: %w", destPath, err)
 	}
 
-	wt, err := repo.Worktree()
-	if err != nil {
-		return false, fmt.Errorf("gitops: worktree %s: %w", destPath, err)
-	}
-
-	err = wt.PullContext(ctx, &git.PullOptions{
-		Auth:          p.auth,
-		ReferenceName: plumbing.NewBranchReferenceName(branch),
-		SingleBranch:  true,
-		Force:         true,
+	// Use FetchContext + hard reset instead of PullContext so we can set
+	// Tags: NoTags — PullOptions does not expose a Tags field.
+	fetchErr := repo.FetchContext(ctx, &git.FetchOptions{
+		Auth:  p.auth,
+		Depth: p.depth,
+		Tags:  git.NoTags,
+		Force: true,
 	})
 
-	if err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
-		// Shallow clone + pull is a known go-git limitation.
+	switch {
+	case fetchErr == nil:
+		// New objects fetched — fast-forward worktree below.
+	case errors.Is(fetchErr, git.NoErrAlreadyUpToDate):
+		p.logger.Debug("already up to date", "dest", destPath)
+		return false, nil
+	default:
+		// Shallow clone + fetch is a known go-git limitation.
 		// Fall back to delete and re-clone.
 		p.logger.Warn("pull failed, falling back to re-clone",
-			"dest", destPath, "error", err)
+			"dest", destPath, "error", fetchErr)
 		if removeErr := os.RemoveAll(destPath); removeErr != nil {
 			return false, fmt.Errorf("gitops: failed to clear for re-clone %s: %w", destPath, removeErr)
 		}
@@ -185,6 +201,25 @@ func (p *Puller) pull(ctx context.Context, repoURL, branch, destPath string) (bo
 			return false, cloneErr
 		}
 		return true, nil
+	}
+
+	// Resolve the remote tracking ref and hard-reset the worktree.
+	remoteRef, err := repo.Reference(
+		plumbing.NewRemoteReferenceName("origin", branch), true)
+	if err != nil {
+		return false, fmt.Errorf("gitops: resolve remote ref %s: %w", destPath, err)
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		return false, fmt.Errorf("gitops: worktree %s: %w", destPath, err)
+	}
+
+	if err := wt.Reset(&git.ResetOptions{
+		Commit: remoteRef.Hash(),
+		Mode:   git.HardReset,
+	}); err != nil {
+		return false, fmt.Errorf("gitops: reset %s: %w", destPath, err)
 	}
 
 	headAfter, err := repo.Head()

--- a/internal/gitops/pull.go
+++ b/internal/gitops/pull.go
@@ -24,15 +24,21 @@ type Puller struct {
 	auth       transport.AuthMethod
 	logger     *slog.Logger
 	SparseDirs []string // if non-empty, only these directories are checked out
-	depth      int      // git clone/pull depth; 0 means full clone
+	depth      int      // git clone/fetch depth; 1 = shallowest
 }
 
 // PullerOption configures optional Puller behaviour.
 type PullerOption func(*Puller)
 
-// WithCloneDepth sets the shallow clone/pull depth. Must be >= 1.
+// WithCloneDepth sets the shallow clone/fetch depth.
+// Values < 1 are silently clamped to 1.
 func WithCloneDepth(depth int) PullerOption {
-	return func(p *Puller) { p.depth = depth }
+	return func(p *Puller) {
+		if depth < 1 {
+			depth = 1
+		}
+		p.depth = depth
+	}
 }
 
 // NewPuller creates a git puller with the given auth configuration.

--- a/internal/gitops/pull_test.go
+++ b/internal/gitops/pull_test.go
@@ -5,12 +5,14 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/pem"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"golang.org/x/crypto/ssh"
 )
@@ -549,5 +551,164 @@ func TestCloneOrPull_SparseTrailingSlashNormalized(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(destDir, "scripts", "deploy.sh")); !os.IsNotExist(err) {
 		t.Fatal("expected scripts/ to be absent in sparse checkout")
+	}
+}
+
+func TestCloneOrPull_CloneDepthDefault(t *testing.T) {
+	bareRepo := newBareRepoWithCommit(t)
+
+	// Default depth is 1 (no WithCloneDepth option).
+	p, err := NewPuller(&AuthConfig{Method: AuthNone}, nil)
+	if err != nil {
+		t.Fatalf("new puller: %v", err)
+	}
+
+	destDir := filepath.Join(t.TempDir(), "depth-default")
+	changed, err := p.CloneOrPull(context.Background(), bareRepo, "master", destDir)
+	if err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true on fresh clone")
+	}
+
+	// Verify it's a shallow clone (depth=1 → single commit).
+	repo, err := git.PlainOpen(destDir)
+	if err != nil {
+		t.Fatalf("open cloned repo: %v", err)
+	}
+	iter, err := repo.Log(&git.LogOptions{})
+	if err != nil {
+		t.Fatalf("log: %v", err)
+	}
+	count := 0
+	iter.ForEach(func(_ *object.Commit) error { //nolint:errcheck,gosec // counting commits
+		count++
+		return nil
+	})
+	if count != 1 {
+		t.Fatalf("expected 1 commit for depth=1 clone, got %d", count)
+	}
+}
+
+func TestCloneOrPull_CloneDepth10(t *testing.T) {
+	bareRepo := newBareRepoWithCommit(t)
+
+	// Add more commits to the bare repo so depth=10 is meaningful.
+	for i := 0; i < 4; i++ {
+		addCommitToBareRepo(t, bareRepo, fmt.Sprintf("file%d.txt", i), fmt.Sprintf("content %d", i))
+	}
+
+	p, err := NewPuller(&AuthConfig{Method: AuthNone}, nil, WithCloneDepth(10))
+	if err != nil {
+		t.Fatalf("new puller: %v", err)
+	}
+
+	destDir := filepath.Join(t.TempDir(), "depth-10")
+	changed, err := p.CloneOrPull(context.Background(), bareRepo, "master", destDir)
+	if err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true on fresh clone")
+	}
+
+	// With 5 commits total and depth=10, all 5 should be visible.
+	repo, err := git.PlainOpen(destDir)
+	if err != nil {
+		t.Fatalf("open cloned repo: %v", err)
+	}
+	iter, err := repo.Log(&git.LogOptions{})
+	if err != nil {
+		t.Fatalf("log: %v", err)
+	}
+	count := 0
+	iter.ForEach(func(_ *object.Commit) error { //nolint:errcheck,gosec // counting commits
+		count++
+		return nil
+	})
+	if count != 5 {
+		t.Fatalf("expected 5 commits for depth=10 clone (only 5 exist), got %d", count)
+	}
+}
+
+func TestCloneOrPull_NoTagsFetched(t *testing.T) {
+	bareRepo := newBareRepoWithCommit(t)
+
+	// Create a tag in the bare repo.
+	bareGit, err := git.PlainOpen(bareRepo)
+	if err != nil {
+		t.Fatalf("open bare repo: %v", err)
+	}
+	head, err := bareGit.Head()
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+	_, err = bareGit.CreateTag("v1.0.0", head.Hash(), nil)
+	if err != nil {
+		t.Fatalf("create tag: %v", err)
+	}
+
+	p, err := NewPuller(&AuthConfig{Method: AuthNone}, nil)
+	if err != nil {
+		t.Fatalf("new puller: %v", err)
+	}
+
+	destDir := filepath.Join(t.TempDir(), "no-tags")
+	if _, err := p.CloneOrPull(context.Background(), bareRepo, "master", destDir); err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+
+	// Verify no tags were fetched.
+	clonedRepo, err := git.PlainOpen(destDir)
+	if err != nil {
+		t.Fatalf("open cloned repo: %v", err)
+	}
+	tags, err := clonedRepo.Tags()
+	if err != nil {
+		t.Fatalf("tags: %v", err)
+	}
+	tagCount := 0
+	tags.ForEach(func(_ *plumbing.Reference) error { //nolint:errcheck,gosec // counting tags
+		tagCount++
+		return nil
+	})
+	if tagCount != 0 {
+		t.Fatalf("expected 0 tags with NoTags, got %d", tagCount)
+	}
+}
+
+func TestCloneOrPull_PullRespectsDepth(t *testing.T) {
+	bareRepo := newBareRepoWithCommit(t)
+
+	p, err := NewPuller(&AuthConfig{Method: AuthNone}, nil, WithCloneDepth(10))
+	if err != nil {
+		t.Fatalf("new puller: %v", err)
+	}
+
+	destDir := filepath.Join(t.TempDir(), "pull-depth")
+	if _, err := p.CloneOrPull(context.Background(), bareRepo, "master", destDir); err != nil {
+		t.Fatalf("initial clone: %v", err)
+	}
+
+	// Push a new commit.
+	addCommitToBareRepo(t, bareRepo, "new.txt", "new content\n")
+
+	// Pull should succeed and detect the change.
+	changed, err := p.CloneOrPull(context.Background(), bareRepo, "master", destDir)
+	if err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true after new commit")
+	}
+
+	// Verify the new file is present.
+	data, err := os.ReadFile(filepath.Join(destDir, "new.txt")) //nolint:gosec // G304: test reads known path
+	if err != nil {
+		t.Fatalf("read new file: %v", err)
+	}
+	if string(data) != "new content\n" {
+		t.Fatalf("unexpected content: %q", data)
 	}
 }

--- a/internal/gitops/pull_test.go
+++ b/internal/gitops/pull_test.go
@@ -678,6 +678,72 @@ func TestCloneOrPull_NoTagsFetched(t *testing.T) {
 	}
 }
 
+func TestCloneOrPull_PullNoTagsFetched(t *testing.T) {
+	bareRepo := newBareRepoWithCommit(t)
+
+	p, err := NewPuller(&AuthConfig{Method: AuthNone}, nil)
+	if err != nil {
+		t.Fatalf("new puller: %v", err)
+	}
+
+	destDir := filepath.Join(t.TempDir(), "pull-no-tags")
+	if _, err := p.CloneOrPull(context.Background(), bareRepo, "master", destDir); err != nil {
+		t.Fatalf("initial clone: %v", err)
+	}
+
+	// Add a tag and a new commit to the bare repo *after* initial clone.
+	addCommitToBareRepo(t, bareRepo, "tagged.txt", "tagged content\n")
+	bareGit, err := git.PlainOpen(bareRepo)
+	if err != nil {
+		t.Fatalf("open bare repo: %v", err)
+	}
+	head, err := bareGit.Head()
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+	if _, err := bareGit.CreateTag("v2.0.0", head.Hash(), nil); err != nil {
+		t.Fatalf("create tag: %v", err)
+	}
+
+	// Pull — should fetch new commit but NOT the tag.
+	changed, err := p.CloneOrPull(context.Background(), bareRepo, "master", destDir)
+	if err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true after new commit")
+	}
+
+	clonedRepo, err := git.PlainOpen(destDir)
+	if err != nil {
+		t.Fatalf("open cloned repo: %v", err)
+	}
+	tags, err := clonedRepo.Tags()
+	if err != nil {
+		t.Fatalf("tags: %v", err)
+	}
+	tagCount := 0
+	tags.ForEach(func(_ *plumbing.Reference) error { //nolint:errcheck,gosec // counting tags
+		tagCount++
+		return nil
+	})
+	if tagCount != 0 {
+		t.Fatalf("expected 0 tags after pull with NoTags, got %d", tagCount)
+	}
+}
+
+func TestWithCloneDepth_ClampsInvalid(t *testing.T) {
+	for _, depth := range []int{0, -1, -100} {
+		p, err := NewPuller(&AuthConfig{Method: AuthNone}, nil, WithCloneDepth(depth))
+		if err != nil {
+			t.Fatalf("new puller with depth %d: %v", depth, err)
+		}
+		if p.depth != 1 {
+			t.Errorf("WithCloneDepth(%d): got depth %d, want 1", depth, p.depth)
+		}
+	}
+}
+
 func TestCloneOrPull_PullRespectsDepth(t *testing.T) {
 	bareRepo := newBareRepoWithCommit(t)
 


### PR DESCRIPTION
Disables tag fetching for content repos (bandwidth savings).
Adds `sync.clone_depth` config (default 1, recommended 10) to reduce expensive re-clone fallbacks on shallow pull failures.

### Changes
- **No-tags fetch**: `Tags: git.NoTags` on clone; `FetchContext` + hard reset on pull (replaces `PullContext` which lacks a Tags field)
- **Configurable clone depth**: `SyncConfig.CloneDepth` with YAML tag `clone_depth`, env var `BLOGFLOW_SYNC_CLONE_DEPTH`, default 1, validated >= 1
- **PullerOption pattern**: `WithCloneDepth(n)` functional option on `NewPuller`
- **Tests**: 4 new tests covering depth=1, depth=10, no-tags, and pull-respects-depth