### PR TITLE
feat(overlayfs): add ContextOverlayFS with context support

### DIFF
--- a/internal/overlayfs/context.go
+++ b/internal/overlayfs/context.go
@@ -50,8 +50,9 @@ func (c *ContextOverlayFS) Inner() *OverlayFS {
 	return c.inner
 }
 
-// Open opens a file with context support. Checks ctx.Done() before each
-// layer attempt. Logs WARN on path traversal attempts with request context values.
+// Open opens a file with context support. Checks ctx.Err() before
+// delegating to the inner OverlayFS. Logs WARN on path traversal attempts
+// with request context values.
 func (c *ContextOverlayFS) Open(ctx context.Context, name string) (fs.File, error) {
 	if err := c.checkPath(ctx, "open", name); err != nil {
 		return nil, err
@@ -162,7 +163,7 @@ func (c *ContextOverlayFS) checkPath(ctx context.Context, op, name string) error
 
 // logOperation logs span-like info for each FS operation via slog.
 func (c *ContextOverlayFS) logOperation(ctx context.Context, op, name string, start time.Time, err error) {
-	if c.logger == nil {
+	if c.logger == nil || !c.logger.Enabled(ctx, slog.LevelDebug) {
 		return
 	}
 	duration := time.Since(start)

--- a/internal/overlayfs/context.go
+++ b/internal/overlayfs/context.go
@@ -36,8 +36,18 @@ type ContextOverlayFS struct {
 
 // NewContextOverlayFS creates a context-aware overlay wrapping the given OverlayFS.
 // A nil logger is safe — logging will be silently skipped.
+// Panics if inner is nil (programming error).
 func NewContextOverlayFS(inner *OverlayFS, logger *slog.Logger) *ContextOverlayFS {
+	if inner == nil {
+		panic("overlayfs: NewContextOverlayFS called with nil OverlayFS")
+	}
 	return &ContextOverlayFS{inner: inner, logger: logger}
+}
+
+// Inner returns the underlying OverlayFS for callers that need a plain
+// fs.FS (e.g., html/template.ParseFS).
+func (c *ContextOverlayFS) Inner() *OverlayFS {
+	return c.inner
 }
 
 // Open opens a file with context support. Checks ctx.Done() before each

--- a/internal/overlayfs/context.go
+++ b/internal/overlayfs/context.go
@@ -1,0 +1,179 @@
+package overlayfs
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"time"
+)
+
+// contextKey is an unexported type for context keys defined in this package,
+// preventing collisions with keys defined in other packages.
+type contextKey int
+
+const (
+	// RequestIDKey is the context key for the HTTP request ID (string).
+	// HTTP middleware populates this for log correlation and tracing.
+	RequestIDKey contextKey = iota
+
+	// RemoteAddrKey is the context key for the client's remote address (string).
+	// Used in security WARN logs for path traversal attribution.
+	RemoteAddrKey
+)
+
+// ContextOverlayFS wraps OverlayFS with context.Context support for
+// cancellation, tracing, and security log correlation. This is the
+// public API surface — consumers should use this type, not OverlayFS directly.
+//
+// It does NOT implement io/fs.FS because its methods require context.Context.
+// For stdlib consumers that need fs.FS (e.g., html/template.ParseFS), use
+// the inner OverlayFS directly.
+type ContextOverlayFS struct {
+	inner  *OverlayFS
+	logger *slog.Logger
+}
+
+// NewContextOverlayFS creates a context-aware overlay wrapping the given OverlayFS.
+// A nil logger is safe — logging will be silently skipped.
+func NewContextOverlayFS(inner *OverlayFS, logger *slog.Logger) *ContextOverlayFS {
+	return &ContextOverlayFS{inner: inner, logger: logger}
+}
+
+// Open opens a file with context support. Checks ctx.Done() before each
+// layer attempt. Logs WARN on path traversal attempts with request context values.
+func (c *ContextOverlayFS) Open(ctx context.Context, name string) (fs.File, error) {
+	if err := c.checkPath(ctx, "open", name); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("overlayfs: open %q: %w", name, err)
+	}
+
+	start := time.Now()
+	f, err := c.inner.Open(name)
+	c.logOperation(ctx, "open", name, start, err)
+	return f, err
+}
+
+// ReadFile reads a file with context support.
+func (c *ContextOverlayFS) ReadFile(ctx context.Context, name string) ([]byte, error) {
+	if err := c.checkPath(ctx, "readfile", name); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("overlayfs: readfile %q: %w", name, err)
+	}
+
+	start := time.Now()
+	data, err := c.inner.ReadFile(name)
+	c.logOperation(ctx, "readfile", name, start, err)
+	return data, err
+}
+
+// ReadDir lists a directory with context support.
+func (c *ContextOverlayFS) ReadDir(ctx context.Context, name string) ([]fs.DirEntry, error) {
+	if err := c.checkPath(ctx, "readdir", name); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("overlayfs: readdir %q: %w", name, err)
+	}
+
+	start := time.Now()
+	entries, err := c.inner.ReadDir(name)
+	c.logOperation(ctx, "readdir", name, start, err)
+	return entries, err
+}
+
+// Stat returns file info with context support.
+func (c *ContextOverlayFS) Stat(ctx context.Context, name string) (fs.FileInfo, error) {
+	if err := c.checkPath(ctx, "stat", name); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("overlayfs: stat %q: %w", name, err)
+	}
+
+	start := time.Now()
+	info, err := c.inner.Stat(name)
+	c.logOperation(ctx, "stat", name, start, err)
+	return info, err
+}
+
+// OpenFile opens a file and returns both handle and FileInfo atomically
+// from a single layer resolution, with context support.
+func (c *ContextOverlayFS) OpenFile(ctx context.Context, name string) (fs.File, fs.FileInfo, error) {
+	if err := c.checkPath(ctx, "openfile", name); err != nil {
+		return nil, nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, nil, fmt.Errorf("overlayfs: openfile %q: %w", name, err)
+	}
+
+	start := time.Now()
+	f, info, err := c.inner.OpenFile(name)
+	c.logOperation(ctx, "openfile", name, start, err)
+	return f, info, err
+}
+
+// InvalidateLayer delegates to the inner OverlayFS.
+func (c *ContextOverlayFS) InvalidateLayer(layerIndex int) {
+	c.inner.InvalidateLayer(layerIndex)
+}
+
+// InvalidateAll delegates to the inner OverlayFS.
+func (c *ContextOverlayFS) InvalidateAll() {
+	c.inner.InvalidateAll()
+}
+
+// ReplaceLayer delegates to the inner OverlayFS.
+func (c *ContextOverlayFS) ReplaceLayer(layerIndex int, newFS fs.FS) error {
+	return c.inner.ReplaceLayer(layerIndex, newFS)
+}
+
+// checkPath validates the path and logs a WARN on traversal attempts.
+func (c *ContextOverlayFS) checkPath(ctx context.Context, op, name string) error {
+	if fs.ValidPath(name) {
+		return nil
+	}
+
+	if c.logger != nil {
+		c.logger.WarnContext(ctx, "path traversal attempt",
+			slog.String("op", op),
+			slog.String("path", name),
+			slog.String("request_id", contextString(ctx, RequestIDKey)),
+			slog.String("remote_addr", contextString(ctx, RemoteAddrKey)),
+		)
+	}
+
+	return &fs.PathError{Op: op, Path: name, Err: fs.ErrInvalid}
+}
+
+// logOperation logs span-like info for each FS operation via slog.
+func (c *ContextOverlayFS) logOperation(ctx context.Context, op, name string, start time.Time, err error) {
+	if c.logger == nil {
+		return
+	}
+	duration := time.Since(start)
+
+	attrs := []slog.Attr{
+		slog.String("op", op),
+		slog.String("path", name),
+		slog.Duration("duration", duration),
+		slog.String("request_id", contextString(ctx, RequestIDKey)),
+	}
+
+	if err != nil {
+		attrs = append(attrs, slog.String("error", err.Error()))
+		c.logger.LogAttrs(ctx, slog.LevelDebug, "overlayfs operation failed", attrs...)
+	} else {
+		c.logger.LogAttrs(ctx, slog.LevelDebug, "overlayfs operation", attrs...)
+	}
+}
+
+// contextString extracts a string value from the context, returning "" if absent.
+func contextString(ctx context.Context, key contextKey) string {
+	v, _ := ctx.Value(key).(string)
+	return v
+}

