### PR TITLE
feat(theme): add context.Context to Render methods

### DIFF
--- a/internal/server/handlers/handlers.go
+++ b/internal/server/handlers/handlers.go
@@ -86,7 +86,7 @@ func ListHandler(deps *Deps) http.HandlerFunc {
 			Pagination: pag,
 		}
 
-		renderTemplate(w, deps.Theme, "templates/list.html", data, http.StatusOK)
+		renderTemplate(w, r, deps.Theme, "templates/list.html", data, http.StatusOK)
 	}
 }
 
@@ -110,7 +110,7 @@ func PostHandler(deps *Deps) http.HandlerFunc {
 			Title: post.Title,
 		}
 
-		renderTemplate(w, deps.Theme, "templates/post.html", data, http.StatusOK)
+		renderTemplate(w, r, deps.Theme, "templates/post.html", data, http.StatusOK)
 	}
 }
 
@@ -134,7 +134,7 @@ func PageHandler(deps *Deps) http.HandlerFunc {
 			Title: page.Title,
 		}
 
-		renderTemplate(w, deps.Theme, "templates/page.html", data, http.StatusOK)
+		renderTemplate(w, r, deps.Theme, "templates/page.html", data, http.StatusOK)
 	}
 }
 
@@ -165,7 +165,7 @@ func TagHandler(deps *Deps) http.HandlerFunc {
 			Pagination: pag,
 		}
 
-		renderTemplate(w, deps.Theme, "templates/list.html", data, http.StatusOK)
+		renderTemplate(w, r, deps.Theme, "templates/list.html", data, http.StatusOK)
 	}
 }
 
@@ -178,7 +178,7 @@ func NotFoundHandler(deps *Deps) http.HandlerFunc {
 			Title: "Page Not Found",
 		}
 
-		renderTemplate(w, deps.Theme, "templates/404.html", data, http.StatusNotFound)
+		renderTemplate(w, r, deps.Theme, "templates/404.html", data, http.StatusNotFound)
 	}
 }
 
