### PR TITLE
feat: restore NewOverlayFS variadic signature per design spec

### DIFF
--- a/internal/overlayfs/overlayfs.go
+++ b/internal/overlayfs/overlayfs.go
@@ -71,17 +71,13 @@ type resolution struct {
 // NewOverlayFS creates a new overlay with the given layers.
 // Layers are in priority order: layers[0] is checked first.
 // Nil layers are silently skipped.
-func NewOverlayFS(layers []fs.FS, names []string) *OverlayFS {
+func NewOverlayFS(layers ...fs.FS) *OverlayFS {
 	var filtered []fs.FS
 	var filteredNames []string
 	for i, l := range layers {
 		if l != nil {
 			filtered = append(filtered, l)
-			if i < len(names) {
-				filteredNames = append(filteredNames, names[i])
-			} else {
-				filteredNames = append(filteredNames, fmt.Sprintf("layer-%d", i))
-			}
+			filteredNames = append(filteredNames, fmt.Sprintf("layer-%d", i))
 		}
 	}
 	return &OverlayFS{
@@ -90,6 +86,19 @@ func NewOverlayFS(layers []fs.FS, names []string) *OverlayFS {
 		layerMeta:          make([]layerMeta, len(filtered)),
 		maxNegCacheEntries: 100_000,
 	}
+}
+
+// WithLayerNames sets human-readable names for the overlay layers.
+// Names correspond positionally to the non-nil layers passed to NewOverlayFS.
+// If fewer names than layers are provided, remaining layers keep their
+// default "layer-N" names.
+func (o *OverlayFS) WithLayerNames(names []string) *OverlayFS {
+	for i, n := range names {
+		if i < len(o.layerNames) {
+			o.layerNames[i] = n
+		}
+	}
+	return o
 }
 
 // NewFromPaths constructs the standard 4-layer BlogFlow overlay.
@@ -139,7 +148,7 @@ func NewFromPaths(themePath, contentPath, configPath string, defaults fs.FS) (*O
 		names = append(names, "defaults")
 	}
 
-	ofs := NewOverlayFS(layers, names)
+	ofs := NewOverlayFS(layers...).WithLayerNames(names)
 	for i, rp := range resolvedPaths {
 		if i < len(ofs.layerMeta) {
 			ofs.layerMeta[i] = layerMeta{rootPath: rp, isDisk: true}
@@ -155,7 +164,7 @@ func NewFromEmbed(defaults embed.FS, prefix string) (*OverlayFS, error) {
 	if err != nil {
 		return nil, fmt.Errorf("overlayfs: fs.Sub(%q): %w", prefix, err)
 	}
-	return NewOverlayFS([]fs.FS{sub}, []string{"defaults"}), nil
+	return NewOverlayFS(sub).WithLayerNames([]string{"defaults"}), nil
 }
 
 // Open implements fs.FS. Returns the file from the highest-priority

--- a/internal/overlayfs/overlayfs_bench_test.go
+++ b/internal/overlayfs/overlayfs_bench_test.go
@@ -24,7 +24,7 @@ func benchOverlay(filesPerLayer int) *OverlayFS {
 		layers[li] = m
 	}
 
-	return NewOverlayFS(layers, names)
+	return NewOverlayFS(layers...).WithLayerNames(names)
 }
 
 // benchReadDirOverlay builds an overlay where each layer contributes
@@ -42,7 +42,7 @@ func benchReadDirOverlay(entriesPerLayer int) *OverlayFS {
 		layers[li] = m
 	}
 
-	return NewOverlayFS(layers, names)
+	return NewOverlayFS(layers...).WithLayerNames(names)
 }
 
 func BenchmarkOpen_TopLayer(b *testing.B) {

--- a/internal/overlayfs/overlayfs_test.go
+++ b/internal/overlayfs/overlayfs_test.go
@@ -268,11 +268,77 @@ func TestReadDir_PartialLayers(t *testing.T) {
 // §3.2 #10: Nil layer in constructor
 func TestNewOverlayFS_NilLayers(t *testing.T) {
 	defaults := fstest.MapFS{"test.txt": {Data: []byte("hello")}}
-	ofs := NewOverlayFS(nil, defaults, nil).WithLayerNames([]string{"nil1", "defaults", "nil2"})
+	// After nil-filtering only one layer survives, so pass one name.
+	ofs := NewOverlayFS(nil, defaults, nil).WithLayerNames([]string{"defaults"})
 
 	if ofs.LayerCount() != 1 {
 		t.Errorf("LayerCount() = %d, want 1 (nil layers should be skipped)", ofs.LayerCount())
 	}
+
+	res, err := ofs.resolveInfo("test.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.LayerName != "defaults" {
+		t.Errorf("LayerName = %q, want %q", res.LayerName, "defaults")
+	}
+}
+
+// WithLayerNames: full, partial, and excess name lists
+func TestWithLayerNames(t *testing.T) {
+	a := fstest.MapFS{"a.txt": {Data: []byte("a")}}
+	b := fstest.MapFS{"b.txt": {Data: []byte("b")}}
+	c := fstest.MapFS{"c.txt": {Data: []byte("c")}}
+
+	t.Run("exact", func(t *testing.T) {
+		ofs := NewOverlayFS(a, b, c).WithLayerNames([]string{"alpha", "beta", "gamma"})
+		for _, tc := range []struct {
+			file, wantName string
+			wantIdx        int
+		}{
+			{"a.txt", "alpha", 0},
+			{"b.txt", "beta", 1},
+			{"c.txt", "gamma", 2},
+		} {
+			res, err := ofs.resolveInfo(tc.file)
+			if err != nil {
+				t.Fatalf("resolveInfo(%q): %v", tc.file, err)
+			}
+			if res.LayerName != tc.wantName {
+				t.Errorf("resolveInfo(%q).LayerName = %q, want %q", tc.file, res.LayerName, tc.wantName)
+			}
+			if res.LayerIndex != tc.wantIdx {
+				t.Errorf("resolveInfo(%q).LayerIndex = %d, want %d", tc.file, res.LayerIndex, tc.wantIdx)
+			}
+		}
+	})
+
+	t.Run("fewer_names", func(t *testing.T) {
+		ofs := NewOverlayFS(a, b, c).WithLayerNames([]string{"alpha"})
+		res, err := ofs.resolveInfo("a.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.LayerName != "alpha" {
+			t.Errorf("LayerName = %q, want %q", res.LayerName, "alpha")
+		}
+		// Unnamed layers keep their default "layer-N" name.
+		res, err = ofs.resolveInfo("c.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.LayerName != "layer-2" {
+			t.Errorf("LayerName = %q, want %q", res.LayerName, "layer-2")
+		}
+	})
+
+	t.Run("excess_names", func(t *testing.T) {
+		// More names than layers should not panic.
+		ofs := NewOverlayFS(a).WithLayerNames([]string{"alpha", "beta", "gamma"})
+		if ofs.LayerCount() != 1 {
+			t.Errorf("LayerCount() = %d, want 1", ofs.LayerCount())
+		}
+	})
 }
 
 // §3.2 #11: Zero layers

--- a/internal/overlayfs/overlayfs_test.go
+++ b/internal/overlayfs/overlayfs_test.go
@@ -13,7 +13,7 @@ func newTestOverlay(layers ...fs.FS) *OverlayFS {
 	for i := range layers {
 		names[i] = layerName(i)
 	}
-	return NewOverlayFS(layers, names)
+	return NewOverlayFS(layers...).WithLayerNames(names)
 }
 
 func layerName(i int) string {
@@ -268,7 +268,7 @@ func TestReadDir_PartialLayers(t *testing.T) {
 // §3.2 #10: Nil layer in constructor
 func TestNewOverlayFS_NilLayers(t *testing.T) {
 	defaults := fstest.MapFS{"test.txt": {Data: []byte("hello")}}
-	ofs := NewOverlayFS([]fs.FS{nil, defaults, nil}, []string{"nil1", "defaults", "nil2"})
+	ofs := NewOverlayFS(nil, defaults, nil).WithLayerNames([]string{"nil1", "defaults", "nil2"})
 
 	if ofs.LayerCount() != 1 {
 		t.Errorf("LayerCount() = %d, want 1 (nil layers should be skipped)", ofs.LayerCount())
@@ -277,7 +277,7 @@ func TestNewOverlayFS_NilLayers(t *testing.T) {
 
 // §3.2 #11: Zero layers
 func TestNewOverlayFS_ZeroLayers(t *testing.T) {
-	ofs := NewOverlayFS(nil, nil)
+	ofs := NewOverlayFS()
 	_, err := ofs.Open("anything.txt")
 	if err == nil {
 		t.Fatal("expected error with zero layers")


### PR DESCRIPTION
Changes `NewOverlayFS([]fs.FS, []string)` to `NewOverlayFS(...fs.FS)`.
Layer names set via `WithLayerNames` method.

- Signature now matches the design spec: `NewOverlayFS(layers ...fs.FS) *OverlayFS`
- Added `WithLayerNames(names []string) *OverlayFS` method for setting layer names
- Updated all internal callers (`NewFromPaths`, `NewFromEmbed`, tests, benchmarks)
- All tests pass with `-race`

Fixes #7