### PR TITLE
feat(theme): add Unicode/i18n support to urlize

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/yuin/goldmark v1.7.17
 	github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc
 	golang.org/x/crypto v0.45.0
+	golang.org/x/text v0.35.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/term v0.37.0 h1:8EGAD0qCmHYZg6J17DvsMy9/wJ7/D/4pV/wfnld5lTU=
 golang.org/x/term v0.37.0/go.mod h1:5pB4lxRNYYVZuTLmy8oR2BH8dflOR+IbTYFD8fi3254=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.31.0 h1:aC8ghyu4JhP8VojJ2lEHBnochRno1sgL6nEi9WGFGMM=
-golang.org/x/text v0.31.0/go.mod h1:tKRAlv61yKIjGGHX/4tP1LTbc13YSec1pxVEWXzfoeM=
+golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
+golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/protobuf v1.36.8 h1:xHScyCOEuuwZEc6UtSOvPbAT4zRh0xcNRYekJwfqyMc=
 google.golang.org/protobuf v1.36.8/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -12,6 +12,9 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unicode"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 // Engine loads and caches templates from the overlay FS.
@@ -160,19 +163,9 @@ func defaultFuncMap() template.FuncMap {
 			}
 			return 1
 		},
-		"urlize": func(s string) string {
-			s = strings.ToLower(s)
-			s = strings.ReplaceAll(s, " ", "-")
-			var b strings.Builder
-			for _, r := range s {
-				if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
-					b.WriteRune(r)
-				}
-			}
-			return b.String()
-		},
-		"add": func(a, b int) int { return a + b },
-		"sub": func(a, b int) int { return a - b },
+		"urlize": urlize,
+		"add":    func(a, b int) int { return a + b },
+		"sub":    func(a, b int) int { return a - b },
 		"seq": func(start, end int) ([]int, error) {
 			if end-start > 10000 || end-start < 0 {
 				return nil, fmt.Errorf("seq: range %d exceeds maximum 10000", end-start)
@@ -184,4 +177,36 @@ func defaultFuncMap() template.FuncMap {
 			return s, nil
 		},
 	}
+}
+
+// urlize converts a human-readable title into a URL-safe slug.
+//
+// It lowercases the input, decomposes Unicode characters via NFKD normalization,
+// strips combining marks (diacritics) so that e.g. "é"→"e", and keeps non-Latin
+// scripts (CJK, Arabic, etc.) intact so browsers can percent-encode them.
+func urlize(s string) string {
+	s = strings.ToLower(s)
+
+	// NFKD decomposition splits characters like "é" into "e" + combining accent.
+	s = norm.NFKD.String(s)
+
+	s = strings.ReplaceAll(s, " ", "-")
+
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-':
+			b.WriteRune(r)
+		case unicode.Is(unicode.Mn, r):
+			// Drop combining marks (diacritics) left over from NFKD.
+		default:
+			// Keep non-Latin scripts (CJK, Cyrillic, Arabic, etc.) as-is.
+			if unicode.IsLetter(r) || unicode.IsNumber(r) {
+				b.WriteRune(r)
+			}
+		}
+	}
+
+	// NFC recomposition restores Hangul Jamo sequences back into syllable blocks.
+	return norm.NFC.String(b.String())
 }

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -179,16 +179,31 @@ func defaultFuncMap() template.FuncMap {
 	}
 }
 
+// latinTranslit maps non-decomposable Latin characters to ASCII equivalents.
+// NFKD handles most diacritics (é→e, ü→u) but these characters have no
+// Unicode decomposition and must be transliterated explicitly.
+var latinTranslit = map[rune]string{
+	'ß': "ss", 'æ': "ae", 'œ': "oe",
+	'ø': "o", 'đ': "d", 'ł': "l",
+	'þ': "th", 'ð': "d",
+}
+
 // urlize converts a human-readable title into a URL-safe slug.
 //
 // It lowercases the input, decomposes Unicode characters via NFKD normalization,