@@ -216,9 +216,9 @@ func paginate(posts []*content.Post, page, perPage int) ([]*content.Post, *Pagin
 // renderTemplate renders the named template into a buffer, then writes
 // the response. If rendering fails the client receives a 500 error
 // without any partial content.
-func renderTemplate(w http.ResponseWriter, engine *theme.Engine, name string, data *PageData, statusCode int) {
+func renderTemplate(w http.ResponseWriter, r *http.Request, engine *theme.Engine, name string, data *PageData, statusCode int) {
 	var buf bytes.Buffer
-	if err := engine.Render(&buf, name, data); err != nil {
+	if err := engine.Render(r.Context(), &buf, name, data); err != nil {
 		slog.Error("template render failed", "template", name, "error", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/internal/server/handlers/handlers.go
+++ b/internal/server/handlers/handlers.go
@@ -219,6 +219,10 @@ func paginate(posts []*content.Post, page, perPage int) ([]*content.Post, *Pagin
 func renderTemplate(w http.ResponseWriter, r *http.Request, engine *theme.Engine, name string, data *PageData, statusCode int) {
 	var buf bytes.Buffer
 	if err := engine.Render(r.Context(), &buf, name, data); err != nil {
+		if r.Context().Err() != nil {
+			slog.Debug("render aborted: client disconnected", "template", name, "error", err)
+			return
+		}
 		slog.Error("template render failed", "template", name, "error", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -5,6 +5,7 @@ package theme
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"html/template"
 	"io"
@@ -37,7 +38,8 @@ func NewEngine(fsys fs.FS) (*Engine, error) {
 // Render renders a page using base.html with the named page template's
 // block overrides ({{define "content"}}, {{define "title"}}, etc.).
 // Each page template is cloned+parsed per request so defines don't collide.
-func (e *Engine) Render(w io.Writer, name string, data any) error {
+// The context allows callers to cancel long-running renders.
+func (e *Engine) Render(ctx context.Context, w io.Writer, name string, data any) error {
 	pages := *e.pages.Load()
 	src, ok := pages[name]
 	if !ok {
@@ -52,6 +54,13 @@ func (e *Engine) Render(w io.Writer, name string, data any) error {
 		return fmt.Errorf("theme: parse page %s: %w", name, err)
 	}
 
+	// Check for cancellation before expensive template execution.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	var buf bytes.Buffer
 	if err := clone.ExecuteTemplate(&buf, "templates/base.html", data); err != nil {
 		return err
@@ -61,9 +70,9 @@ func (e *Engine) Render(w io.Writer, name string, data any) error {
 }
 
 // RenderToString renders a named template to a string.
-func (e *Engine) RenderToString(name string, data any) (string, error) {
+func (e *Engine) RenderToString(ctx context.Context, name string, data any) (string, error) {
 	var b strings.Builder
-	if err := e.Render(&b, name, data); err != nil {
+	if err := e.Render(ctx, &b, name, data); err != nil {
 		return "", err
 	}
 	return b.String(), nil

--- a/internal/theme/theme_test.go
+++ b/internal/theme/theme_test.go
@@ -1,6 +1,7 @@
 package theme
 
 import (
+	"context"
 	"html/template"
 	"strings"
 	"sync"
@@ -34,7 +35,7 @@ func TestNewEngine_LoadsTemplates(t *testing.T) {
 	}
 
 	var b strings.Builder
-	if err := e.Render(&b, "templates/index.html", nil); err != nil {
+	if err := e.Render(context.Background(), &b, "templates/index.html", nil); err != nil {
 		t.Fatalf("Render: %v", err)
 	}
 	if got := b.String(); !strings.Contains(got, "<h1>Hello</h1>") {
@@ -58,7 +59,7 @@ func TestRender_WithData(t *testing.T) {
 	}{Title: "My Post", Author: "Alice"}
 
 	var b strings.Builder
-	if err := e.Render(&b, "templates/post.html", data); err != nil {
+	if err := e.Render(context.Background(), &b, "templates/post.html", data); err != nil {
 		t.Fatalf("Render: %v", err)
 	}
 	want := `<h1>My Post</h1><p>by Alice</p>`
@@ -157,7 +158,7 @@ func TestRender_FuncMap(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewEngine: %v", err)
 			}
-			got, err := e.RenderToString("templates/t.html", tt.data)
+			got, err := e.RenderToString(context.Background(), "templates/t.html", tt.data)
 			if err != nil {
 				t.Fatalf("RenderToString: %v", err)
 			}
@@ -180,7 +181,7 @@ func TestRender_Partials(t *testing.T) {
 	}
 
 	data := struct{ SiteName string }{SiteName: "BlogFlow"}
-	got, err := e.RenderToString("templates/page.html", data)
+	got, err := e.RenderToString(context.Background(), "templates/page.html", data)
 	if err != nil {
 		t.Fatalf("RenderToString: %v", err)
 	}
@@ -201,7 +202,7 @@ func TestRender_MissingTemplate(t *testing.T) {
 	}
 
 	var b strings.Builder
-	err = e.Render(&b, "templates/nonexistent.html", nil)
+	err = e.Render(context.Background(), &b, "templates/nonexistent.html", nil)
 	if err == nil {
 		t.Fatal("expected error for missing template, got nil")
 	}
@@ -220,7 +221,7 @@ func TestRender_Blocks(t *testing.T) {
 			t.Fatalf("NewEngine: %v", err)
 		}
 
-		got, err := e.RenderToString("templates/empty.html", nil)
+		got, err := e.RenderToString(context.Background(), "templates/empty.html", nil)
 		if err != nil {
 			t.Fatalf("RenderToString: %v", err)
 		}
@@ -241,7 +242,7 @@ func TestRender_Blocks(t *testing.T) {
 			t.Fatalf("NewEngine: %v", err)
 		}
 
-		got, err := e.RenderToString("templates/home.html", nil)
+		got, err := e.RenderToString(context.Background(), "templates/home.html", nil)
 		if err != nil {
 			t.Fatalf("RenderToString: %v", err)
 		}
@@ -262,7 +263,7 @@ func TestReload(t *testing.T) {
 		t.Fatalf("NewEngine: %v", err)
 	}
 
-	got, err := e.RenderToString("templates/index.html", nil)
+	got, err := e.RenderToString(context.Background(), "templates/index.html", nil)
 	if err != nil {
 		t.Fatalf("RenderToString: %v", err)
 	}
@@ -277,7 +278,7 @@ func TestReload(t *testing.T) {
 		t.Fatalf("Reload: %v", err)
 	}
 
-	got, err = e.RenderToString("templates/index.html", nil)
+	got, err = e.RenderToString(context.Background(), "templates/index.html", nil)
 	if err != nil {
 		t.Fatalf("RenderToString after reload: %v", err)
 	}
@@ -301,7 +302,7 @@ func TestReload_ConcurrentWithRender(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < 100; j++ {
-				_, _ = e.RenderToString("templates/t.html", nil)
+				_, _ = e.RenderToString(context.Background(), "templates/t.html", nil)
 			}
 		}()
 		go func() {
@@ -337,7 +338,7 @@ func TestRender_HTMLEscaping(t *testing.T) {
 	}
 
 	data := struct{ Content string }{Content: `<script>alert("xss")</script>`}
-	got, err := e.RenderToString("templates/page.html", data)
+	got, err := e.RenderToString(context.Background(), "templates/page.html", data)
 	if err != nil {
 		t.Fatalf("RenderToString: %v", err)
 	}
@@ -391,7 +392,7 @@ func TestRender_HTMLEscaping_TemplateHTML(t *testing.T) {
 			data := struct{ Content template.HTML }{
 				Content: template.HTML(sanitized), //nolint:gosec // testing that sanitizer already stripped the tag
 			}
-			got, err := e.RenderToString("templates/page.html", data)
+			got, err := e.RenderToString(context.Background(), "templates/page.html", data)
 			if err != nil {
 				t.Fatalf("RenderToString: %v", err)
 			}
@@ -413,7 +414,7 @@ func TestRender_HTMLEscaping_TemplateHTML(t *testing.T) {
 		safeData := struct{ Content template.HTML }{
 			Content: template.HTML(safeMD), //nolint:gosec // safe content
 		}
-		safeGot, err := e.RenderToString("templates/page.html", safeData)
+		safeGot, err := e.RenderToString(context.Background(), "templates/page.html", safeData)
 		if err != nil {
 			t.Fatalf("RenderToString: %v", err)
 		}
@@ -455,7 +456,7 @@ func TestReadingTime_TemplateHTML(t *testing.T) {
 			}
 
 			data := struct{ Content template.HTML }{Content: tt.content}
-			got, err := e.RenderToString("templates/post.html", data)
+			got, err := e.RenderToString(context.Background(), "templates/post.html", data)
 			if err != nil {
 				t.Fatalf("RenderToString: %v", err)
 			}
@@ -477,11 +478,75 @@ func TestRenderToString(t *testing.T) {
 	}
 
 	data := struct{ Name string }{Name: "World"}
-	got, err := e.RenderToString("templates/greeting.html", data)
+	got, err := e.RenderToString(context.Background(), "templates/greeting.html", data)
 	if err != nil {
 		t.Fatalf("RenderToString: %v", err)
 	}
 	if !strings.Contains(got, "Hello, World!") {
 		t.Errorf("output %q does not contain %q", got, "Hello, World!")
+	}
+}
+
+func TestRender_CancelledContext(t *testing.T) {
+	fs := testFS(map[string]string{
+		"templates/index.html": `{{define "content"}}<h1>Hello</h1>{{end}}`,
+	})
+
+	e, err := NewEngine(fs)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	var b strings.Builder
+	err = e.Render(ctx, &b, "templates/index.html", nil)
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestRenderToString_CancelledContext(t *testing.T) {
+	fs := testFS(map[string]string{
+		"templates/index.html": `{{define "content"}}<h1>Hello</h1>{{end}}`,
+	})
+
+	e, err := NewEngine(fs)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = e.RenderToString(ctx, "templates/index.html", nil)
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestRender_ValidContext(t *testing.T) {
+	fs := testFS(map[string]string{
+		"templates/index.html": `{{define "content"}}<h1>Works</h1>{{end}}`,
+	})
+
+	e, err := NewEngine(fs)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	var b strings.Builder
+	if err := e.Render(context.Background(), &b, "templates/index.html", nil); err != nil {
+		t.Fatalf("Render with valid context: %v", err)
+	}
+	if !strings.Contains(b.String(), "<h1>Works</h1>") {
+		t.Errorf("output %q does not contain expected content", b.String())
 	}
 }


### PR DESCRIPTION
## Summary

Add `context.Context` as the first parameter to `Engine.Render` and `Engine.RenderToString`. Before template execution, the context is checked for cancellation so long-running renders can be aborted by callers (e.g. on client disconnect).

## Changes

- **`internal/theme/theme.go`** — `Render(ctx, w, name, data)` and `RenderToString(ctx, name, data)` now accept context; check `ctx.Done()` before `ExecuteTemplate`
- **`internal/server/handlers/handlers.go`** — `renderTemplate` passes `r.Context()` from the HTTP request
- **`internal/theme/theme_test.go`** — All existing tests pass `context.Background()`; 3 new tests:
  - `TestRender_CancelledContext` — cancelled context returns `context.Canceled`
  - `TestRenderToString_CancelledContext` — same for `RenderToString`
  - `TestRender_ValidContext` — normal render still succeeds

## Testing

- `go test -race ./...` ✅
- `golangci-lint run ./...` — no new issues (1 pre-existing gosec warning in `cmd/blogflow/main.go`)

Fixes #21