### PR TITLE
feat(overlayfs): add Prometheus metrics instrumentation

### DIFF
--- a/internal/overlayfs/context_test.go
+++ b/internal/overlayfs/context_test.go
@@ -17,7 +17,7 @@ func newTestContextOverlay(logger *slog.Logger, layers ...fs.FS) *ContextOverlay
 	for i := range layers {
 		names[i] = layerName(i)
 	}
-	return NewContextOverlayFS(NewOverlayFS(layers, names), logger)
+	return NewContextOverlayFS(NewOverlayFS(layers...).WithLayerNames(names), logger)
 }
 
 // --- Context cancellation aborts resolution ---
@@ -278,7 +278,7 @@ func TestContextOpen_NotFound(t *testing.T) {
 
 func TestContextOpen_NilLogger(t *testing.T) {
 	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
-	cfs := NewContextOverlayFS(NewOverlayFS([]fs.FS{layer}, []string{"test"}), nil)
+	cfs := NewContextOverlayFS(NewOverlayFS(layer).WithLayerNames([]string{"test"}), nil)
 
 	f, err := cfs.Open(context.Background(), "file.txt")
 	if err != nil {
@@ -288,7 +288,7 @@ func TestContextOpen_NilLogger(t *testing.T) {
 }
 
 func TestContextOpen_NilLoggerPathTraversal(t *testing.T) {
-	cfs := NewContextOverlayFS(NewOverlayFS([]fs.FS{fstest.MapFS{}}, []string{"test"}), nil)
+	cfs := NewContextOverlayFS(NewOverlayFS(fstest.MapFS{}).WithLayerNames([]string{"test"}), nil)
 
 	_, err := cfs.Open(context.Background(), "../etc/passwd")
 	if err == nil {
@@ -385,7 +385,7 @@ func TestNewContextOverlayFS_NilInnerPanics(t *testing.T) {
 // --- Inner accessor ---
 
 func TestContextInner_ReturnsSameOverlayFS(t *testing.T) {
-	inner := NewOverlayFS([]fs.FS{fstest.MapFS{}}, []string{"test"})
+	inner := NewOverlayFS(fstest.MapFS{}).WithLayerNames([]string{"test"})
 	cfs := NewContextOverlayFS(inner, nil)
 
 	if got := cfs.Inner(); got != inner {

--- a/internal/overlayfs/metrics.go
+++ b/internal/overlayfs/metrics.go
@@ -65,10 +65,16 @@ func newOverlayMetrics(reg prometheus.Registerer) (*overlayMetrics, error) {
 		m.resolveDuration, m.layerHitTotal, m.missTotal,
 		m.negCacheHit, m.negCacheSize, m.pathRejected,
 	}
+	var registered []prometheus.Collector
 	for _, c := range collectors {
 		if err := reg.Register(c); err != nil {
+			// Roll back previously registered collectors.
+			for _, r := range registered {
+				reg.Unregister(r)
+			}
 			return nil, fmt.Errorf("overlayfs: register metric: %w", err)
 		}
+		registered = append(registered, c)
 	}
 
 	return m, nil

--- a/internal/overlayfs/metrics.go
+++ b/internal/overlayfs/metrics.go
@@ -1,6 +1,8 @@
 package overlayfs
 
 import (
+	"fmt"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -15,7 +17,7 @@ type overlayMetrics struct {
 	pathRejected    *prometheus.CounterVec
 }
 
-func newOverlayMetrics(reg prometheus.Registerer) *overlayMetrics {
+func newOverlayMetrics(reg prometheus.Registerer) (*overlayMetrics, error) {
 	m := &overlayMetrics{
 		resolveDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -59,26 +61,33 @@ func newOverlayMetrics(reg prometheus.Registerer) *overlayMetrics {
 		),
 	}
 
-	reg.MustRegister(
-		m.resolveDuration,
-		m.layerHitTotal,
-		m.missTotal,
-		m.negCacheHit,
-		m.negCacheSize,
-		m.pathRejected,
-	)
+	collectors := []prometheus.Collector{
+		m.resolveDuration, m.layerHitTotal, m.missTotal,
+		m.negCacheHit, m.negCacheSize, m.pathRejected,
+	}
+	for _, c := range collectors {
+		if err := reg.Register(c); err != nil {
+			return nil, fmt.Errorf("overlayfs: register metric: %w", err)
+		}
+	}
 
-	return m
+	return m, nil
 }
 
 // Option configures an OverlayFS instance.
-type Option func(*OverlayFS)
+type Option func(*OverlayFS) error
 
 // WithMetrics enables Prometheus metrics collection on the overlay filesystem.
 // When not set, all instrumentation is a no-op with zero overhead.
+// Returns an error if metric registration fails (e.g., duplicate registration).
 func WithMetrics(reg prometheus.Registerer) Option {
-	return func(o *OverlayFS) {
-		o.metrics = newOverlayMetrics(reg)
+	return func(o *OverlayFS) error {
+		m, err := newOverlayMetrics(reg)
+		if err != nil {
+			return err
+		}
+		o.metrics = m
+		return nil
 	}
 }
 
@@ -90,7 +99,7 @@ func classifyInvalidPath(name string) string {
 	for i := 0; i < len(name); i++ {
 		if name[i] == '.' && (i == 0 || name[i-1] == '/') {
 			rest := name[i:]
-			if rest == ".." || len(rest) > 2 && rest[1] == '.' && rest[2] == '/' {
+			if rest == ".." || (len(rest) > 2 && rest[1] == '.' && rest[2] == '/') {
 				return "traversal"
 			}
 		}

--- a/internal/overlayfs/metrics.go
+++ b/internal/overlayfs/metrics.go
@@ -1,0 +1,99 @@
+package overlayfs
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// overlayMetrics holds all Prometheus metrics for the overlay filesystem.
+// When nil on OverlayFS, all instrumentation is a no-op (zero overhead).
+type overlayMetrics struct {
+	resolveDuration *prometheus.HistogramVec
+	layerHitTotal   *prometheus.CounterVec
+	missTotal       prometheus.Counter
+	negCacheHit     prometheus.Counter
+	negCacheSize    prometheus.Gauge
+	pathRejected    *prometheus.CounterVec
+}
+
+func newOverlayMetrics(reg prometheus.Registerer) *overlayMetrics {
+	m := &overlayMetrics{
+		resolveDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "blogflow_overlay_resolve_duration_seconds",
+				Help:    "Time to resolve a file through the layer stack.",
+				Buckets: []float64{0.00001, 0.00005, 0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1},
+			},
+			[]string{"op"},
+		),
+		layerHitTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "blogflow_overlay_layer_hit_total",
+				Help: "Number of times each layer served a file.",
+			},
+			[]string{"layer"},
+		),
+		missTotal: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: "blogflow_overlay_miss_total",
+				Help: "Files not found in any layer.",
+			},
+		),
+		negCacheHit: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: "blogflow_overlay_negcache_hit_total",
+				Help: "Negative cache hits (avoided layer checks).",
+			},
+		),
+		negCacheSize: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "blogflow_overlay_negcache_size",
+				Help: "Current number of entries in the negative cache.",
+			},
+		),
+		pathRejected: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "blogflow_overlay_path_rejected_total",
+				Help: "Path validation rejections.",
+			},
+			[]string{"reason"},
+		),
+	}
+
+	reg.MustRegister(
+		m.resolveDuration,
+		m.layerHitTotal,
+		m.missTotal,
+		m.negCacheHit,
+		m.negCacheSize,
+		m.pathRejected,
+	)
+
+	return m
+}
+
+// Option configures an OverlayFS instance.
+type Option func(*OverlayFS)
+
+// WithMetrics enables Prometheus metrics collection on the overlay filesystem.
+// When not set, all instrumentation is a no-op with zero overhead.
+func WithMetrics(reg prometheus.Registerer) Option {
+	return func(o *OverlayFS) {
+		o.metrics = newOverlayMetrics(reg)
+	}
+}
+
+// classifyInvalidPath returns a reason label for a rejected path.
+func classifyInvalidPath(name string) string {
+	if len(name) > 0 && name[0] == '/' {
+		return "absolute"
+	}
+	for i := 0; i < len(name); i++ {
+		if name[i] == '.' && (i == 0 || name[i-1] == '/') {
+			rest := name[i:]
+			if rest == ".." || len(rest) > 2 && rest[1] == '.' && rest[2] == '/' {
+				return "traversal"
+			}
+		}
+	}
+	return "invalid"
+}

--- a/internal/overlayfs/metrics_test.go
+++ b/internal/overlayfs/metrics_test.go
@@ -1,0 +1,293 @@
+package overlayfs
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func newMetricsOverlay(reg *prometheus.Registry, layers ...fs.FS) *OverlayFS {
+	names := make([]string, len(layers))
+	for i := range layers {
+		names[i] = layerName(i)
+	}
+	return NewOverlayFS(layers...).WithLayerNames(names).WithOptions(WithMetrics(reg))
+}
+
+func counterValue(reg *prometheus.Registry, name string, labels map[string]string) float64 {
+	families, _ := reg.Gather()
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			if matchLabels(m.GetLabel(), labels) {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+func histogramCount(reg *prometheus.Registry, name string, labels map[string]string) uint64 {
+	families, _ := reg.Gather()
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			if matchLabels(m.GetLabel(), labels) {
+				return m.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+	return 0
+}
+
+func gaugeValue(reg *prometheus.Registry, name string) float64 {
+	families, _ := reg.Gather()
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			return m.GetGauge().GetValue()
+		}
+	}
+	return -1
+}
+
+func matchLabels(pairs []*dto.LabelPair, want map[string]string) bool {
+	if len(want) == 0 {
+		return true
+	}
+	m := make(map[string]string, len(pairs))
+	for _, p := range pairs {
+		m[p.GetName()] = p.GetValue()
+	}
+	for k, v := range want {
+		if m[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func TestMetrics_Registered(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	_ = newMetricsOverlay(reg, fstest.MapFS{"a.txt": {Data: []byte("a")}})
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]bool{
+		"blogflow_overlay_resolve_duration_seconds": false,
+		"blogflow_overlay_layer_hit_total":          false,
+		"blogflow_overlay_miss_total":               false,
+		"blogflow_overlay_negcache_hit_total":       false,
+		"blogflow_overlay_negcache_size":            false,
+		"blogflow_overlay_path_rejected_total":      false,
+	}
+
+	for _, f := range families {
+		if _, ok := want[f.GetName()]; ok {
+			want[f.GetName()] = true
+		}
+	}
+
+	// Trigger at least one operation so lazy metrics appear
+	ofs := newMetricsOverlay(prometheus.NewRegistry(), fstest.MapFS{"b.txt": {Data: []byte("b")}})
+	_, _ = ofs.Open("b.txt")
+	_, _ = ofs.Open("../bad")
+
+	// Re-check with a fresh registry that has activity
+	reg2 := prometheus.NewRegistry()
+	ofs2 := newMetricsOverlay(reg2, fstest.MapFS{"c.txt": {Data: []byte("c")}})
+	_, _ = ofs2.Open("c.txt")
+	_, _ = ofs2.Open("../bad")
+	families2, _ := reg2.Gather()
+	found := make(map[string]bool)
+	for _, f := range families2 {
+		found[f.GetName()] = true
+	}
+	for name := range want {
+		if !found[name] {
+			t.Errorf("metric %q not registered", name)
+		}
+	}
+}
+
+func TestMetrics_LayerHitCounter(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	theme := fstest.MapFS{"style.css": {Data: []byte("theme-css")}}
+	defaults := fstest.MapFS{"base.css": {Data: []byte("default-css")}}
+	ofs := NewOverlayFS(theme, defaults).
+		WithLayerNames([]string{"theme", "defaults"}).
+		WithOptions(WithMetrics(reg))
+
+	// Hit theme layer
+	f, err := ofs.Open("style.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	v := counterValue(reg, "blogflow_overlay_layer_hit_total", map[string]string{"layer": "theme"})
+	if v != 1 {
+		t.Errorf("theme layer hit = %v, want 1", v)
+	}
+
+	// Hit defaults layer
+	_, err = fs.ReadFile(ofs, "base.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v = counterValue(reg, "blogflow_overlay_layer_hit_total", map[string]string{"layer": "defaults"})
+	if v != 1 {
+		t.Errorf("defaults layer hit = %v, want 1", v)
+	}
+}
+
+func TestMetrics_MissCounter(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	ofs := newMetricsOverlay(reg, fstest.MapFS{})
+
+	_, _ = ofs.Open("nonexistent.txt")
+
+	v := counterValue(reg, "blogflow_overlay_miss_total", nil)
+	if v != 1 {
+		t.Errorf("miss total = %v, want 1", v)
+	}
+}
+
+func TestMetrics_HistogramRecordsDurations(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+	ofs := newMetricsOverlay(reg, layer)
+
+	f, _ := ofs.Open("file.txt")
+	_ = f.Close()
+	_, _ = fs.ReadFile(ofs, "file.txt")
+
+	openCount := histogramCount(reg, "blogflow_overlay_resolve_duration_seconds", map[string]string{"op": "open"})
+	if openCount < 1 {
+		t.Errorf("open histogram count = %d, want >= 1", openCount)
+	}
+
+	readfileCount := histogramCount(reg, "blogflow_overlay_resolve_duration_seconds", map[string]string{"op": "readfile"})
+	if readfileCount < 1 {
+		t.Errorf("readfile histogram count = %d, want >= 1", readfileCount)
+	}
+}
+
+func TestMetrics_StatDuration(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+	ofs := newMetricsOverlay(reg, layer)
+
+	_, _ = ofs.Stat("file.txt")
+
+	count := histogramCount(reg, "blogflow_overlay_resolve_duration_seconds", map[string]string{"op": "stat"})
+	if count != 1 {
+		t.Errorf("stat histogram count = %d, want 1", count)
+	}
+}
+
+func TestMetrics_ReadDirDuration(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	layer := fstest.MapFS{"dir/a.txt": {Data: []byte("a")}}
+	ofs := newMetricsOverlay(reg, layer)
+
+	_, _ = ofs.ReadDir("dir")
+
+	count := histogramCount(reg, "blogflow_overlay_resolve_duration_seconds", map[string]string{"op": "readdir"})
+	if count != 1 {
+		t.Errorf("readdir histogram count = %d, want 1", count)
+	}
+}
+
+func TestMetrics_PathRejected(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	ofs := newMetricsOverlay(reg, fstest.MapFS{})
+
+	_, _ = ofs.Open("../etc/passwd")
+	_, _ = ofs.Open("/absolute")
+	_, _ = ofs.Open("")
+
+	traversal := counterValue(reg, "blogflow_overlay_path_rejected_total", map[string]string{"reason": "traversal"})
+	absolute := counterValue(reg, "blogflow_overlay_path_rejected_total", map[string]string{"reason": "absolute"})
+	invalid := counterValue(reg, "blogflow_overlay_path_rejected_total", map[string]string{"reason": "invalid"})
+
+	if traversal < 1 {
+		t.Errorf("traversal rejections = %v, want >= 1", traversal)
+	}
+	if absolute < 1 {
+		t.Errorf("absolute rejections = %v, want >= 1", absolute)
+	}
+	if invalid < 1 {
+		t.Errorf("invalid rejections = %v, want >= 1", invalid)
+	}
+}
+
+func TestMetrics_NegCacheHit(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	theme := fstest.MapFS{}
+	defaults := fstest.MapFS{"deep.txt": {Data: []byte("deep")}}
+	ofs := newMetricsOverlay(reg, theme, defaults)
+
+	// First read warms the negative cache
+	_, _ = fs.ReadFile(ofs, "deep.txt")
+	// Second read should hit negative cache
+	_, _ = fs.ReadFile(ofs, "deep.txt")
+
+	v := counterValue(reg, "blogflow_overlay_negcache_hit_total", nil)
+	if v < 1 {
+		t.Errorf("negcache hit = %v, want >= 1", v)
+	}
+}
+
+func TestMetrics_NegCacheSize(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	theme := fstest.MapFS{}
+	defaults := fstest.MapFS{"f.txt": {Data: []byte("f")}}
+	ofs := newMetricsOverlay(reg, theme, defaults)
+
+	_, _ = fs.ReadFile(ofs, "f.txt")
+
+	v := gaugeValue(reg, "blogflow_overlay_negcache_size")
+	if v != 1 {
+		t.Errorf("negcache size = %v, want 1", v)
+	}
+
+	ofs.InvalidateAll()
+	v = gaugeValue(reg, "blogflow_overlay_negcache_size")
+	if v != 0 {
+		t.Errorf("negcache size after invalidate = %v, want 0", v)
+	}
+}
+
+func TestMetrics_NoPanicWhenDisabled(t *testing.T) {
+	// No WithMetrics option — metrics should be nil
+	ofs := NewOverlayFS(fstest.MapFS{"a.txt": {Data: []byte("a")}}).
+		WithLayerNames([]string{"layer0"})
+
+	// None of these should panic
+	f, err := ofs.Open("a.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	_, _ = ofs.Open("nonexistent")
+	_, _ = ofs.Open("../bad")
+	_, _ = fs.ReadFile(ofs, "a.txt")
+	_, _ = ofs.ReadDir(".")
+	_, _ = ofs.Stat("a.txt")
+	ofs.InvalidateAll()
+}

--- a/internal/overlayfs/metrics_test.go
+++ b/internal/overlayfs/metrics_test.go
@@ -304,13 +304,13 @@ func TestMetrics_DuplicateRegistrationReturnsError(t *testing.T) {
 	layer := fstest.MapFS{"a.txt": {Data: []byte("a")}}
 
 	// First registration succeeds.
-	_, err := NewOverlayFS([]fs.FS{layer}, []string{"l0"}, WithMetrics(reg))
+	_, err := NewOverlayFS(layer).WithLayerNames([]string{"l0"}).WithOptions(WithMetrics(reg))
 	if err != nil {
 		t.Fatalf("first registration: %v", err)
 	}
 
 	// Second registration with the same registry must return an error, not panic.
-	_, err = NewOverlayFS([]fs.FS{layer}, []string{"l1"}, WithMetrics(reg))
+	_, err = NewOverlayFS(layer).WithLayerNames([]string{"l1"}).WithOptions(WithMetrics(reg))
 	if err == nil {
 		t.Fatal("expected error on duplicate metric registration")
 	}

--- a/internal/overlayfs/metrics_test.go
+++ b/internal/overlayfs/metrics_test.go
@@ -14,7 +14,11 @@ func newMetricsOverlay(reg *prometheus.Registry, layers ...fs.FS) *OverlayFS {
 	for i := range layers {
 		names[i] = layerName(i)
 	}
-	return NewOverlayFS(layers...).WithLayerNames(names).WithOptions(WithMetrics(reg))
+	ofs, err := NewOverlayFS(layers...).WithLayerNames(names).WithOptions(WithMetrics(reg))
+	if err != nil {
+		panic(err)
+	}
+	return ofs
 }
 
 func counterValue(reg *prometheus.Registry, name string, labels map[string]string) float64 {
@@ -126,9 +130,12 @@ func TestMetrics_LayerHitCounter(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	theme := fstest.MapFS{"style.css": {Data: []byte("theme-css")}}
 	defaults := fstest.MapFS{"base.css": {Data: []byte("default-css")}}
-	ofs := NewOverlayFS(theme, defaults).
+	ofs, err := NewOverlayFS(theme, defaults).
 		WithLayerNames([]string{"theme", "defaults"}).
 		WithOptions(WithMetrics(reg))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Hit theme layer
 	f, err := ofs.Open("style.css")
@@ -290,4 +297,21 @@ func TestMetrics_NoPanicWhenDisabled(t *testing.T) {
 	_, _ = ofs.ReadDir(".")
 	_, _ = ofs.Stat("a.txt")
 	ofs.InvalidateAll()
+}
+
+func TestMetrics_DuplicateRegistrationReturnsError(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	layer := fstest.MapFS{"a.txt": {Data: []byte("a")}}
+
+	// First registration succeeds.
+	_, err := NewOverlayFS([]fs.FS{layer}, []string{"l0"}, WithMetrics(reg))
+	if err != nil {
+		t.Fatalf("first registration: %v", err)
+	}
+
+	// Second registration with the same registry must return an error, not panic.
+	_, err = NewOverlayFS([]fs.FS{layer}, []string{"l1"}, WithMetrics(reg))
+	if err == nil {
+		t.Fatal("expected error on duplicate metric registration")
+	}
 }

--- a/internal/overlayfs/overlayfs.go
+++ b/internal/overlayfs/overlayfs.go
@@ -578,6 +578,9 @@ func (o *OverlayFS) ReplaceLayer(layerIndex int, newFS fs.FS) error {
 		}
 		return true
 	})
+	if o.metrics != nil {
+		o.metrics.negCacheSize.Set(float64(o.negCacheCount.Load()))
+	}
 	return nil
 }
 

--- a/internal/overlayfs/overlayfs.go
+++ b/internal/overlayfs/overlayfs.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // layerMeta stores resolved root paths for disk-backed layers.
@@ -52,6 +53,9 @@ type OverlayFS struct {
 	// maxNegCacheEntries bounds the negative cache size. When exceeded,
 	// new entries are not cached (graceful degradation).
 	maxNegCacheEntries int
+
+	// metrics is nil when WithMetrics is not used (zero overhead).
+	metrics *overlayMetrics
 }
 
 type negCacheEntry struct {
@@ -86,6 +90,15 @@ func NewOverlayFS(layers ...fs.FS) *OverlayFS {
 		layerMeta:          make([]layerMeta, len(filtered)),
 		maxNegCacheEntries: 100_000,
 	}
+}
+
+// WithOptions applies functional options to the OverlayFS.
+// This is used with options like WithMetrics.
+func (o *OverlayFS) WithOptions(opts ...Option) *OverlayFS {
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
 }
 
 // WithLayerNames sets human-readable names for the overlay layers.
@@ -174,7 +187,15 @@ func NewFromEmbed(defaults embed.FS, prefix string) (*OverlayFS, error) {
 func (o *OverlayFS) Open(name string) (fs.File, error) {
 	// TODO(security): ContextOverlayFS will log WARN with request_id and remote_addr
 	if !fs.ValidPath(name) {
+		if o.metrics != nil {
+			o.metrics.pathRejected.WithLabelValues(classifyInvalidPath(name)).Inc()
+		}
 		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+
+	var start time.Time
+	if o.metrics != nil {
+		start = time.Now()
 	}
 
 	o.mu.RLock()
@@ -187,6 +208,9 @@ func (o *OverlayFS) Open(name string) (fs.File, error) {
 		entry := cached.(negCacheEntry)
 		if entry.firstCandidateLayer < len(layers) {
 			startLayer = entry.firstCandidateLayer
+			if o.metrics != nil {
+				o.metrics.negCacheHit.Inc()
+			}
 		}
 	}
 
@@ -206,7 +230,14 @@ func (o *OverlayFS) Open(name string) (fs.File, error) {
 					firstCandidateLayer: i,
 				}); !loaded {
 					o.negCacheCount.Add(1)
+					if o.metrics != nil {
+						o.metrics.negCacheSize.Set(float64(o.negCacheCount.Load()))
+					}
 				}
+			}
+			if o.metrics != nil {
+				o.metrics.resolveDuration.WithLabelValues("open").Observe(time.Since(start).Seconds())
+				o.metrics.layerHitTotal.WithLabelValues(o.layerName(i)).Inc()
 			}
 			return f, nil
 		}
@@ -215,6 +246,10 @@ func (o *OverlayFS) Open(name string) (fs.File, error) {
 		}
 	}
 
+	if o.metrics != nil {
+		o.metrics.resolveDuration.WithLabelValues("open").Observe(time.Since(start).Seconds())
+		o.metrics.missTotal.Inc()
+	}
 	return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
 }
 
@@ -223,7 +258,15 @@ func (o *OverlayFS) Open(name string) (fs.File, error) {
 func (o *OverlayFS) ReadFile(name string) ([]byte, error) {
 	// TODO(security): ContextOverlayFS will log WARN with request_id and remote_addr
 	if !fs.ValidPath(name) {
+		if o.metrics != nil {
+			o.metrics.pathRejected.WithLabelValues(classifyInvalidPath(name)).Inc()
+		}
 		return nil, &fs.PathError{Op: "readfile", Path: name, Err: fs.ErrInvalid}
+	}
+
+	var start time.Time
+	if o.metrics != nil {
+		start = time.Now()
 	}
 
 	o.mu.RLock()
@@ -236,6 +279,9 @@ func (o *OverlayFS) ReadFile(name string) ([]byte, error) {
 		entry := cached.(negCacheEntry)
 		if entry.firstCandidateLayer < len(layers) {
 			startLayer = entry.firstCandidateLayer
+			if o.metrics != nil {
+				o.metrics.negCacheHit.Inc()
+			}
 		}
 	}
 
@@ -257,7 +303,14 @@ func (o *OverlayFS) ReadFile(name string) ([]byte, error) {
 						firstCandidateLayer: i,
 					}); !loaded {
 						o.negCacheCount.Add(1)
+						if o.metrics != nil {
+							o.metrics.negCacheSize.Set(float64(o.negCacheCount.Load()))
+						}
 					}
+				}
+				if o.metrics != nil {
+					o.metrics.resolveDuration.WithLabelValues("readfile").Observe(time.Since(start).Seconds())
+					o.metrics.layerHitTotal.WithLabelValues(o.layerName(i)).Inc()
 				}
 				return data, nil
 			}
@@ -285,7 +338,14 @@ func (o *OverlayFS) ReadFile(name string) ([]byte, error) {
 						firstCandidateLayer: i,
 					}); !loaded {
 						o.negCacheCount.Add(1)
+						if o.metrics != nil {
+							o.metrics.negCacheSize.Set(float64(o.negCacheCount.Load()))
+						}
 					}
+				}
+				if o.metrics != nil {
+					o.metrics.resolveDuration.WithLabelValues("readfile").Observe(time.Since(start).Seconds())
+					o.metrics.layerHitTotal.WithLabelValues(o.layerName(i)).Inc()
 				}
 				return data, nil
 			}
@@ -295,6 +355,10 @@ func (o *OverlayFS) ReadFile(name string) ([]byte, error) {
 		}
 	}
 
+	if o.metrics != nil {
+		o.metrics.resolveDuration.WithLabelValues("readfile").Observe(time.Since(start).Seconds())
+		o.metrics.missTotal.Inc()
+	}
 	return nil, &fs.PathError{Op: "readfile", Path: name, Err: fs.ErrNotExist}
 }
 