--- a/internal/overlayfs/context_test.go
+++ b/internal/overlayfs/context_test.go
@@ -1,0 +1,383 @@
+package overlayfs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"io/fs"
+	"log/slog"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func newTestContextOverlay(logger *slog.Logger, layers ...fs.FS) *ContextOverlayFS {
+	names := make([]string, len(layers))
+	for i := range layers {
+		names[i] = layerName(i)
+	}
+	return NewContextOverlayFS(NewOverlayFS(layers, names), logger)
+}
+
+// --- Context cancellation aborts resolution ---
+
+func TestContextOpen_Cancelled(t *testing.T) {
+	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+	cfs := newTestContextOverlay(nil, layer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := cfs.Open(ctx, "file.txt")
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestContextReadFile_Cancelled(t *testing.T) {
+	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+	cfs := newTestContextOverlay(nil, layer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := cfs.ReadFile(ctx, "file.txt")
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestContextReadDir_Cancelled(t *testing.T) {
+	layer := fstest.MapFS{"dir/file.txt": {Data: []byte("data")}}
+	cfs := newTestContextOverlay(nil, layer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := cfs.ReadDir(ctx, "dir")
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestContextStat_Cancelled(t *testing.T) {
+	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+	cfs := newTestContextOverlay(nil, layer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := cfs.Stat(ctx, "file.txt")
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestContextOpenFile_Cancelled(t *testing.T) {
+	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+	cfs := newTestContextOverlay(nil, layer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, err := cfs.OpenFile(ctx, "file.txt")
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// --- Security logging on path traversal ---
+
+func TestContextOpen_PathTraversalLogged(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	cfs := newTestContextOverlay(logger, fstest.MapFS{})
+
+	ctx := context.WithValue(context.Background(), RequestIDKey, "req-123")
+	ctx = context.WithValue(ctx, RemoteAddrKey, "192.168.1.100")
+
+	_, err := cfs.Open(ctx, "../etc/passwd")
+	if err == nil {
+		t.Fatal("expected error for path traversal")
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "path traversal attempt") {
+		t.Error("expected 'path traversal attempt' in log")
+	}
+	if !strings.Contains(logged, "req-123") {
+		t.Error("expected request_id in log")
+	}
+	if !strings.Contains(logged, "192.168.1.100") {
+		t.Error("expected remote_addr in log")
+	}
+}
+
+func TestContextReadFile_PathTraversalLogged(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	cfs := newTestContextOverlay(logger, fstest.MapFS{})
+
+	ctx := context.WithValue(context.Background(), RequestIDKey, "req-456")
+	_, err := cfs.ReadFile(ctx, "/etc/shadow")
+	if err == nil {
+		t.Fatal("expected error for absolute path")
+	}
+	if !strings.Contains(buf.String(), "path traversal attempt") {
+		t.Error("expected security log")
+	}
+}
+
+func TestContextStat_PathTraversalLogged(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	cfs := newTestContextOverlay(logger, fstest.MapFS{})
+
+	_, err := cfs.Stat(context.Background(), "../etc/passwd")
+	if err == nil {
+		t.Fatal("expected error for traversal path")
+	}
+	if !strings.Contains(buf.String(), "path traversal attempt") {
+		t.Error("expected security log")
+	}
+}
+
+// --- All FS methods work through the wrapper ---
+
+func TestContextOpen_Works(t *testing.T) {
+	theme := fstest.MapFS{"templates/post.html": {Data: []byte("theme-post")}}
+	defaults := fstest.MapFS{"templates/post.html": {Data: []byte("default-post")}}
+	cfs := newTestContextOverlay(nil, theme, defaults)
+
+	f, err := cfs.Open(context.Background(), "templates/post.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "theme-post" {
+		t.Errorf("got %q, want %q", data, "theme-post")
+	}
+}
+
+func TestContextReadFile_Works(t *testing.T) {
+	layer := fstest.MapFS{"file.txt": {Data: []byte("hello")}}
+	cfs := newTestContextOverlay(nil, layer)
+
+	data, err := cfs.ReadFile(context.Background(), "file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("got %q, want %q", data, "hello")
+	}
+}
+
+func TestContextReadFile_Fallback(t *testing.T) {
+	theme := fstest.MapFS{}
+	defaults := fstest.MapFS{"base.html": {Data: []byte("default-base")}}
+	cfs := newTestContextOverlay(nil, theme, defaults)
+
+	data, err := cfs.ReadFile(context.Background(), "base.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "default-base" {
+		t.Errorf("got %q, want %q", data, "default-base")
+	}
+}
+
+func TestContextReadDir_Works(t *testing.T) {
+	theme := fstest.MapFS{
+		"templates/a.html": {Data: []byte("a")},
+	}
+	defaults := fstest.MapFS{
+		"templates/b.html": {Data: []byte("b")},
+	}
+	cfs := newTestContextOverlay(nil, theme, defaults)
+
+	entries, err := cfs.ReadDir(context.Background(), "templates")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(entries))
+	}
+	if entries[0].Name() != "a.html" || entries[1].Name() != "b.html" {
+		t.Errorf("got [%s, %s], want [a.html, b.html]", entries[0].Name(), entries[1].Name())
+	}
+}
+
+func TestContextStat_Works(t *testing.T) {
+	layer := fstest.MapFS{"file.txt": {Data: []byte("hello world")}}
+	cfs := newTestContextOverlay(nil, layer)
+
+	info, err := cfs.Stat(context.Background(), "file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Name() != "file.txt" {
+		t.Errorf("Name = %q, want %q", info.Name(), "file.txt")
+	}
+	if info.Size() != 11 {
+		t.Errorf("Size = %d, want 11", info.Size())
+	}
+}
+
+func TestContextOpenFile_Works(t *testing.T) {
+	layer := fstest.MapFS{"file.txt": {Data: []byte("hello world")}}
+	cfs := newTestContextOverlay(nil, layer)
+
+	f, info, err := cfs.OpenFile(context.Background(), "file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if info.Name() != "file.txt" {
+		t.Errorf("Name = %q, want %q", info.Name(), "file.txt")
+	}
+	if info.Size() != 11 {
+		t.Errorf("Size = %d, want 11", info.Size())
+	}
+}
+
+func TestContextOpen_NotFound(t *testing.T) {
+	cfs := newTestContextOverlay(nil, fstest.MapFS{})
+
+	_, err := cfs.Open(context.Background(), "nope.txt")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("expected ErrNotExist, got %v", err)
+	}
+}
+
+// --- Nil logger is safe ---
+
+func TestContextOpen_NilLogger(t *testing.T) {
+	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+	cfs := NewContextOverlayFS(NewOverlayFS([]fs.FS{layer}, []string{"test"}), nil)
+
+	f, err := cfs.Open(context.Background(), "file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+}
+
+func TestContextOpen_NilLoggerPathTraversal(t *testing.T) {
+	cfs := NewContextOverlayFS(NewOverlayFS([]fs.FS{fstest.MapFS{}}, []string{"test"}), nil)
+
+	_, err := cfs.Open(context.Background(), "../etc/passwd")
+	if err == nil {
+		t.Fatal("expected error for path traversal")
+	}
+}
+
+// --- Delegation methods ---
+
+func TestContextInvalidateLayer(t *testing.T) {
+	theme := fstest.MapFS{}
+	defaults := fstest.MapFS{"file.txt": {Data: []byte("default")}}
+	cfs := newTestContextOverlay(nil, theme, defaults)
+
+	// Warm the negative cache
+	_, _ = cfs.ReadFile(context.Background(), "file.txt")
+
+	// Replace and invalidate
+	newTheme := fstest.MapFS{"file.txt": {Data: []byte("theme")}}
+	_ = cfs.ReplaceLayer(0, newTheme)
+
+	data, _ := cfs.ReadFile(context.Background(), "file.txt")
+	if string(data) != "theme" {
+		t.Errorf("got %q, want %q", data, "theme")
+	}
+}
+
+func TestContextInvalidateAll(t *testing.T) {
+	cfs := newTestContextOverlay(nil, fstest.MapFS{"file.txt": {Data: []byte("v1")}})
+
+	_, _ = cfs.ReadFile(context.Background(), "file.txt")
+	cfs.InvalidateAll() // should not panic
+}
+
+// --- Logging with context values ---
+
+func TestContextOpen_LogsOperation(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+	cfs := newTestContextOverlay(logger, layer)
+
+	ctx := context.WithValue(context.Background(), RequestIDKey, "req-789")
+	_, err := cfs.Open(ctx, "file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "overlayfs operation") {
+		t.Error("expected operation log")
+	}
+	if !strings.Contains(logged, "req-789") {
+		t.Error("expected request_id in log")
+	}
+}
+
+// --- Context key types ---
+
+func TestContextKeys_Distinct(t *testing.T) {
+	ctx := context.WithValue(context.Background(), RequestIDKey, "req-abc")
+	ctx = context.WithValue(ctx, RemoteAddrKey, "10.0.0.1")
+
+	if got := contextString(ctx, RequestIDKey); got != "req-abc" {
+		t.Errorf("RequestIDKey = %q, want %q", got, "req-abc")
+	}
+	if got := contextString(ctx, RemoteAddrKey); got != "10.0.0.1" {
+		t.Errorf("RemoteAddrKey = %q, want %q", got, "10.0.0.1")
+	}
+}
+
+func TestContextString_Missing(t *testing.T) {
+	if got := contextString(context.Background(), RequestIDKey); got != "" {
+		t.Errorf("missing key should return empty string, got %q", got)
+	}
+}
+
+// --- Permission error propagates (does not fall through) ---
+
+func TestContextOpen_PermissionError(t *testing.T) {
+	permFS := &errFS{err: fs.ErrPermission}
+	defaults := fstest.MapFS{"file.txt": {Data: []byte("default")}}
+	cfs := newTestContextOverlay(nil, permFS, defaults)
+
+	_, err := cfs.Open(context.Background(), "file.txt")
+	if err == nil {
+		t.Fatal("expected permission error")
+	}
+	if !errors.Is(err, fs.ErrPermission) {
+		t.Errorf("expected fs.ErrPermission, got %v", err)
+	}
+}

--- a/internal/overlayfs/context_test.go
+++ b/internal/overlayfs/context_test.go
@@ -366,6 +366,33 @@ func TestContextString_Missing(t *testing.T) {
 	}
 }
 
+// --- Constructor panics on nil inner ---
+
+func TestNewContextOverlayFS_NilInnerPanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for nil inner OverlayFS")
+		}
+		msg, ok := r.(string)
+		if !ok || !strings.Contains(msg, "nil OverlayFS") {
+			t.Errorf("unexpected panic value: %v", r)
+		}
+	}()
+	NewContextOverlayFS(nil, nil)
+}
+
+// --- Inner accessor ---
+
+func TestContextInner_ReturnsSameOverlayFS(t *testing.T) {
+	inner := NewOverlayFS([]fs.FS{fstest.MapFS{}}, []string{"test"})
+	cfs := NewContextOverlayFS(inner, nil)
+
+	if got := cfs.Inner(); got != inner {
+		t.Errorf("Inner() returned different pointer")
+	}
+}
+
 // --- Permission error propagates (does not fall through) ---
 
 func TestContextOpen_PermissionError(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements `ContextOverlayFS` wrapping `*OverlayFS` with `context.Context` on all methods for cancellation, security logging, and operation tracing.

### Changes

- **`internal/overlayfs/context.go`**: `ContextOverlayFS` struct with context-aware `Open`, `ReadFile`, `ReadDir`, `Stat`, `OpenFile` plus delegation methods
- **`internal/overlayfs/context_test.go`**: 23 tests covering cancellation, security logging, FS methods, nil logger safety, error propagation

### Design (per §2.5)

- `ctx.Done()` checked before each layer operation
- `slog.WARN` on path traversal with `request_id` and `remote_addr` from context
- slog-based span-like tracing (op, path, duration) — no hard OTel dependency
- Unexported context key types prevent collisions
- Does NOT implement `io/fs.FS` (methods require `context.Context`)

Fixes #5