-// strips combining marks (diacritics) so that e.g. "é"→"e", and keeps non-Latin
+// strips combining marks (diacritics) so that e.g. "é"→"e", transliterates
+// non-decomposable Latin characters (ß→ss, æ→ae), and keeps non-Latin
 // scripts (CJK, Arabic, etc.) intact so browsers can percent-encode them.
 func urlize(s string) string {
 	s = strings.ToLower(s)
 
 	// NFKD decomposition splits characters like "é" into "e" + combining accent.
 	s = norm.NFKD.String(s)
+
+	// Transliterate Latin characters that NFKD does not decompose.
+	for old, repl := range latinTranslit {
+		s = strings.ReplaceAll(s, string(old), repl)
+	}
 
 	s = strings.ReplaceAll(s, " ", "-")
 

--- a/internal/theme/urlize_test.go
+++ b/internal/theme/urlize_test.go
@@ -18,8 +18,27 @@ func TestUrlize(t *testing.T) {
 		// Latin diacritics — decompose + strip combining marks.
 		{name: "cafe acute", input: "café", want: "cafe"},
 		{name: "german umlauts", input: "Ärger über Öl", want: "arger-uber-ol"},
+		{name: "german eszett", input: "Straße", want: "strasse"},
 		{name: "spanish enye", input: "Año Nuevo", want: "ano-nuevo"},
 		{name: "mixed diacritics", input: "Crème Brûlée", want: "creme-brulee"},
+
+		// Non-decomposable Latin characters — explicit transliteration.
+		{name: "ae ligature", input: "Ærodynamik", want: "aerodynamik"},
+		{name: "oe ligature", input: "Œuvre", want: "oeuvre"},
+		{name: "danish oe", input: "Ørsted", want: "orsted"},
+		{name: "polish l stroke", input: "Łódź", want: "lodz"},
+		{name: "icelandic thorn", input: "Þór", want: "thor"},
+		{name: "icelandic eth", input: "Norðurland", want: "nordurland"},
+
+		// Turkish İ — combining dot above must be stripped after NFKD.
+		{name: "turkish dotted I", input: "İstanbul", want: "istanbul"},
+
+		// Zero-width / invisible characters — must be stripped.
+		{name: "zero-width space", input: "hello\u200Bworld", want: "helloworld"},
+		{name: "zero-width joiner", input: "hello\u200Dworld", want: "helloworld"},
+		{name: "zero-width non-joiner", input: "hello\u200Cworld", want: "helloworld"},
+		{name: "soft hyphen", input: "break\u00ADpoint", want: "breakpoint"},
+		{name: "BOM", input: "\uFEFFtitle", want: "title"},
 
 		// CJK — characters preserved as-is.
 		{name: "chinese title", input: "你好世界", want: "你好世界"},

--- a/internal/theme/urlize_test.go
+++ b/internal/theme/urlize_test.go
@@ -1,0 +1,43 @@
+package theme
+
+import "testing"
+
+func TestUrlize(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		// Backward-compatible ASCII behavior.
+		{name: "simple ascii", input: "Hello World", want: "hello-world"},
+		{name: "punctuation stripped", input: "Hello, World!", want: "hello-world"},
+		{name: "multiple spaces", input: "a  b", want: "a--b"},
+		{name: "empty string", input: "", want: ""},
+		{name: "already a slug", input: "my-post", want: "my-post"},
+
+		// Latin diacritics — decompose + strip combining marks.
+		{name: "cafe acute", input: "café", want: "cafe"},
+		{name: "german umlauts", input: "Ärger über Öl", want: "arger-uber-ol"},
+		{name: "spanish enye", input: "Año Nuevo", want: "ano-nuevo"},
+		{name: "mixed diacritics", input: "Crème Brûlée", want: "creme-brulee"},
+
+		// CJK — characters preserved as-is.
+		{name: "chinese title", input: "你好世界", want: "你好世界"},
+		{name: "japanese title", input: "東京タワー", want: "東京タワー"},
+		{name: "korean title", input: "서울 타워", want: "서울-타워"},
+
+		// Mixed scripts.
+		{name: "mixed latin-cjk", input: "Go语言 Blog", want: "go语言-blog"},
+		{name: "cyrillic", input: "Привет Мир", want: "привет-мир"},
+		{name: "arabic", input: "مرحبا بالعالم", want: "مرحبا-بالعالم"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := urlize(tt.input)
+			if got != tt.want {
+				t.Errorf("urlize(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add Unicode normalization and transliteration to the `urlize` template function so international blog titles produce correct URL slugs.

### Changes
- **NFKD decomposition** via `golang.org/x/text/unicode/norm` splits accented characters into base + combining mark
- **Diacritic stripping** removes combining marks for clean ASCII slugs (é→e, ü→u, ñ→n)
- **Non-Latin script preservation** keeps CJK, Cyrillic, Arabic, Hangul characters intact (browsers percent-encode them)
- **NFC recomposition** restores decomposed Hangul Jamo back into syllable blocks
- ASCII-only input behavior is unchanged (backward compatible)

### Tests added (16 cases)
- ASCII backward compatibility (simple text, punctuation, empty string)
- Latin diacritics (café, German umlauts, Spanish ñ, French accents)
- CJK preservation (Chinese, Japanese, Korean)
- Mixed scripts, Cyrillic, Arabic

Fixes #22