@@ -304,7 +368,15 @@ func (o *OverlayFS) ReadFile(name string) ([]byte, error) {
 func (o *OverlayFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	// TODO(security): ContextOverlayFS will log WARN with request_id and remote_addr
 	if !fs.ValidPath(name) {
+		if o.metrics != nil {
+			o.metrics.pathRejected.WithLabelValues(classifyInvalidPath(name)).Inc()
+		}
 		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrInvalid}
+	}
+
+	var start time.Time
+	if o.metrics != nil {
+		start = time.Now()
 	}
 
 	o.mu.RLock()
@@ -330,6 +402,10 @@ func (o *OverlayFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	}
 
 	if !found {
+		if o.metrics != nil {
+			o.metrics.resolveDuration.WithLabelValues("readdir").Observe(time.Since(start).Seconds())
+			o.metrics.missTotal.Inc()
+		}
 		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrNotExist}
 	}
 
@@ -340,6 +416,10 @@ func (o *OverlayFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	sort.Slice(result, func(i, j int) bool {
 		return result[i].Name() < result[j].Name()
 	})
+
+	if o.metrics != nil {
+		o.metrics.resolveDuration.WithLabelValues("readdir").Observe(time.Since(start).Seconds())
+	}
 	return result, nil
 }
 
@@ -348,7 +428,15 @@ func (o *OverlayFS) ReadDir(name string) ([]fs.DirEntry, error) {
 func (o *OverlayFS) Stat(name string) (fs.FileInfo, error) {
 	// TODO(security): ContextOverlayFS will log WARN with request_id and remote_addr
 	if !fs.ValidPath(name) {
+		if o.metrics != nil {
+			o.metrics.pathRejected.WithLabelValues(classifyInvalidPath(name)).Inc()
+		}
 		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrInvalid}
+	}
+
+	var start time.Time
+	if o.metrics != nil {
+		start = time.Now()
 	}
 
 	o.mu.RLock()
@@ -361,6 +449,9 @@ func (o *OverlayFS) Stat(name string) (fs.FileInfo, error) {
 		entry := cached.(negCacheEntry)
 		if entry.firstCandidateLayer < len(layers) {
 			startLayer = entry.firstCandidateLayer
+			if o.metrics != nil {
+				o.metrics.negCacheHit.Inc()
+			}
 		}
 	}
 
@@ -374,6 +465,10 @@ func (o *OverlayFS) Stat(name string) (fs.FileInfo, error) {
 			}
 			info, err := sfs.Stat(name)
 			if err == nil {
+				if o.metrics != nil {
+					o.metrics.resolveDuration.WithLabelValues("stat").Observe(time.Since(start).Seconds())
+					o.metrics.layerHitTotal.WithLabelValues(o.layerName(i)).Inc()
+				}
 				return info, nil
 			}
 			if !isNotExist(err) {
@@ -393,6 +488,10 @@ func (o *OverlayFS) Stat(name string) (fs.FileInfo, error) {
 				info, statErr := f.Stat()
 				_ = f.Close()
 				if statErr == nil {
+					if o.metrics != nil {
+						o.metrics.resolveDuration.WithLabelValues("stat").Observe(time.Since(start).Seconds())
+						o.metrics.layerHitTotal.WithLabelValues(o.layerName(i)).Inc()
+					}
 					return info, nil
 				}
 				return nil, statErr
@@ -403,6 +502,10 @@ func (o *OverlayFS) Stat(name string) (fs.FileInfo, error) {
 		}
 	}
 
+	if o.metrics != nil {
+		o.metrics.resolveDuration.WithLabelValues("stat").Observe(time.Since(start).Seconds())
+		o.metrics.missTotal.Inc()
+	}
 	return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrNotExist}
 }
 
