### PR TITLE
fix: wire puller into PollStrategy after bootstrap

### DIFF
--- a/cmd/blogflow/bootstrap.go
+++ b/cmd/blogflow/bootstrap.go
@@ -17,16 +17,19 @@ func safeRepoURL(raw string) string { return gitops.SanitizeURL(raw) }
 // cold-start problem for webhook deployments where no content exists until
 // the first push event.
 //
+// Returns the configured Puller (nil on auth/creation failure) plus the
+// resolved branch and dest so callers can reuse them (e.g. poll wiring).
+//
 // Clone failures are logged but non-fatal — the server continues with
 // embedded defaults for graceful degradation.
-func bootstrapContent(cfg *config.Config, contentPath string, logger *slog.Logger) {
+func bootstrapContent(cfg *config.Config, contentPath string, logger *slog.Logger) (puller *gitops.Puller, branch, dest string) {
 	repoURL := cfg.Sync.Repo
-	branch := cfg.Sync.Branch
+	branch = cfg.Sync.Branch
 	if branch == "" {
 		branch = "main"
 	}
 
-	dest := contentPath
+	dest = contentPath
 	if dest == "" {
 		dest = "content"
 	}
@@ -36,13 +39,13 @@ func bootstrapContent(cfg *config.Config, contentPath string, logger *slog.Logge
 	authCfg, err := gitops.LoadAuthFromEnv(logger)
 	if err != nil {
 		logger.Error("content bootstrap: failed to load git auth", "error", err)
-		return
+		return nil, branch, dest
 	}
 
-	puller, err := gitops.NewPuller(authCfg, logger, gitops.WithCloneDepth(cfg.Sync.CloneDepth))
+	puller, err = gitops.NewPuller(authCfg, logger, gitops.WithCloneDepth(cfg.Sync.CloneDepth))
 	if err != nil {
 		logger.Error("content bootstrap: failed to create git puller", "error", err)
-		return
+		return nil, branch, dest
 	}
 	puller.SparseDirs = cfg.Sync.SparseDirs
 
@@ -53,7 +56,7 @@ func bootstrapContent(cfg *config.Config, contentPath string, logger *slog.Logge
 	if err != nil {
 		logger.Error("content bootstrap: clone/pull failed — continuing with defaults",
 			"repo", safeRepoURL(repoURL), "error", err)
-		return
+		return puller, branch, dest
 	}
 
 	if changed {
@@ -61,4 +64,5 @@ func bootstrapContent(cfg *config.Config, contentPath string, logger *slog.Logge
 	} else {
 		logger.Info("content bootstrap: repository already up to date", "repo", safeRepoURL(repoURL), "branch", branch)
 	}
+	return puller, branch, dest
 }

--- a/cmd/blogflow/bootstrap_test.go
+++ b/cmd/blogflow/bootstrap_test.go
@@ -67,7 +67,16 @@ func TestBootstrapContent_ClonesRepo(t *testing.T) {
 
 	logger := slog.Default()
 
-	bootstrapContent(cfg, destDir, logger)
+	puller, branch, dest := bootstrapContent(cfg, destDir, logger)
+	if puller == nil {
+		t.Fatal("expected non-nil puller after successful bootstrap")
+	}
+	if branch != "master" {
+		t.Errorf("expected branch %q, got %q", "master", branch)
+	}
+	if dest != destDir {
+		t.Errorf("expected dest %q, got %q", destDir, dest)
+	}
 
 	// Verify the cloned content exists.
 	postPath := filepath.Join(destDir, "posts", "test.md")
@@ -92,7 +101,9 @@ func TestBootstrapContent_CloneFailureIsNonFatal(t *testing.T) {
 	logger := slog.Default()
 
 	// Should not panic — clone failure is logged but non-fatal.
-	bootstrapContent(cfg, destDir, logger)
+	puller, _, _ := bootstrapContent(cfg, destDir, logger)
+	// Puller may be non-nil (auth succeeded) even if clone failed, or nil if auth failed.
+	_ = puller
 
 	// Dest dir may or may not exist; the important thing is no panic/crash.
 	if _, err := os.Stat(filepath.Join(destDir, ".git")); err == nil {
@@ -114,7 +125,10 @@ func TestBootstrapContent_DefaultBranch(t *testing.T) {
 
 	// "main" branch doesn't exist in our test repo (it uses "master"),
 	// so this should fail gracefully.
-	bootstrapContent(cfg, destDir, logger)
+	_, branch, _ := bootstrapContent(cfg, destDir, logger)
+	if branch != "main" {
+		t.Errorf("expected default branch %q, got %q", "main", branch)
+	}
 
 	// Non-fatal: server would continue.
 }
@@ -142,7 +156,10 @@ func TestBootstrapContent_DefaultContentPath(t *testing.T) {
 	logger := slog.Default()
 
 	// Empty contentPath should default to "content".
-	bootstrapContent(cfg, "", logger)
+	_, _, dest := bootstrapContent(cfg, "", logger)
+	if dest != "content" {
+		t.Errorf("expected default dest %q, got %q", "content", dest)
+	}
 
 	postPath := filepath.Join(tmpDir, "content", "posts", "test.md")
 	if _, err := os.Stat(postPath); err != nil {
@@ -163,10 +180,10 @@ func TestBootstrapContent_PullExisting(t *testing.T) {
 	logger := slog.Default()
 
 	// First clone.
-	bootstrapContent(cfg, destDir, logger)
+	bootstrapContent(cfg, destDir, logger) //nolint:dogsled
 
 	// Second call should pull (not re-clone) and succeed.
-	bootstrapContent(cfg, destDir, logger)
+	bootstrapContent(cfg, destDir, logger) //nolint:dogsled
 
 	postPath := filepath.Join(destDir, "posts", "test.md")
 	if _, err := os.Stat(postPath); err != nil {

--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -118,8 +118,13 @@ func main() {
 	logger.Info("configuration loaded", "port", cfg.Server.Port, "theme", cfg.Theme.Name)
 
 	// 2b. Content bootstrap: clone repo before scanning
+	var (
+		bootstrapPuller *gitops.Puller
+		repoBranch      string
+		repoDest        string
+	)
 	if cfg.Sync.Repo != "" {
-		bootstrapContent(cfg, *contentPath, logger)
+		bootstrapPuller, repoBranch, repoDest = bootstrapContent(cfg, *contentPath, logger)
 	}
 
 	// 3. Initialize content pipeline
@@ -169,27 +174,12 @@ func main() {
 		ws.SetDirs(*contentPath)
 	}
 
-	// Wire up puller for poll sync
+	// Wire up puller for poll sync (reuse bootstrap's Puller to avoid duplicate auth)
 	if ps, ok := syncStrategy.(*gitops.PollStrategy); ok && cfg.Sync.Repo != "" {
-		authCfg, authErr := gitops.LoadAuthFromEnv(logger)
-		if authErr != nil {
-			logger.Error("failed to load git auth for poll strategy", "error", authErr)
+		if bootstrapPuller != nil {
+			ps.SetPuller(bootstrapPuller, cfg.Sync.Repo, repoBranch, repoDest)
 		} else {
-			puller, pullerErr := gitops.NewPuller(authCfg, logger)
-			if pullerErr != nil {
-				logger.Error("failed to create git puller for poll strategy", "error", pullerErr)
-			} else {
-				puller.SparseDirs = cfg.Sync.SparseDirs
-				branch := cfg.Sync.Branch
-				if branch == "" {
-					branch = "main"
-				}
-				dest := *contentPath
-				if dest == "" {
-					dest = "content"
-				}
-				ps.SetPuller(puller, cfg.Sync.Repo, branch, dest)
-			}
+			logger.Warn("poll sync not activated — git puller unavailable (check auth config)")
 		}
 	}
 

--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -169,6 +169,30 @@ func main() {
 		ws.SetDirs(*contentPath)
 	}
 
+	// Wire up puller for poll sync
+	if ps, ok := syncStrategy.(*gitops.PollStrategy); ok && cfg.Sync.Repo != "" {
+		authCfg, authErr := gitops.LoadAuthFromEnv(logger)
+		if authErr != nil {
+			logger.Error("failed to load git auth for poll strategy", "error", authErr)
+		} else {
+			puller, pullerErr := gitops.NewPuller(authCfg, logger)
+			if pullerErr != nil {
+				logger.Error("failed to create git puller for poll strategy", "error", pullerErr)
+			} else {
+				puller.SparseDirs = cfg.Sync.SparseDirs
+				branch := cfg.Sync.Branch
+				if branch == "" {
+					branch = "main"
+				}
+				dest := *contentPath
+				if dest == "" {
+					dest = "content"
+				}
+				ps.SetPuller(puller, cfg.Sync.Repo, branch, dest)
+			}
+		}
+	}
+
 	// 10. Register routes
 	staticFS, fsErr := fs.Sub(contentOverlay, "static")
 	if fsErr != nil {


### PR DESCRIPTION
## Problem
When `sync.strategy=poll` is configured, the content bootstrap successfully clones the repository but the ongoing poll sync is never activated because `SetPuller()` is never called on the PollStrategy.

## Fix
After creating the sync strategy in `main.go`, detect PollStrategy and wire a Puller with the configured repo URL, branch, sparse dirs, and content path — matching what bootstrap does.

## Changes
- `cmd/blogflow/main.go` — added PollStrategy type assertion + SetPuller wiring (24 lines)

Fixes #117