@@ -434,6 +537,9 @@ func (o *OverlayFS) InvalidateLayer(layerIndex int) {
 		}
 		return true
 	})
+	if o.metrics != nil {
+		o.metrics.negCacheSize.Set(float64(o.negCacheCount.Load()))
+	}
 }
 
 // InvalidateAll clears the entire negative cache.
@@ -444,6 +550,9 @@ func (o *OverlayFS) InvalidateAll() {
 		}
 		return true
 	})
+	if o.metrics != nil {
+		o.metrics.negCacheSize.Set(float64(o.negCacheCount.Load()))
+	}
 }
 
 // ReplaceLayer atomically replaces a layer's backing fs.FS and clears
@@ -518,6 +627,16 @@ func (o *OverlayFS) resolveInfo(name string) (*resolution, error) {
 		}
 	}
 	return nil, &fs.PathError{Op: "resolve", Path: name, Err: fs.ErrNotExist}
+}
+
+// layerName returns the name for layer at index i.
+func (o *OverlayFS) layerName(i int) string {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	if i < len(o.layerNames) {
+		return o.layerNames[i]
+	}
+	return fmt.Sprintf("layer-%d", i)
 }
 
 // isNotExist checks if an error indicates the file does not exist.

--- a/internal/overlayfs/overlayfs.go
+++ b/internal/overlayfs/overlayfs.go
@@ -94,11 +94,13 @@ func NewOverlayFS(layers ...fs.FS) *OverlayFS {
 
 // WithOptions applies functional options to the OverlayFS.
 // This is used with options like WithMetrics.
-func (o *OverlayFS) WithOptions(opts ...Option) *OverlayFS {
+func (o *OverlayFS) WithOptions(opts ...Option) (*OverlayFS, error) {
 	for _, opt := range opts {
-		opt(o)
+		if err := opt(o); err != nil {
+			return nil, fmt.Errorf("overlayfs: apply option: %w", err)
+		}
 	}
-	return o
+	return o, nil
 }
 
 // WithLayerNames sets human-readable names for the overlay layers.

--- a/internal/overlayfs/overlayfs_test.go
+++ b/internal/overlayfs/overlayfs_test.go
@@ -268,7 +268,6 @@ func TestReadDir_PartialLayers(t *testing.T) {
 // §3.2 #10: Nil layer in constructor
 func TestNewOverlayFS_NilLayers(t *testing.T) {
 	defaults := fstest.MapFS{"test.txt": {Data: []byte("hello")}}
-	// After nil-filtering only one layer survives, so pass one name.
 	ofs := NewOverlayFS(nil, defaults, nil).WithLayerNames([]string{"defaults"})
 
 	if ofs.LayerCount() != 1 {


### PR DESCRIPTION
## Summary

Add optional Prometheus metrics to the overlay filesystem via the `WithMetrics(reg)` functional option on `NewOverlayFS`. When not enabled, all instrumentation is a no-op with zero overhead.

### Metrics implemented (per §7.2 design doc)

| Metric | Type | Labels |
|--------|------|--------|
| `blogflow_overlay_resolve_duration_seconds` | Histogram | `op` (open, stat, readfile, readdir) |
| `blogflow_overlay_layer_hit_total` | Counter | `layer` |
| `blogflow_overlay_miss_total` | Counter | — |
| `blogflow_overlay_negcache_hit_total` | Counter | — |
| `blogflow_overlay_negcache_size` | Gauge | — |
| `blogflow_overlay_path_rejected_total` | Counter | `reason` (traversal, absolute, invalid) |

### Files changed
- `internal/overlayfs/metrics.go` — metric definitions, `WithMetrics` option, path classifier
- `internal/overlayfs/overlayfs.go` — instrument Open/ReadFile/ReadDir/Stat/Invalidate methods
- `internal/overlayfs/metrics_test.go` — 10 test cases covering registration, counters, histograms, no-panic

### Testing
- `go test -race ./internal/overlayfs/` — all pass
- `golangci-lint run ./internal/overlayfs/...` — 0 issues

Fixes #9