### PR TITLE
feat: export Resolution type for ContextOverlayFS tracing

### DIFF
--- a/internal/overlayfs/context.go
+++ b/internal/overlayfs/context.go
@@ -32,6 +32,12 @@ type resolutionContextKey struct{}
 // It does NOT implement io/fs.FS because its methods require context.Context.
 // For stdlib consumers that need fs.FS (e.g., html/template.ParseFS), use
 // the inner OverlayFS directly.
+//
+// ContextOverlayFS is NOT safe for concurrent use. It is designed to be
+// created per-request and accessed from a single goroutine.
+//
+// Security: Resolution MUST NOT appear in HTTP responses. It is
+// intended for server-side observability only.
 type ContextOverlayFS struct {
 inner  *OverlayFS
 logger *slog.Logger

--- a/internal/overlayfs/context.go
+++ b/internal/overlayfs/context.go
@@ -1,11 +1,11 @@
 package overlayfs
 
 import (
-"context"
-"fmt"
-"io/fs"
-"log/slog"
-"time"
+	"context"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"time"
 )
 
 // contextKey is an unexported type for context keys defined in this package,
@@ -13,13 +13,13 @@ import (
 type contextKey int
 
 const (
-// RequestIDKey is the context key for the HTTP request ID (string).
-// HTTP middleware populates this for log correlation and tracing.
-RequestIDKey contextKey = iota
+	// RequestIDKey is the context key for the HTTP request ID (string).
+	// HTTP middleware populates this for log correlation and tracing.
+	RequestIDKey contextKey = iota
 
-// RemoteAddrKey is the context key for the client's remote address (string).
-// Used in security WARN logs for path traversal attribution.
-RemoteAddrKey
+	// RemoteAddrKey is the context key for the client's remote address (string).
+	// Used in security WARN logs for path traversal attribution.
+	RemoteAddrKey
 )
 
 // resolutionKey is a distinct unexported type for the Resolution context key.
@@ -39,171 +39,171 @@ type resolutionContextKey struct{}
 // Security: Resolution MUST NOT appear in HTTP responses. It is
 // intended for server-side observability only.
 type ContextOverlayFS struct {
-inner  *OverlayFS
-logger *slog.Logger
+	inner  *OverlayFS
+	logger *slog.Logger
 }
 
 // NewContextOverlayFS creates a context-aware overlay wrapping the given OverlayFS.
 // A nil logger is safe — logging will be silently skipped.
 // Panics if inner is nil (programming error).
 func NewContextOverlayFS(inner *OverlayFS, logger *slog.Logger) *ContextOverlayFS {
-if inner == nil {
-panic("overlayfs: NewContextOverlayFS called with nil OverlayFS")
-}
-return &ContextOverlayFS{inner: inner, logger: logger}
+	if inner == nil {
+		panic("overlayfs: NewContextOverlayFS called with nil OverlayFS")
+	}
+	return &ContextOverlayFS{inner: inner, logger: logger}
 }
 
 // Inner returns the underlying OverlayFS for callers that need a plain
 // fs.FS (e.g., html/template.ParseFS).
 func (c *ContextOverlayFS) Inner() *OverlayFS {
-return c.inner
+	return c.inner
 }
 
 // Open opens a file with context support. Checks ctx.Err() before
 // delegating to the inner OverlayFS. Logs WARN on path traversal attempts
 // with request context values.
 func (c *ContextOverlayFS) Open(ctx context.Context, name string) (fs.File, error) {
-if err := c.checkPath(ctx, "open", name); err != nil {
-return nil, err
-}
-if err := ctx.Err(); err != nil {
-return nil, fmt.Errorf("overlayfs: open %q: %w", name, err)
-}
+	if err := c.checkPath(ctx, "open", name); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("overlayfs: open %q: %w", name, err)
+	}
 
-start := time.Now()
-f, err := c.inner.Open(name)
-c.logOperation(ctx, "open", name, start, err)
-return f, err
+	start := time.Now()
+	f, err := c.inner.Open(name)
+	c.logOperation(ctx, "open", name, start, err)
+	return f, err
 }
 
 // ReadFile reads a file with context support.
 func (c *ContextOverlayFS) ReadFile(ctx context.Context, name string) ([]byte, error) {
-if err := c.checkPath(ctx, "readfile", name); err != nil {
-return nil, err
-}
-if err := ctx.Err(); err != nil {
-return nil, fmt.Errorf("overlayfs: readfile %q: %w", name, err)
-}
+	if err := c.checkPath(ctx, "readfile", name); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("overlayfs: readfile %q: %w", name, err)
+	}
 
-start := time.Now()
-data, err := c.inner.ReadFile(name)
-c.logOperation(ctx, "readfile", name, start, err)
-return data, err
+	start := time.Now()
+	data, err := c.inner.ReadFile(name)
+	c.logOperation(ctx, "readfile", name, start, err)
+	return data, err
 }
 
 // ReadDir lists a directory with context support.
 func (c *ContextOverlayFS) ReadDir(ctx context.Context, name string) ([]fs.DirEntry, error) {
-if err := c.checkPath(ctx, "readdir", name); err != nil {
-return nil, err
-}
-if err := ctx.Err(); err != nil {
-return nil, fmt.Errorf("overlayfs: readdir %q: %w", name, err)
-}
+	if err := c.checkPath(ctx, "readdir", name); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("overlayfs: readdir %q: %w", name, err)
+	}
 
-start := time.Now()
-entries, err := c.inner.ReadDir(name)
-c.logOperation(ctx, "readdir", name, start, err)
-return entries, err
+	start := time.Now()
+	entries, err := c.inner.ReadDir(name)
+	c.logOperation(ctx, "readdir", name, start, err)
+	return entries, err
 }
 
 // Stat returns file info with context support.
 func (c *ContextOverlayFS) Stat(ctx context.Context, name string) (fs.FileInfo, error) {
-if err := c.checkPath(ctx, "stat", name); err != nil {
-return nil, err
-}
-if err := ctx.Err(); err != nil {
-return nil, fmt.Errorf("overlayfs: stat %q: %w", name, err)
-}
+	if err := c.checkPath(ctx, "stat", name); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("overlayfs: stat %q: %w", name, err)
+	}
 
-start := time.Now()
-info, err := c.inner.Stat(name)
-c.logOperation(ctx, "stat", name, start, err)
-return info, err
+	start := time.Now()
+	info, err := c.inner.Stat(name)
+	c.logOperation(ctx, "stat", name, start, err)
+	return info, err
 }
 
 // OpenFile opens a file and returns both handle and FileInfo atomically
 // from a single layer resolution, with context support.
 func (c *ContextOverlayFS) OpenFile(ctx context.Context, name string) (fs.File, fs.FileInfo, error) {
-if err := c.checkPath(ctx, "openfile", name); err != nil {
-return nil, nil, err
-}
-if err := ctx.Err(); err != nil {
-return nil, nil, fmt.Errorf("overlayfs: openfile %q: %w", name, err)
-}
+	if err := c.checkPath(ctx, "openfile", name); err != nil {
+		return nil, nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, nil, fmt.Errorf("overlayfs: openfile %q: %w", name, err)
+	}
 
-start := time.Now()
-f, info, err := c.inner.OpenFile(name)
-c.logOperation(ctx, "openfile", name, start, err)
-return f, info, err
+	start := time.Now()
+	f, info, err := c.inner.OpenFile(name)
+	c.logOperation(ctx, "openfile", name, start, err)
+	return f, info, err
 }
 
 // InvalidateLayer delegates to the inner OverlayFS.
 func (c *ContextOverlayFS) InvalidateLayer(layerIndex int) {
-c.inner.InvalidateLayer(layerIndex)
+	c.inner.InvalidateLayer(layerIndex)
 }
 
 // InvalidateAll delegates to the inner OverlayFS.
 func (c *ContextOverlayFS) InvalidateAll() {
-c.inner.InvalidateAll()
+	c.inner.InvalidateAll()
 }
 
 // ReplaceLayer delegates to the inner OverlayFS.
 func (c *ContextOverlayFS) ReplaceLayer(layerIndex int, newFS fs.FS) error {
-return c.inner.ReplaceLayer(layerIndex, newFS)
+	return c.inner.ReplaceLayer(layerIndex, newFS)
 }
 
 // checkPath validates the path and logs a WARN on traversal attempts.
 func (c *ContextOverlayFS) checkPath(ctx context.Context, op, name string) error {
-if fs.ValidPath(name) {
-return nil
-}
+	if fs.ValidPath(name) {
+		return nil
+	}
 
-if c.logger != nil {
-c.logger.WarnContext(ctx, "path traversal attempt",
-slog.String("op", op),
-slog.String("path", name),
-slog.String("request_id", contextString(ctx, RequestIDKey)),
-slog.String("remote_addr", contextString(ctx, RemoteAddrKey)),
-)
-}
+	if c.logger != nil {
+		c.logger.WarnContext(ctx, "path traversal attempt",
+			slog.String("op", op),
+			slog.String("path", name),
+			slog.String("request_id", contextString(ctx, RequestIDKey)),
+			slog.String("remote_addr", contextString(ctx, RemoteAddrKey)),
+		)
+	}
 
-return &fs.PathError{Op: op, Path: name, Err: fs.ErrInvalid}
+	return &fs.PathError{Op: op, Path: name, Err: fs.ErrInvalid}
 }
 
 // logOperation logs span-like info for each FS operation via slog.
 func (c *ContextOverlayFS) logOperation(ctx context.Context, op, name string, start time.Time, err error) {
-if c.logger == nil || !c.logger.Enabled(ctx, slog.LevelDebug) {
-return
-}
-duration := time.Since(start)
+	if c.logger == nil || !c.logger.Enabled(ctx, slog.LevelDebug) {
+		return
+	}
+	duration := time.Since(start)
 
-attrs := []slog.Attr{
-slog.String("op", op),
-slog.String("path", name),
-slog.Duration("duration", duration),
-slog.String("request_id", contextString(ctx, RequestIDKey)),
-}
+	attrs := []slog.Attr{
+		slog.String("op", op),
+		slog.String("path", name),
+		slog.Duration("duration", duration),
+		slog.String("request_id", contextString(ctx, RequestIDKey)),
+	}
 
-if err != nil {
-attrs = append(attrs, slog.String("error", err.Error()))
-c.logger.LogAttrs(ctx, slog.LevelDebug, "overlayfs operation failed", attrs...)
-} else {
-c.logger.LogAttrs(ctx, slog.LevelDebug, "overlayfs operation", attrs...)
-}
+	if err != nil {
+		attrs = append(attrs, slog.String("error", err.Error()))
+		c.logger.LogAttrs(ctx, slog.LevelDebug, "overlayfs operation failed", attrs...)
+	} else {
+		c.logger.LogAttrs(ctx, slog.LevelDebug, "overlayfs operation", attrs...)
+	}
 }
 
 // contextString extracts a string value from the context, returning "" if absent.
 func contextString(ctx context.Context, key contextKey) string {
-v, _ := ctx.Value(key).(string)
-return v
+	v, _ := ctx.Value(key).(string)
+	return v
 }
 
 // ResolutionFromContext extracts a Resolution stored by ContextWithResolution.
 // Returns the Resolution and true if present, or the zero value and false
 // if no resolution has been stored.
 func ResolutionFromContext(ctx context.Context) (Resolution, bool) {
-r, ok := ctx.Value(resolutionContextKey{}).(Resolution)
-return r, ok
+	r, ok := ctx.Value(resolutionContextKey{}).(Resolution)
+	return r, ok
 }
 
 // ContextWithResolution returns a new context carrying the given Resolution.
@@ -213,5 +213,5 @@ return r, ok
 // Security: Resolution MUST NOT appear in HTTP responses. It is
 // intended for server-side observability only.
 func ContextWithResolution(ctx context.Context, r Resolution) context.Context {
-return context.WithValue(ctx, resolutionContextKey{}, r)
+	return context.WithValue(ctx, resolutionContextKey{}, r)
 }

--- a/internal/overlayfs/context.go
+++ b/internal/overlayfs/context.go
@@ -1,11 +1,11 @@
 package overlayfs
 
 import (
-	"context"
-	"fmt"
-	"io/fs"
-	"log/slog"
-	"time"
+"context"
+"fmt"
+"io/fs"
+"log/slog"
+"time"
 )
 
 // contextKey is an unexported type for context keys defined in this package,
@@ -13,14 +13,17 @@ import (
 type contextKey int
 
 const (
-	// RequestIDKey is the context key for the HTTP request ID (string).
-	// HTTP middleware populates this for log correlation and tracing.
-	RequestIDKey contextKey = iota
+// RequestIDKey is the context key for the HTTP request ID (string).
+// HTTP middleware populates this for log correlation and tracing.
+RequestIDKey contextKey = iota
 
-	// RemoteAddrKey is the context key for the client's remote address (string).
-	// Used in security WARN logs for path traversal attribution.
-	RemoteAddrKey
+// RemoteAddrKey is the context key for the client's remote address (string).
+// Used in security WARN logs for path traversal attribution.
+RemoteAddrKey
 )
+
+// resolutionKey is a distinct unexported type for the Resolution context key.
+type resolutionContextKey struct{}
 
 // ContextOverlayFS wraps OverlayFS with context.Context support for
 // cancellation, tracing, and security log correlation. This is the
@@ -30,161 +33,179 @@ const (
 // For stdlib consumers that need fs.FS (e.g., html/template.ParseFS), use
 // the inner OverlayFS directly.
 type ContextOverlayFS struct {
-	inner  *OverlayFS
-	logger *slog.Logger
+inner  *OverlayFS
+logger *slog.Logger
 }
 
 // NewContextOverlayFS creates a context-aware overlay wrapping the given OverlayFS.
 // A nil logger is safe — logging will be silently skipped.
 // Panics if inner is nil (programming error).
 func NewContextOverlayFS(inner *OverlayFS, logger *slog.Logger) *ContextOverlayFS {
-	if inner == nil {
-		panic("overlayfs: NewContextOverlayFS called with nil OverlayFS")
-	}
-	return &ContextOverlayFS{inner: inner, logger: logger}
+if inner == nil {
+panic("overlayfs: NewContextOverlayFS called with nil OverlayFS")
+}
+return &ContextOverlayFS{inner: inner, logger: logger}
 }
 
 // Inner returns the underlying OverlayFS for callers that need a plain
 // fs.FS (e.g., html/template.ParseFS).
 func (c *ContextOverlayFS) Inner() *OverlayFS {
-	return c.inner
+return c.inner
 }
 
 // Open opens a file with context support. Checks ctx.Err() before
 // delegating to the inner OverlayFS. Logs WARN on path traversal attempts
 // with request context values.
 func (c *ContextOverlayFS) Open(ctx context.Context, name string) (fs.File, error) {
-	if err := c.checkPath(ctx, "open", name); err != nil {
-		return nil, err
-	}
-	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("overlayfs: open %q: %w", name, err)
-	}
+if err := c.checkPath(ctx, "open", name); err != nil {
+return nil, err
+}
+if err := ctx.Err(); err != nil {
+return nil, fmt.Errorf("overlayfs: open %q: %w", name, err)
+}
 
-	start := time.Now()
-	f, err := c.inner.Open(name)
-	c.logOperation(ctx, "open", name, start, err)
-	return f, err
+start := time.Now()
+f, err := c.inner.Open(name)
+c.logOperation(ctx, "open", name, start, err)
+return f, err
 }
 
 // ReadFile reads a file with context support.
 func (c *ContextOverlayFS) ReadFile(ctx context.Context, name string) ([]byte, error) {
-	if err := c.checkPath(ctx, "readfile", name); err != nil {
-		return nil, err
-	}
-	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("overlayfs: readfile %q: %w", name, err)
-	}
+if err := c.checkPath(ctx, "readfile", name); err != nil {
+return nil, err
+}
+if err := ctx.Err(); err != nil {
+return nil, fmt.Errorf("overlayfs: readfile %q: %w", name, err)
+}
 
-	start := time.Now()
-	data, err := c.inner.ReadFile(name)
-	c.logOperation(ctx, "readfile", name, start, err)
-	return data, err
+start := time.Now()
+data, err := c.inner.ReadFile(name)
+c.logOperation(ctx, "readfile", name, start, err)
+return data, err
 }
 
 // ReadDir lists a directory with context support.
 func (c *ContextOverlayFS) ReadDir(ctx context.Context, name string) ([]fs.DirEntry, error) {
-	if err := c.checkPath(ctx, "readdir", name); err != nil {
-		return nil, err
-	}
-	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("overlayfs: readdir %q: %w", name, err)
-	}
+if err := c.checkPath(ctx, "readdir", name); err != nil {
+return nil, err
+}
+if err := ctx.Err(); err != nil {
+return nil, fmt.Errorf("overlayfs: readdir %q: %w", name, err)
+}
 
-	start := time.Now()
-	entries, err := c.inner.ReadDir(name)
-	c.logOperation(ctx, "readdir", name, start, err)
-	return entries, err
+start := time.Now()
+entries, err := c.inner.ReadDir(name)
+c.logOperation(ctx, "readdir", name, start, err)
+return entries, err
 }
 
 // Stat returns file info with context support.
 func (c *ContextOverlayFS) Stat(ctx context.Context, name string) (fs.FileInfo, error) {
-	if err := c.checkPath(ctx, "stat", name); err != nil {
-		return nil, err
-	}
-	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("overlayfs: stat %q: %w", name, err)
-	}
+if err := c.checkPath(ctx, "stat", name); err != nil {
+return nil, err
+}
+if err := ctx.Err(); err != nil {
+return nil, fmt.Errorf("overlayfs: stat %q: %w", name, err)
+}
 
-	start := time.Now()
-	info, err := c.inner.Stat(name)
-	c.logOperation(ctx, "stat", name, start, err)
-	return info, err
+start := time.Now()
+info, err := c.inner.Stat(name)
+c.logOperation(ctx, "stat", name, start, err)
+return info, err
 }
 
 // OpenFile opens a file and returns both handle and FileInfo atomically
 // from a single layer resolution, with context support.
 func (c *ContextOverlayFS) OpenFile(ctx context.Context, name string) (fs.File, fs.FileInfo, error) {
-	if err := c.checkPath(ctx, "openfile", name); err != nil {
-		return nil, nil, err
-	}
-	if err := ctx.Err(); err != nil {
-		return nil, nil, fmt.Errorf("overlayfs: openfile %q: %w", name, err)
-	}
+if err := c.checkPath(ctx, "openfile", name); err != nil {
+return nil, nil, err
+}
+if err := ctx.Err(); err != nil {
+return nil, nil, fmt.Errorf("overlayfs: openfile %q: %w", name, err)
+}
 
-	start := time.Now()
-	f, info, err := c.inner.OpenFile(name)
-	c.logOperation(ctx, "openfile", name, start, err)
-	return f, info, err
+start := time.Now()
+f, info, err := c.inner.OpenFile(name)
+c.logOperation(ctx, "openfile", name, start, err)
+return f, info, err
 }
 
 // InvalidateLayer delegates to the inner OverlayFS.
 func (c *ContextOverlayFS) InvalidateLayer(layerIndex int) {
-	c.inner.InvalidateLayer(layerIndex)
+c.inner.InvalidateLayer(layerIndex)
 }
 
 // InvalidateAll delegates to the inner OverlayFS.
 func (c *ContextOverlayFS) InvalidateAll() {
-	c.inner.InvalidateAll()
+c.inner.InvalidateAll()
 }
 
 // ReplaceLayer delegates to the inner OverlayFS.
 func (c *ContextOverlayFS) ReplaceLayer(layerIndex int, newFS fs.FS) error {
-	return c.inner.ReplaceLayer(layerIndex, newFS)
+return c.inner.ReplaceLayer(layerIndex, newFS)
 }
 
 // checkPath validates the path and logs a WARN on traversal attempts.
 func (c *ContextOverlayFS) checkPath(ctx context.Context, op, name string) error {
-	if fs.ValidPath(name) {
-		return nil
-	}
+if fs.ValidPath(name) {
+return nil
+}
 
-	if c.logger != nil {
-		c.logger.WarnContext(ctx, "path traversal attempt",
-			slog.String("op", op),
-			slog.String("path", name),
-			slog.String("request_id", contextString(ctx, RequestIDKey)),
-			slog.String("remote_addr", contextString(ctx, RemoteAddrKey)),
-		)
-	}
+if c.logger != nil {
+c.logger.WarnContext(ctx, "path traversal attempt",
+slog.String("op", op),
+slog.String("path", name),
+slog.String("request_id", contextString(ctx, RequestIDKey)),
+slog.String("remote_addr", contextString(ctx, RemoteAddrKey)),
+)
+}
 
-	return &fs.PathError{Op: op, Path: name, Err: fs.ErrInvalid}
+return &fs.PathError{Op: op, Path: name, Err: fs.ErrInvalid}
 }
 
 // logOperation logs span-like info for each FS operation via slog.
 func (c *ContextOverlayFS) logOperation(ctx context.Context, op, name string, start time.Time, err error) {
-	if c.logger == nil || !c.logger.Enabled(ctx, slog.LevelDebug) {
-		return
-	}
-	duration := time.Since(start)
+if c.logger == nil || !c.logger.Enabled(ctx, slog.LevelDebug) {
+return
+}
+duration := time.Since(start)
 
-	attrs := []slog.Attr{
-		slog.String("op", op),
-		slog.String("path", name),
-		slog.Duration("duration", duration),
-		slog.String("request_id", contextString(ctx, RequestIDKey)),
-	}
+attrs := []slog.Attr{
+slog.String("op", op),
+slog.String("path", name),
+slog.Duration("duration", duration),
+slog.String("request_id", contextString(ctx, RequestIDKey)),
+}
 
-	if err != nil {
-		attrs = append(attrs, slog.String("error", err.Error()))
-		c.logger.LogAttrs(ctx, slog.LevelDebug, "overlayfs operation failed", attrs...)
-	} else {
-		c.logger.LogAttrs(ctx, slog.LevelDebug, "overlayfs operation", attrs...)
-	}
+if err != nil {
+attrs = append(attrs, slog.String("error", err.Error()))
+c.logger.LogAttrs(ctx, slog.LevelDebug, "overlayfs operation failed", attrs...)
+} else {
+c.logger.LogAttrs(ctx, slog.LevelDebug, "overlayfs operation", attrs...)
+}
 }
 
 // contextString extracts a string value from the context, returning "" if absent.
 func contextString(ctx context.Context, key contextKey) string {
-	v, _ := ctx.Value(key).(string)
-	return v
+v, _ := ctx.Value(key).(string)
+return v
+}
+
+// ResolutionFromContext extracts a Resolution stored by ContextWithResolution.
+// Returns the Resolution and true if present, or the zero value and false
+// if no resolution has been stored.
+func ResolutionFromContext(ctx context.Context) (Resolution, bool) {
+r, ok := ctx.Value(resolutionContextKey{}).(Resolution)
+return r, ok
+}
+
+// ContextWithResolution returns a new context carrying the given Resolution.
+// This is intended for middleware or handlers that call OverlayFS.Resolve
+// and want to propagate the result downstream for observability.
+//
+// Security: Resolution MUST NOT appear in HTTP responses. It is
+// intended for server-side observability only.
+func ContextWithResolution(ctx context.Context, r Resolution) context.Context {
+return context.WithValue(ctx, resolutionContextKey{}, r)
 }

--- a/internal/overlayfs/context_test.go
+++ b/internal/overlayfs/context_test.go
@@ -1,491 +1,491 @@
 package overlayfs
 
 import (
-"bytes"
-"context"
-"errors"
-"io"
-"io/fs"
-"log/slog"
-"strings"
-"testing"
-"testing/fstest"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"io/fs"
+	"log/slog"
+	"strings"
+	"testing"
+	"testing/fstest"
 )
 
 func newTestContextOverlay(logger *slog.Logger, layers ...fs.FS) *ContextOverlayFS {
-names := make([]string, len(layers))
-for i := range layers {
-names[i] = layerName(i)
-}
-return NewContextOverlayFS(NewOverlayFS(layers...).WithLayerNames(names), logger)
+	names := make([]string, len(layers))
+	for i := range layers {
+		names[i] = layerName(i)
+	}
+	return NewContextOverlayFS(NewOverlayFS(layers...).WithLayerNames(names), logger)
 }
 
 // --- Context cancellation aborts resolution ---
 
 func TestContextOpen_Cancelled(t *testing.T) {
-layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
-cfs := newTestContextOverlay(nil, layer)
+	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+	cfs := newTestContextOverlay(nil, layer)
 
-ctx, cancel := context.WithCancel(context.Background())
-cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 
-_, err := cfs.Open(ctx, "file.txt")
-if err == nil {
-t.Fatal("expected error from cancelled context")
-}
-if !errors.Is(err, context.Canceled) {
-t.Errorf("expected context.Canceled, got %v", err)
-}
+	_, err := cfs.Open(ctx, "file.txt")
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
 }
 
 func TestContextReadFile_Cancelled(t *testing.T) {
-layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
-cfs := newTestContextOverlay(nil, layer)
+	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+	cfs := newTestContextOverlay(nil, layer)
 
-ctx, cancel := context.WithCancel(context.Background())
-cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 
-_, err := cfs.ReadFile(ctx, "file.txt")
-if err == nil {
-t.Fatal("expected error from cancelled context")
-}
-if !errors.Is(err, context.Canceled) {
-t.Errorf("expected context.Canceled, got %v", err)
-}
+	_, err := cfs.ReadFile(ctx, "file.txt")
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
 }
 
 func TestContextReadDir_Cancelled(t *testing.T) {
-layer := fstest.MapFS{"dir/file.txt": {Data: []byte("data")}}
-cfs := newTestContextOverlay(nil, layer)
+	layer := fstest.MapFS{"dir/file.txt": {Data: []byte("data")}}
+	cfs := newTestContextOverlay(nil, layer)
 
-ctx, cancel := context.WithCancel(context.Background())
-cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 
-_, err := cfs.ReadDir(ctx, "dir")
-if err == nil {
-t.Fatal("expected error from cancelled context")
-}
-if !errors.Is(err, context.Canceled) {
-t.Errorf("expected context.Canceled, got %v", err)
-}
+	_, err := cfs.ReadDir(ctx, "dir")
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
 }
 
 func TestContextStat_Cancelled(t *testing.T) {
-layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
-cfs := newTestContextOverlay(nil, layer)
+	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+	cfs := newTestContextOverlay(nil, layer)
 
-ctx, cancel := context.WithCancel(context.Background())
-cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 
-_, err := cfs.Stat(ctx, "file.txt")
-if err == nil {
-t.Fatal("expected error from cancelled context")
-}
-if !errors.Is(err, context.Canceled) {
-t.Errorf("expected context.Canceled, got %v", err)
-}
+	_, err := cfs.Stat(ctx, "file.txt")
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
 }
 
 func TestContextOpenFile_Cancelled(t *testing.T) {
-layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
-cfs := newTestContextOverlay(nil, layer)
+	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+	cfs := newTestContextOverlay(nil, layer)
 
-ctx, cancel := context.WithCancel(context.Background())
-cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 
-_, _, err := cfs.OpenFile(ctx, "file.txt")
-if err == nil {
-t.Fatal("expected error from cancelled context")
-}
-if !errors.Is(err, context.Canceled) {
-t.Errorf("expected context.Canceled, got %v", err)
-}
+	_, _, err := cfs.OpenFile(ctx, "file.txt")
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
 }
 
 // --- Security logging on path traversal ---
 
 func TestContextOpen_PathTraversalLogged(t *testing.T) {
-var buf bytes.Buffer
-logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
-cfs := newTestContextOverlay(logger, fstest.MapFS{})
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	cfs := newTestContextOverlay(logger, fstest.MapFS{})
 
-ctx := context.WithValue(context.Background(), RequestIDKey, "req-123")
-ctx = context.WithValue(ctx, RemoteAddrKey, "192.168.1.100")
+	ctx := context.WithValue(context.Background(), RequestIDKey, "req-123")
+	ctx = context.WithValue(ctx, RemoteAddrKey, "192.168.1.100")
 
-_, err := cfs.Open(ctx, "../etc/passwd")
-if err == nil {
-t.Fatal("expected error for path traversal")
-}
+	_, err := cfs.Open(ctx, "../etc/passwd")
+	if err == nil {
+		t.Fatal("expected error for path traversal")
+	}
 
-logged := buf.String()
-if !strings.Contains(logged, "path traversal attempt") {
-t.Error("expected 'path traversal attempt' in log")
-}
-if !strings.Contains(logged, "req-123") {
-t.Error("expected request_id in log")
-}
-if !strings.Contains(logged, "192.168.1.100") {
-t.Error("expected remote_addr in log")
-}
+	logged := buf.String()
+	if !strings.Contains(logged, "path traversal attempt") {
+		t.Error("expected 'path traversal attempt' in log")
+	}
+	if !strings.Contains(logged, "req-123") {
+		t.Error("expected request_id in log")
+	}
+	if !strings.Contains(logged, "192.168.1.100") {
+		t.Error("expected remote_addr in log")
+	}
 }
 
 func TestContextReadFile_PathTraversalLogged(t *testing.T) {
-var buf bytes.Buffer
-logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
-cfs := newTestContextOverlay(logger, fstest.MapFS{})
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	cfs := newTestContextOverlay(logger, fstest.MapFS{})
 
-ctx := context.WithValue(context.Background(), RequestIDKey, "req-456")
-_, err := cfs.ReadFile(ctx, "/etc/shadow")
-if err == nil {
-t.Fatal("expected error for absolute path")
-}
-if !strings.Contains(buf.String(), "path traversal attempt") {
-t.Error("expected security log")
-}
+	ctx := context.WithValue(context.Background(), RequestIDKey, "req-456")
+	_, err := cfs.ReadFile(ctx, "/etc/shadow")
+	if err == nil {
+		t.Fatal("expected error for absolute path")
+	}
+	if !strings.Contains(buf.String(), "path traversal attempt") {
+		t.Error("expected security log")
+	}
 }
 
 func TestContextStat_PathTraversalLogged(t *testing.T) {
-var buf bytes.Buffer
-logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
-cfs := newTestContextOverlay(logger, fstest.MapFS{})
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	cfs := newTestContextOverlay(logger, fstest.MapFS{})
 
-_, err := cfs.Stat(context.Background(), "../etc/passwd")
-if err == nil {
-t.Fatal("expected error for traversal path")
-}
-if !strings.Contains(buf.String(), "path traversal attempt") {
-t.Error("expected security log")
-}
+	_, err := cfs.Stat(context.Background(), "../etc/passwd")
+	if err == nil {
+		t.Fatal("expected error for traversal path")
+	}
+	if !strings.Contains(buf.String(), "path traversal attempt") {
+		t.Error("expected security log")
+	}
 }
 
 // --- All FS methods work through the wrapper ---
 
 func TestContextOpen_Works(t *testing.T) {
-theme := fstest.MapFS{"templates/post.html": {Data: []byte("theme-post")}}
-defaults := fstest.MapFS{"templates/post.html": {Data: []byte("default-post")}}
-cfs := newTestContextOverlay(nil, theme, defaults)
+	theme := fstest.MapFS{"templates/post.html": {Data: []byte("theme-post")}}
+	defaults := fstest.MapFS{"templates/post.html": {Data: []byte("default-post")}}
+	cfs := newTestContextOverlay(nil, theme, defaults)
 
-f, err := cfs.Open(context.Background(), "templates/post.html")
-if err != nil {
-t.Fatal(err)
-}
-defer func() { _ = f.Close() }()
+	f, err := cfs.Open(context.Background(), "templates/post.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
 
-data, err := io.ReadAll(f)
-if err != nil {
-t.Fatal(err)
-}
-if string(data) != "theme-post" {
-t.Errorf("got %q, want %q", data, "theme-post")
-}
+	data, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "theme-post" {
+		t.Errorf("got %q, want %q", data, "theme-post")
+	}
 }
 
 func TestContextReadFile_Works(t *testing.T) {
-layer := fstest.MapFS{"file.txt": {Data: []byte("hello")}}
-cfs := newTestContextOverlay(nil, layer)
+	layer := fstest.MapFS{"file.txt": {Data: []byte("hello")}}
+	cfs := newTestContextOverlay(nil, layer)
 
-data, err := cfs.ReadFile(context.Background(), "file.txt")
-if err != nil {
-t.Fatal(err)
-}
-if string(data) != "hello" {
-t.Errorf("got %q, want %q", data, "hello")
-}
+	data, err := cfs.ReadFile(context.Background(), "file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("got %q, want %q", data, "hello")
+	}
 }
 
 func TestContextReadFile_Fallback(t *testing.T) {
-theme := fstest.MapFS{}
-defaults := fstest.MapFS{"base.html": {Data: []byte("default-base")}}
-cfs := newTestContextOverlay(nil, theme, defaults)
+	theme := fstest.MapFS{}
+	defaults := fstest.MapFS{"base.html": {Data: []byte("default-base")}}
+	cfs := newTestContextOverlay(nil, theme, defaults)
 
-data, err := cfs.ReadFile(context.Background(), "base.html")
-if err != nil {
-t.Fatal(err)
-}
-if string(data) != "default-base" {
-t.Errorf("got %q, want %q", data, "default-base")
-}
+	data, err := cfs.ReadFile(context.Background(), "base.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "default-base" {
+		t.Errorf("got %q, want %q", data, "default-base")
+	}
 }
 
 func TestContextReadDir_Works(t *testing.T) {
-theme := fstest.MapFS{
-"templates/a.html": {Data: []byte("a")},
-}
-defaults := fstest.MapFS{
-"templates/b.html": {Data: []byte("b")},
-}
-cfs := newTestContextOverlay(nil, theme, defaults)
+	theme := fstest.MapFS{
+		"templates/a.html": {Data: []byte("a")},
+	}
+	defaults := fstest.MapFS{
+		"templates/b.html": {Data: []byte("b")},
+	}
+	cfs := newTestContextOverlay(nil, theme, defaults)
 
-entries, err := cfs.ReadDir(context.Background(), "templates")
-if err != nil {
-t.Fatal(err)
-}
-if len(entries) != 2 {
-t.Fatalf("got %d entries, want 2", len(entries))
-}
-if entries[0].Name() != "a.html" || entries[1].Name() != "b.html" {
-t.Errorf("got [%s, %s], want [a.html, b.html]", entries[0].Name(), entries[1].Name())
-}
+	entries, err := cfs.ReadDir(context.Background(), "templates")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(entries))
+	}
+	if entries[0].Name() != "a.html" || entries[1].Name() != "b.html" {
+		t.Errorf("got [%s, %s], want [a.html, b.html]", entries[0].Name(), entries[1].Name())
+	}
 }
 
 func TestContextStat_Works(t *testing.T) {
-layer := fstest.MapFS{"file.txt": {Data: []byte("hello world")}}
-cfs := newTestContextOverlay(nil, layer)
+	layer := fstest.MapFS{"file.txt": {Data: []byte("hello world")}}
+	cfs := newTestContextOverlay(nil, layer)
 
-info, err := cfs.Stat(context.Background(), "file.txt")
-if err != nil {
-t.Fatal(err)
-}
-if info.Name() != "file.txt" {
-t.Errorf("Name = %q, want %q", info.Name(), "file.txt")
-}
-if info.Size() != 11 {
-t.Errorf("Size = %d, want 11", info.Size())
-}
+	info, err := cfs.Stat(context.Background(), "file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Name() != "file.txt" {
+		t.Errorf("Name = %q, want %q", info.Name(), "file.txt")
+	}
+	if info.Size() != 11 {
+		t.Errorf("Size = %d, want 11", info.Size())
+	}
 }
 
 func TestContextOpenFile_Works(t *testing.T) {
-layer := fstest.MapFS{"file.txt": {Data: []byte("hello world")}}
-cfs := newTestContextOverlay(nil, layer)
+	layer := fstest.MapFS{"file.txt": {Data: []byte("hello world")}}
+	cfs := newTestContextOverlay(nil, layer)
 
-f, info, err := cfs.OpenFile(context.Background(), "file.txt")
-if err != nil {
-t.Fatal(err)
-}
-defer func() { _ = f.Close() }()
+	f, info, err := cfs.OpenFile(context.Background(), "file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
 
-if info.Name() != "file.txt" {
-t.Errorf("Name = %q, want %q", info.Name(), "file.txt")
-}
-if info.Size() != 11 {
-t.Errorf("Size = %d, want 11", info.Size())
-}
+	if info.Name() != "file.txt" {
+		t.Errorf("Name = %q, want %q", info.Name(), "file.txt")
+	}
+	if info.Size() != 11 {
+		t.Errorf("Size = %d, want 11", info.Size())
+	}
 }
 
 func TestContextOpen_NotFound(t *testing.T) {
-cfs := newTestContextOverlay(nil, fstest.MapFS{})
+	cfs := newTestContextOverlay(nil, fstest.MapFS{})
 
-_, err := cfs.Open(context.Background(), "nope.txt")
-if err == nil {
-t.Fatal("expected error")
-}
-if !errors.Is(err, fs.ErrNotExist) {
-t.Errorf("expected ErrNotExist, got %v", err)
-}
+	_, err := cfs.Open(context.Background(), "nope.txt")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("expected ErrNotExist, got %v", err)
+	}
 }
 
 // --- Nil logger is safe ---
 
 func TestContextOpen_NilLogger(t *testing.T) {
-layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
-cfs := NewContextOverlayFS(NewOverlayFS(layer).WithLayerNames([]string{"test"}), nil)
+	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+	cfs := NewContextOverlayFS(NewOverlayFS(layer).WithLayerNames([]string{"test"}), nil)
 
-f, err := cfs.Open(context.Background(), "file.txt")
-if err != nil {
-t.Fatal(err)
-}
-_ = f.Close()
+	f, err := cfs.Open(context.Background(), "file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
 }
 
 func TestContextOpen_NilLoggerPathTraversal(t *testing.T) {
-cfs := NewContextOverlayFS(NewOverlayFS(fstest.MapFS{}).WithLayerNames([]string{"test"}), nil)
+	cfs := NewContextOverlayFS(NewOverlayFS(fstest.MapFS{}).WithLayerNames([]string{"test"}), nil)
 
-_, err := cfs.Open(context.Background(), "../etc/passwd")
-if err == nil {
-t.Fatal("expected error for path traversal")
-}
+	_, err := cfs.Open(context.Background(), "../etc/passwd")
+	if err == nil {
+		t.Fatal("expected error for path traversal")
+	}
 }
 
 // --- Delegation methods ---
 
 func TestContextInvalidateLayer(t *testing.T) {
-theme := fstest.MapFS{}
-defaults := fstest.MapFS{"file.txt": {Data: []byte("default")}}
-cfs := newTestContextOverlay(nil, theme, defaults)
+	theme := fstest.MapFS{}
+	defaults := fstest.MapFS{"file.txt": {Data: []byte("default")}}
+	cfs := newTestContextOverlay(nil, theme, defaults)
 
-// Warm the negative cache
-_, _ = cfs.ReadFile(context.Background(), "file.txt")
+	// Warm the negative cache
+	_, _ = cfs.ReadFile(context.Background(), "file.txt")
 
-// Replace and invalidate
-newTheme := fstest.MapFS{"file.txt": {Data: []byte("theme")}}
-_ = cfs.ReplaceLayer(0, newTheme)
+	// Replace and invalidate
+	newTheme := fstest.MapFS{"file.txt": {Data: []byte("theme")}}
+	_ = cfs.ReplaceLayer(0, newTheme)
 
-data, _ := cfs.ReadFile(context.Background(), "file.txt")
-if string(data) != "theme" {
-t.Errorf("got %q, want %q", data, "theme")
-}
+	data, _ := cfs.ReadFile(context.Background(), "file.txt")
+	if string(data) != "theme" {
+		t.Errorf("got %q, want %q", data, "theme")
+	}
 }
 
 func TestContextInvalidateAll(t *testing.T) {
-cfs := newTestContextOverlay(nil, fstest.MapFS{"file.txt": {Data: []byte("v1")}})
+	cfs := newTestContextOverlay(nil, fstest.MapFS{"file.txt": {Data: []byte("v1")}})
 
-_, _ = cfs.ReadFile(context.Background(), "file.txt")
-cfs.InvalidateAll() // should not panic
+	_, _ = cfs.ReadFile(context.Background(), "file.txt")
+	cfs.InvalidateAll() // should not panic
 }
 
 // --- Logging with context values ---
 
 func TestContextOpen_LogsOperation(t *testing.T) {
-var buf bytes.Buffer
-logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
-cfs := newTestContextOverlay(logger, layer)
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+	cfs := newTestContextOverlay(logger, layer)
 
-ctx := context.WithValue(context.Background(), RequestIDKey, "req-789")
-_, err := cfs.Open(ctx, "file.txt")
-if err != nil {
-t.Fatal(err)
-}
+	ctx := context.WithValue(context.Background(), RequestIDKey, "req-789")
+	_, err := cfs.Open(ctx, "file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-logged := buf.String()
-if !strings.Contains(logged, "overlayfs operation") {
-t.Error("expected operation log")
-}
-if !strings.Contains(logged, "req-789") {
-t.Error("expected request_id in log")
-}
+	logged := buf.String()
+	if !strings.Contains(logged, "overlayfs operation") {
+		t.Error("expected operation log")
+	}
+	if !strings.Contains(logged, "req-789") {
+		t.Error("expected request_id in log")
+	}
 }
 
 // --- Context key types ---
 
 func TestContextKeys_Distinct(t *testing.T) {
-ctx := context.WithValue(context.Background(), RequestIDKey, "req-abc")
-ctx = context.WithValue(ctx, RemoteAddrKey, "10.0.0.1")
+	ctx := context.WithValue(context.Background(), RequestIDKey, "req-abc")
+	ctx = context.WithValue(ctx, RemoteAddrKey, "10.0.0.1")
 
-if got := contextString(ctx, RequestIDKey); got != "req-abc" {
-t.Errorf("RequestIDKey = %q, want %q", got, "req-abc")
-}
-if got := contextString(ctx, RemoteAddrKey); got != "10.0.0.1" {
-t.Errorf("RemoteAddrKey = %q, want %q", got, "10.0.0.1")
-}
+	if got := contextString(ctx, RequestIDKey); got != "req-abc" {
+		t.Errorf("RequestIDKey = %q, want %q", got, "req-abc")
+	}
+	if got := contextString(ctx, RemoteAddrKey); got != "10.0.0.1" {
+		t.Errorf("RemoteAddrKey = %q, want %q", got, "10.0.0.1")
+	}
 }
 
 func TestContextString_Missing(t *testing.T) {
-if got := contextString(context.Background(), RequestIDKey); got != "" {
-t.Errorf("missing key should return empty string, got %q", got)
-}
+	if got := contextString(context.Background(), RequestIDKey); got != "" {
+		t.Errorf("missing key should return empty string, got %q", got)
+	}
 }
 
 // --- Constructor panics on nil inner ---
 
 func TestNewContextOverlayFS_NilInnerPanics(t *testing.T) {
-defer func() {
-r := recover()
-if r == nil {
-t.Fatal("expected panic for nil inner OverlayFS")
-}
-msg, ok := r.(string)
-if !ok || !strings.Contains(msg, "nil OverlayFS") {
-t.Errorf("unexpected panic value: %v", r)
-}
-}()
-NewContextOverlayFS(nil, nil)
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for nil inner OverlayFS")
+		}
+		msg, ok := r.(string)
+		if !ok || !strings.Contains(msg, "nil OverlayFS") {
+			t.Errorf("unexpected panic value: %v", r)
+		}
+	}()
+	NewContextOverlayFS(nil, nil)
 }
 
 // --- Inner accessor ---
 
 func TestContextInner_ReturnsSameOverlayFS(t *testing.T) {
-inner := NewOverlayFS(fstest.MapFS{}).WithLayerNames([]string{"test"})
-cfs := NewContextOverlayFS(inner, nil)
+	inner := NewOverlayFS(fstest.MapFS{}).WithLayerNames([]string{"test"})
+	cfs := NewContextOverlayFS(inner, nil)
 
-if got := cfs.Inner(); got != inner {
-t.Errorf("Inner() returned different pointer")
-}
+	if got := cfs.Inner(); got != inner {
+		t.Errorf("Inner() returned different pointer")
+	}
 }
 
 // --- Permission error propagates (does not fall through) ---
 
 func TestContextOpen_PermissionError(t *testing.T) {
-permFS := &errFS{err: fs.ErrPermission}
-defaults := fstest.MapFS{"file.txt": {Data: []byte("default")}}
-cfs := newTestContextOverlay(nil, permFS, defaults)
+	permFS := &errFS{err: fs.ErrPermission}
+	defaults := fstest.MapFS{"file.txt": {Data: []byte("default")}}
+	cfs := newTestContextOverlay(nil, permFS, defaults)
 
-_, err := cfs.Open(context.Background(), "file.txt")
-if err == nil {
-t.Fatal("expected permission error")
-}
-if !errors.Is(err, fs.ErrPermission) {
-t.Errorf("expected fs.ErrPermission, got %v", err)
-}
+	_, err := cfs.Open(context.Background(), "file.txt")
+	if err == nil {
+		t.Fatal("expected permission error")
+	}
+	if !errors.Is(err, fs.ErrPermission) {
+		t.Errorf("expected fs.ErrPermission, got %v", err)
+	}
 }
 
 // --- Resolution type tests ---
 
 func TestResolve_CorrectLayerNameAndIndex(t *testing.T) {
-theme := fstest.MapFS{"style.css": {Data: []byte("theme-css")}}
-content := fstest.MapFS{"posts/hello.md": {Data: []byte("# Hello")}}
-config := fstest.MapFS{}
-defaults := fstest.MapFS{
-"style.css":      {Data: []byte("default-css")},
-"posts/hello.md": {Data: []byte("# Default Hello")},
-"base.html":      {Data: []byte("<html>")},
-}
+	theme := fstest.MapFS{"style.css": {Data: []byte("theme-css")}}
+	content := fstest.MapFS{"posts/hello.md": {Data: []byte("# Hello")}}
+	config := fstest.MapFS{}
+	defaults := fstest.MapFS{
+		"style.css":      {Data: []byte("default-css")},
+		"posts/hello.md": {Data: []byte("# Default Hello")},
+		"base.html":      {Data: []byte("<html>")},
+	}
 
-ofs := newTestOverlay(theme, content, config, defaults)
+	ofs := newTestOverlay(theme, content, config, defaults)
 
-tests := []struct {
-name      string
-path      string
-wantIndex int
-wantLayer string
-}{
-{"top layer", "style.css", 0, "theme"},
-{"middle layer", "posts/hello.md", 1, "content"},
-{"bottom layer", "base.html", 3, "defaults"},
-}
+	tests := []struct {
+		name      string
+		path      string
+		wantIndex int
+		wantLayer string
+	}{
+		{"top layer", "style.css", 0, "theme"},
+		{"middle layer", "posts/hello.md", 1, "content"},
+		{"bottom layer", "base.html", 3, "defaults"},
+	}
 
-for _, tc := range tests {
-t.Run(tc.name, func(t *testing.T) {
-res, err := ofs.Resolve(tc.path)
-if err != nil {
-t.Fatalf("Resolve(%q) error: %v", tc.path, err)
-}
-if res.LayerIndex != tc.wantIndex {
-t.Errorf("LayerIndex = %d, want %d", res.LayerIndex, tc.wantIndex)
-}
-if res.LayerName != tc.wantLayer {
-t.Errorf("LayerName = %q, want %q", res.LayerName, tc.wantLayer)
-}
-if res.Path != tc.path {
-t.Errorf("Path = %q, want %q", res.Path, tc.path)
-}
-})
-}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := ofs.Resolve(tc.path)
+			if err != nil {
+				t.Fatalf("Resolve(%q) error: %v", tc.path, err)
+			}
+			if res.LayerIndex != tc.wantIndex {
+				t.Errorf("LayerIndex = %d, want %d", res.LayerIndex, tc.wantIndex)
+			}
+			if res.LayerName != tc.wantLayer {
+				t.Errorf("LayerName = %q, want %q", res.LayerName, tc.wantLayer)
+			}
+			if res.Path != tc.path {
+				t.Errorf("Path = %q, want %q", res.Path, tc.path)
+			}
+		})
+	}
 }
 
 func TestResolve_MissingFileReturnsError(t *testing.T) {
-ofs := newTestOverlay(fstest.MapFS{})
-_, err := ofs.Resolve("nonexistent.txt")
-if err == nil {
-t.Fatal("expected error for missing file, got nil")
-}
-if !isNotExist(err) {
-t.Errorf("expected ErrNotExist, got %v", err)
-}
+	ofs := newTestOverlay(fstest.MapFS{})
+	_, err := ofs.Resolve("nonexistent.txt")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+	if !isNotExist(err) {
+		t.Errorf("expected ErrNotExist, got %v", err)
+	}
 }
 
 // --- ResolutionFromContext / ContextWithResolution ---
 
 func TestResolutionFromContext_EmptyContext(t *testing.T) {
-_, ok := ResolutionFromContext(context.Background())
-if ok {
-t.Error("expected false from empty context")
-}
+	_, ok := ResolutionFromContext(context.Background())
+	if ok {
+		t.Error("expected false from empty context")
+	}
 }
 
 func TestContextWithResolution_RoundTrip(t *testing.T) {
-r := Resolution{
-Path:       "style.css",
-LayerIndex: 0,
-LayerName:  "theme",
-}
-ctx := ContextWithResolution(context.Background(), r)
+	r := Resolution{
+		Path:       "style.css",
+		LayerIndex: 0,
+		LayerName:  "theme",
+	}
+	ctx := ContextWithResolution(context.Background(), r)
 
-got, ok := ResolutionFromContext(ctx)
-if !ok {
-t.Fatal("expected Resolution in context")
-}
-if got.Path != r.Path || got.LayerIndex != r.LayerIndex || got.LayerName != r.LayerName {
-t.Errorf("got %+v, want %+v", got, r)
-}
+	got, ok := ResolutionFromContext(ctx)
+	if !ok {
+		t.Fatal("expected Resolution in context")
+	}
+	if got.Path != r.Path || got.LayerIndex != r.LayerIndex || got.LayerName != r.LayerName {
+		t.Errorf("got %+v, want %+v", got, r)
+	}
 }

--- a/internal/overlayfs/context_test.go
+++ b/internal/overlayfs/context_test.go
@@ -1,410 +1,491 @@
 package overlayfs
 
 import (
-	"bytes"
-	"context"
-	"errors"
-	"io"
-	"io/fs"
-	"log/slog"
-	"strings"
-	"testing"
-	"testing/fstest"
+"bytes"
+"context"
+"errors"
+"io"
+"io/fs"
+"log/slog"
+"strings"
+"testing"
+"testing/fstest"
 )
 
 func newTestContextOverlay(logger *slog.Logger, layers ...fs.FS) *ContextOverlayFS {
-	names := make([]string, len(layers))
-	for i := range layers {
-		names[i] = layerName(i)
-	}
-	return NewContextOverlayFS(NewOverlayFS(layers...).WithLayerNames(names), logger)
+names := make([]string, len(layers))
+for i := range layers {
+names[i] = layerName(i)
+}
+return NewContextOverlayFS(NewOverlayFS(layers...).WithLayerNames(names), logger)
 }
 
 // --- Context cancellation aborts resolution ---
 
 func TestContextOpen_Cancelled(t *testing.T) {
-	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
-	cfs := newTestContextOverlay(nil, layer)
+layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+cfs := newTestContextOverlay(nil, layer)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+ctx, cancel := context.WithCancel(context.Background())
+cancel()
 
-	_, err := cfs.Open(ctx, "file.txt")
-	if err == nil {
-		t.Fatal("expected error from cancelled context")
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("expected context.Canceled, got %v", err)
-	}
+_, err := cfs.Open(ctx, "file.txt")
+if err == nil {
+t.Fatal("expected error from cancelled context")
+}
+if !errors.Is(err, context.Canceled) {
+t.Errorf("expected context.Canceled, got %v", err)
+}
 }
 
 func TestContextReadFile_Cancelled(t *testing.T) {
-	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
-	cfs := newTestContextOverlay(nil, layer)
+layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+cfs := newTestContextOverlay(nil, layer)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+ctx, cancel := context.WithCancel(context.Background())
+cancel()
 
-	_, err := cfs.ReadFile(ctx, "file.txt")
-	if err == nil {
-		t.Fatal("expected error from cancelled context")
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("expected context.Canceled, got %v", err)
-	}
+_, err := cfs.ReadFile(ctx, "file.txt")
+if err == nil {
+t.Fatal("expected error from cancelled context")
+}
+if !errors.Is(err, context.Canceled) {
+t.Errorf("expected context.Canceled, got %v", err)
+}
 }
 
 func TestContextReadDir_Cancelled(t *testing.T) {
-	layer := fstest.MapFS{"dir/file.txt": {Data: []byte("data")}}
-	cfs := newTestContextOverlay(nil, layer)
+layer := fstest.MapFS{"dir/file.txt": {Data: []byte("data")}}
+cfs := newTestContextOverlay(nil, layer)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+ctx, cancel := context.WithCancel(context.Background())
+cancel()
 
-	_, err := cfs.ReadDir(ctx, "dir")
-	if err == nil {
-		t.Fatal("expected error from cancelled context")
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("expected context.Canceled, got %v", err)
-	}
+_, err := cfs.ReadDir(ctx, "dir")
+if err == nil {
+t.Fatal("expected error from cancelled context")
+}
+if !errors.Is(err, context.Canceled) {
+t.Errorf("expected context.Canceled, got %v", err)
+}
 }
 
 func TestContextStat_Cancelled(t *testing.T) {
-	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
-	cfs := newTestContextOverlay(nil, layer)
+layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+cfs := newTestContextOverlay(nil, layer)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+ctx, cancel := context.WithCancel(context.Background())
+cancel()
 
-	_, err := cfs.Stat(ctx, "file.txt")
-	if err == nil {
-		t.Fatal("expected error from cancelled context")
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("expected context.Canceled, got %v", err)
-	}
+_, err := cfs.Stat(ctx, "file.txt")
+if err == nil {
+t.Fatal("expected error from cancelled context")
+}
+if !errors.Is(err, context.Canceled) {
+t.Errorf("expected context.Canceled, got %v", err)
+}
 }
 
 func TestContextOpenFile_Cancelled(t *testing.T) {
-	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
-	cfs := newTestContextOverlay(nil, layer)
+layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+cfs := newTestContextOverlay(nil, layer)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+ctx, cancel := context.WithCancel(context.Background())
+cancel()
 
-	_, _, err := cfs.OpenFile(ctx, "file.txt")
-	if err == nil {
-		t.Fatal("expected error from cancelled context")
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("expected context.Canceled, got %v", err)
-	}
+_, _, err := cfs.OpenFile(ctx, "file.txt")
+if err == nil {
+t.Fatal("expected error from cancelled context")
+}
+if !errors.Is(err, context.Canceled) {
+t.Errorf("expected context.Canceled, got %v", err)
+}
 }
 
 // --- Security logging on path traversal ---
 
 func TestContextOpen_PathTraversalLogged(t *testing.T) {
-	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	cfs := newTestContextOverlay(logger, fstest.MapFS{})
+var buf bytes.Buffer
+logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+cfs := newTestContextOverlay(logger, fstest.MapFS{})
 
-	ctx := context.WithValue(context.Background(), RequestIDKey, "req-123")
-	ctx = context.WithValue(ctx, RemoteAddrKey, "192.168.1.100")
+ctx := context.WithValue(context.Background(), RequestIDKey, "req-123")
+ctx = context.WithValue(ctx, RemoteAddrKey, "192.168.1.100")
 
-	_, err := cfs.Open(ctx, "../etc/passwd")
-	if err == nil {
-		t.Fatal("expected error for path traversal")
-	}
+_, err := cfs.Open(ctx, "../etc/passwd")
+if err == nil {
+t.Fatal("expected error for path traversal")
+}
 
-	logged := buf.String()
-	if !strings.Contains(logged, "path traversal attempt") {
-		t.Error("expected 'path traversal attempt' in log")
-	}
-	if !strings.Contains(logged, "req-123") {
-		t.Error("expected request_id in log")
-	}
-	if !strings.Contains(logged, "192.168.1.100") {
-		t.Error("expected remote_addr in log")
-	}
+logged := buf.String()
+if !strings.Contains(logged, "path traversal attempt") {
+t.Error("expected 'path traversal attempt' in log")
+}
+if !strings.Contains(logged, "req-123") {
+t.Error("expected request_id in log")
+}
+if !strings.Contains(logged, "192.168.1.100") {
+t.Error("expected remote_addr in log")
+}
 }
 
 func TestContextReadFile_PathTraversalLogged(t *testing.T) {
-	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	cfs := newTestContextOverlay(logger, fstest.MapFS{})
+var buf bytes.Buffer
+logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+cfs := newTestContextOverlay(logger, fstest.MapFS{})
 
-	ctx := context.WithValue(context.Background(), RequestIDKey, "req-456")
-	_, err := cfs.ReadFile(ctx, "/etc/shadow")
-	if err == nil {
-		t.Fatal("expected error for absolute path")
-	}
-	if !strings.Contains(buf.String(), "path traversal attempt") {
-		t.Error("expected security log")
-	}
+ctx := context.WithValue(context.Background(), RequestIDKey, "req-456")
+_, err := cfs.ReadFile(ctx, "/etc/shadow")
+if err == nil {
+t.Fatal("expected error for absolute path")
+}
+if !strings.Contains(buf.String(), "path traversal attempt") {
+t.Error("expected security log")
+}
 }
 
 func TestContextStat_PathTraversalLogged(t *testing.T) {
-	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	cfs := newTestContextOverlay(logger, fstest.MapFS{})
+var buf bytes.Buffer
+logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+cfs := newTestContextOverlay(logger, fstest.MapFS{})
 
-	_, err := cfs.Stat(context.Background(), "../etc/passwd")
-	if err == nil {
-		t.Fatal("expected error for traversal path")
-	}
-	if !strings.Contains(buf.String(), "path traversal attempt") {
-		t.Error("expected security log")
-	}
+_, err := cfs.Stat(context.Background(), "../etc/passwd")
+if err == nil {
+t.Fatal("expected error for traversal path")
+}
+if !strings.Contains(buf.String(), "path traversal attempt") {
+t.Error("expected security log")
+}
 }
 
 // --- All FS methods work through the wrapper ---
 
 func TestContextOpen_Works(t *testing.T) {
-	theme := fstest.MapFS{"templates/post.html": {Data: []byte("theme-post")}}
-	defaults := fstest.MapFS{"templates/post.html": {Data: []byte("default-post")}}
-	cfs := newTestContextOverlay(nil, theme, defaults)
+theme := fstest.MapFS{"templates/post.html": {Data: []byte("theme-post")}}
+defaults := fstest.MapFS{"templates/post.html": {Data: []byte("default-post")}}
+cfs := newTestContextOverlay(nil, theme, defaults)
 
-	f, err := cfs.Open(context.Background(), "templates/post.html")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = f.Close() }()
+f, err := cfs.Open(context.Background(), "templates/post.html")
+if err != nil {
+t.Fatal(err)
+}
+defer func() { _ = f.Close() }()
 
-	data, err := io.ReadAll(f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != "theme-post" {
-		t.Errorf("got %q, want %q", data, "theme-post")
-	}
+data, err := io.ReadAll(f)
+if err != nil {
+t.Fatal(err)
+}
+if string(data) != "theme-post" {
+t.Errorf("got %q, want %q", data, "theme-post")
+}
 }
 
 func TestContextReadFile_Works(t *testing.T) {
-	layer := fstest.MapFS{"file.txt": {Data: []byte("hello")}}
-	cfs := newTestContextOverlay(nil, layer)
+layer := fstest.MapFS{"file.txt": {Data: []byte("hello")}}
+cfs := newTestContextOverlay(nil, layer)
 
-	data, err := cfs.ReadFile(context.Background(), "file.txt")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != "hello" {
-		t.Errorf("got %q, want %q", data, "hello")
-	}
+data, err := cfs.ReadFile(context.Background(), "file.txt")
+if err != nil {
+t.Fatal(err)
+}
+if string(data) != "hello" {
+t.Errorf("got %q, want %q", data, "hello")
+}
 }
 
 func TestContextReadFile_Fallback(t *testing.T) {
-	theme := fstest.MapFS{}
-	defaults := fstest.MapFS{"base.html": {Data: []byte("default-base")}}
-	cfs := newTestContextOverlay(nil, theme, defaults)
+theme := fstest.MapFS{}
+defaults := fstest.MapFS{"base.html": {Data: []byte("default-base")}}
+cfs := newTestContextOverlay(nil, theme, defaults)
 
-	data, err := cfs.ReadFile(context.Background(), "base.html")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != "default-base" {
-		t.Errorf("got %q, want %q", data, "default-base")
-	}
+data, err := cfs.ReadFile(context.Background(), "base.html")
+if err != nil {
+t.Fatal(err)
+}
+if string(data) != "default-base" {
+t.Errorf("got %q, want %q", data, "default-base")
+}
 }
 
 func TestContextReadDir_Works(t *testing.T) {
-	theme := fstest.MapFS{
-		"templates/a.html": {Data: []byte("a")},
-	}
-	defaults := fstest.MapFS{
-		"templates/b.html": {Data: []byte("b")},
-	}
-	cfs := newTestContextOverlay(nil, theme, defaults)
+theme := fstest.MapFS{
+"templates/a.html": {Data: []byte("a")},
+}
+defaults := fstest.MapFS{
+"templates/b.html": {Data: []byte("b")},
+}
+cfs := newTestContextOverlay(nil, theme, defaults)
 
-	entries, err := cfs.ReadDir(context.Background(), "templates")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(entries) != 2 {
-		t.Fatalf("got %d entries, want 2", len(entries))
-	}
-	if entries[0].Name() != "a.html" || entries[1].Name() != "b.html" {
-		t.Errorf("got [%s, %s], want [a.html, b.html]", entries[0].Name(), entries[1].Name())
-	}
+entries, err := cfs.ReadDir(context.Background(), "templates")
+if err != nil {
+t.Fatal(err)
+}
+if len(entries) != 2 {
+t.Fatalf("got %d entries, want 2", len(entries))
+}
+if entries[0].Name() != "a.html" || entries[1].Name() != "b.html" {
+t.Errorf("got [%s, %s], want [a.html, b.html]", entries[0].Name(), entries[1].Name())
+}
 }
 
 func TestContextStat_Works(t *testing.T) {
-	layer := fstest.MapFS{"file.txt": {Data: []byte("hello world")}}
-	cfs := newTestContextOverlay(nil, layer)
+layer := fstest.MapFS{"file.txt": {Data: []byte("hello world")}}
+cfs := newTestContextOverlay(nil, layer)
 
-	info, err := cfs.Stat(context.Background(), "file.txt")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Name() != "file.txt" {
-		t.Errorf("Name = %q, want %q", info.Name(), "file.txt")
-	}
-	if info.Size() != 11 {
-		t.Errorf("Size = %d, want 11", info.Size())
-	}
+info, err := cfs.Stat(context.Background(), "file.txt")
+if err != nil {
+t.Fatal(err)
+}
+if info.Name() != "file.txt" {
+t.Errorf("Name = %q, want %q", info.Name(), "file.txt")
+}
+if info.Size() != 11 {
+t.Errorf("Size = %d, want 11", info.Size())
+}
 }
 
 func TestContextOpenFile_Works(t *testing.T) {
-	layer := fstest.MapFS{"file.txt": {Data: []byte("hello world")}}
-	cfs := newTestContextOverlay(nil, layer)
+layer := fstest.MapFS{"file.txt": {Data: []byte("hello world")}}
+cfs := newTestContextOverlay(nil, layer)
 
-	f, info, err := cfs.OpenFile(context.Background(), "file.txt")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = f.Close() }()
+f, info, err := cfs.OpenFile(context.Background(), "file.txt")
+if err != nil {
+t.Fatal(err)
+}
+defer func() { _ = f.Close() }()
 
-	if info.Name() != "file.txt" {
-		t.Errorf("Name = %q, want %q", info.Name(), "file.txt")
-	}
-	if info.Size() != 11 {
-		t.Errorf("Size = %d, want 11", info.Size())
-	}
+if info.Name() != "file.txt" {
+t.Errorf("Name = %q, want %q", info.Name(), "file.txt")
+}
+if info.Size() != 11 {
+t.Errorf("Size = %d, want 11", info.Size())
+}
 }
 
 func TestContextOpen_NotFound(t *testing.T) {
-	cfs := newTestContextOverlay(nil, fstest.MapFS{})
+cfs := newTestContextOverlay(nil, fstest.MapFS{})
 
-	_, err := cfs.Open(context.Background(), "nope.txt")
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	if !errors.Is(err, fs.ErrNotExist) {
-		t.Errorf("expected ErrNotExist, got %v", err)
-	}
+_, err := cfs.Open(context.Background(), "nope.txt")
+if err == nil {
+t.Fatal("expected error")
+}
+if !errors.Is(err, fs.ErrNotExist) {
+t.Errorf("expected ErrNotExist, got %v", err)
+}
 }
 
 // --- Nil logger is safe ---
 
 func TestContextOpen_NilLogger(t *testing.T) {
-	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
-	cfs := NewContextOverlayFS(NewOverlayFS(layer).WithLayerNames([]string{"test"}), nil)
+layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+cfs := NewContextOverlayFS(NewOverlayFS(layer).WithLayerNames([]string{"test"}), nil)
 
-	f, err := cfs.Open(context.Background(), "file.txt")
-	if err != nil {
-		t.Fatal(err)
-	}
-	_ = f.Close()
+f, err := cfs.Open(context.Background(), "file.txt")
+if err != nil {
+t.Fatal(err)
+}
+_ = f.Close()
 }
 
 func TestContextOpen_NilLoggerPathTraversal(t *testing.T) {
-	cfs := NewContextOverlayFS(NewOverlayFS(fstest.MapFS{}).WithLayerNames([]string{"test"}), nil)
+cfs := NewContextOverlayFS(NewOverlayFS(fstest.MapFS{}).WithLayerNames([]string{"test"}), nil)
 
-	_, err := cfs.Open(context.Background(), "../etc/passwd")
-	if err == nil {
-		t.Fatal("expected error for path traversal")
-	}
+_, err := cfs.Open(context.Background(), "../etc/passwd")
+if err == nil {
+t.Fatal("expected error for path traversal")
+}
 }
 
 // --- Delegation methods ---
 
 func TestContextInvalidateLayer(t *testing.T) {
-	theme := fstest.MapFS{}
-	defaults := fstest.MapFS{"file.txt": {Data: []byte("default")}}
-	cfs := newTestContextOverlay(nil, theme, defaults)
+theme := fstest.MapFS{}
+defaults := fstest.MapFS{"file.txt": {Data: []byte("default")}}
+cfs := newTestContextOverlay(nil, theme, defaults)
 
-	// Warm the negative cache
-	_, _ = cfs.ReadFile(context.Background(), "file.txt")
+// Warm the negative cache
+_, _ = cfs.ReadFile(context.Background(), "file.txt")
 
-	// Replace and invalidate
-	newTheme := fstest.MapFS{"file.txt": {Data: []byte("theme")}}
-	_ = cfs.ReplaceLayer(0, newTheme)
+// Replace and invalidate
+newTheme := fstest.MapFS{"file.txt": {Data: []byte("theme")}}
+_ = cfs.ReplaceLayer(0, newTheme)
 
-	data, _ := cfs.ReadFile(context.Background(), "file.txt")
-	if string(data) != "theme" {
-		t.Errorf("got %q, want %q", data, "theme")
-	}
+data, _ := cfs.ReadFile(context.Background(), "file.txt")
+if string(data) != "theme" {
+t.Errorf("got %q, want %q", data, "theme")
+}
 }
 
 func TestContextInvalidateAll(t *testing.T) {
-	cfs := newTestContextOverlay(nil, fstest.MapFS{"file.txt": {Data: []byte("v1")}})
+cfs := newTestContextOverlay(nil, fstest.MapFS{"file.txt": {Data: []byte("v1")}})
 
-	_, _ = cfs.ReadFile(context.Background(), "file.txt")
-	cfs.InvalidateAll() // should not panic
+_, _ = cfs.ReadFile(context.Background(), "file.txt")
+cfs.InvalidateAll() // should not panic
 }
 
 // --- Logging with context values ---
 
 func TestContextOpen_LogsOperation(t *testing.T) {
-	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
-	cfs := newTestContextOverlay(logger, layer)
+var buf bytes.Buffer
+logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+cfs := newTestContextOverlay(logger, layer)
 
-	ctx := context.WithValue(context.Background(), RequestIDKey, "req-789")
-	_, err := cfs.Open(ctx, "file.txt")
-	if err != nil {
-		t.Fatal(err)
-	}
+ctx := context.WithValue(context.Background(), RequestIDKey, "req-789")
+_, err := cfs.Open(ctx, "file.txt")
+if err != nil {
+t.Fatal(err)
+}
 
-	logged := buf.String()
-	if !strings.Contains(logged, "overlayfs operation") {
-		t.Error("expected operation log")
-	}
-	if !strings.Contains(logged, "req-789") {
-		t.Error("expected request_id in log")
-	}
+logged := buf.String()
+if !strings.Contains(logged, "overlayfs operation") {
+t.Error("expected operation log")
+}
+if !strings.Contains(logged, "req-789") {
+t.Error("expected request_id in log")
+}
 }
 
 // --- Context key types ---
 
 func TestContextKeys_Distinct(t *testing.T) {
-	ctx := context.WithValue(context.Background(), RequestIDKey, "req-abc")
-	ctx = context.WithValue(ctx, RemoteAddrKey, "10.0.0.1")
+ctx := context.WithValue(context.Background(), RequestIDKey, "req-abc")
+ctx = context.WithValue(ctx, RemoteAddrKey, "10.0.0.1")
 
-	if got := contextString(ctx, RequestIDKey); got != "req-abc" {
-		t.Errorf("RequestIDKey = %q, want %q", got, "req-abc")
-	}
-	if got := contextString(ctx, RemoteAddrKey); got != "10.0.0.1" {
-		t.Errorf("RemoteAddrKey = %q, want %q", got, "10.0.0.1")
-	}
+if got := contextString(ctx, RequestIDKey); got != "req-abc" {
+t.Errorf("RequestIDKey = %q, want %q", got, "req-abc")
+}
+if got := contextString(ctx, RemoteAddrKey); got != "10.0.0.1" {
+t.Errorf("RemoteAddrKey = %q, want %q", got, "10.0.0.1")
+}
 }
 
 func TestContextString_Missing(t *testing.T) {
-	if got := contextString(context.Background(), RequestIDKey); got != "" {
-		t.Errorf("missing key should return empty string, got %q", got)
-	}
+if got := contextString(context.Background(), RequestIDKey); got != "" {
+t.Errorf("missing key should return empty string, got %q", got)
+}
 }
 
 // --- Constructor panics on nil inner ---
 
 func TestNewContextOverlayFS_NilInnerPanics(t *testing.T) {
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("expected panic for nil inner OverlayFS")
-		}
-		msg, ok := r.(string)
-		if !ok || !strings.Contains(msg, "nil OverlayFS") {
-			t.Errorf("unexpected panic value: %v", r)
-		}
-	}()
-	NewContextOverlayFS(nil, nil)
+defer func() {
+r := recover()
+if r == nil {
+t.Fatal("expected panic for nil inner OverlayFS")
+}
+msg, ok := r.(string)
+if !ok || !strings.Contains(msg, "nil OverlayFS") {
+t.Errorf("unexpected panic value: %v", r)
+}
+}()
+NewContextOverlayFS(nil, nil)
 }
 
 // --- Inner accessor ---
 
 func TestContextInner_ReturnsSameOverlayFS(t *testing.T) {
-	inner := NewOverlayFS(fstest.MapFS{}).WithLayerNames([]string{"test"})
-	cfs := NewContextOverlayFS(inner, nil)
+inner := NewOverlayFS(fstest.MapFS{}).WithLayerNames([]string{"test"})
+cfs := NewContextOverlayFS(inner, nil)
 
-	if got := cfs.Inner(); got != inner {
-		t.Errorf("Inner() returned different pointer")
-	}
+if got := cfs.Inner(); got != inner {
+t.Errorf("Inner() returned different pointer")
+}
 }
 
 // --- Permission error propagates (does not fall through) ---
 
 func TestContextOpen_PermissionError(t *testing.T) {
-	permFS := &errFS{err: fs.ErrPermission}
-	defaults := fstest.MapFS{"file.txt": {Data: []byte("default")}}
-	cfs := newTestContextOverlay(nil, permFS, defaults)
+permFS := &errFS{err: fs.ErrPermission}
+defaults := fstest.MapFS{"file.txt": {Data: []byte("default")}}
+cfs := newTestContextOverlay(nil, permFS, defaults)
 
-	_, err := cfs.Open(context.Background(), "file.txt")
-	if err == nil {
-		t.Fatal("expected permission error")
-	}
-	if !errors.Is(err, fs.ErrPermission) {
-		t.Errorf("expected fs.ErrPermission, got %v", err)
-	}
+_, err := cfs.Open(context.Background(), "file.txt")
+if err == nil {
+t.Fatal("expected permission error")
+}
+if !errors.Is(err, fs.ErrPermission) {
+t.Errorf("expected fs.ErrPermission, got %v", err)
+}
+}
+
+// --- Resolution type tests ---
+
+func TestResolve_CorrectLayerNameAndIndex(t *testing.T) {
+theme := fstest.MapFS{"style.css": {Data: []byte("theme-css")}}
+content := fstest.MapFS{"posts/hello.md": {Data: []byte("# Hello")}}
+config := fstest.MapFS{}
+defaults := fstest.MapFS{
+"style.css":      {Data: []byte("default-css")},
+"posts/hello.md": {Data: []byte("# Default Hello")},
+"base.html":      {Data: []byte("<html>")},
+}
+
+ofs := newTestOverlay(theme, content, config, defaults)
+
+tests := []struct {
+name      string
+path      string
+wantIndex int
+wantLayer string
+}{
+{"top layer", "style.css", 0, "theme"},
+{"middle layer", "posts/hello.md", 1, "content"},
+{"bottom layer", "base.html", 3, "defaults"},
+}
+
+for _, tc := range tests {
+t.Run(tc.name, func(t *testing.T) {
+res, err := ofs.Resolve(tc.path)
+if err != nil {
+t.Fatalf("Resolve(%q) error: %v", tc.path, err)
+}
+if res.LayerIndex != tc.wantIndex {
+t.Errorf("LayerIndex = %d, want %d", res.LayerIndex, tc.wantIndex)
+}
+if res.LayerName != tc.wantLayer {
+t.Errorf("LayerName = %q, want %q", res.LayerName, tc.wantLayer)
+}
+if res.Path != tc.path {
+t.Errorf("Path = %q, want %q", res.Path, tc.path)
+}
+})
+}
+}
+
+func TestResolve_MissingFileReturnsError(t *testing.T) {
+ofs := newTestOverlay(fstest.MapFS{})
+_, err := ofs.Resolve("nonexistent.txt")
+if err == nil {
+t.Fatal("expected error for missing file, got nil")
+}
+if !isNotExist(err) {
+t.Errorf("expected ErrNotExist, got %v", err)
+}
+}
+
+// --- ResolutionFromContext / ContextWithResolution ---
+
+func TestResolutionFromContext_EmptyContext(t *testing.T) {
+_, ok := ResolutionFromContext(context.Background())
+if ok {
+t.Error("expected false from empty context")
+}
+}
+
+func TestContextWithResolution_RoundTrip(t *testing.T) {
+r := Resolution{
+Path:       "style.css",
+LayerIndex: 0,
+LayerName:  "theme",
+}
+ctx := ContextWithResolution(context.Background(), r)
+
+got, ok := ResolutionFromContext(ctx)
+if !ok {
+t.Fatal("expected Resolution in context")
+}
+if got.Path != r.Path || got.LayerIndex != r.LayerIndex || got.LayerName != r.LayerName {
+t.Errorf("got %+v, want %+v", got, r)
+}
 }

--- a/internal/overlayfs/overlayfs.go
+++ b/internal/overlayfs/overlayfs.go
@@ -73,13 +73,13 @@ type negCacheEntry struct {
 // server-side observability only (structured logging, OpenTelemetry spans).
 type Resolution struct {
 	// Path is the fs.FS-clean path that was resolved.
-	Path string
+	Path string `json:"-"`
 
 	// LayerIndex is the zero-based index of the layer that served the file.
-	LayerIndex int
+	LayerIndex int `json:"-"`
 
 	// LayerName is the human-readable name of the layer (e.g. "theme", "defaults").
-	LayerName string
+	LayerName string `json:"-"`
 }
 
 // NewOverlayFS creates a new overlay with the given layers.

--- a/internal/overlayfs/overlayfs.go
+++ b/internal/overlayfs/overlayfs.go
@@ -65,11 +65,21 @@ type negCacheEntry struct {
 	firstCandidateLayer int
 }
 
-// resolution describes which layer served a file.
-type resolution struct {
-	Path       string
+// Resolution describes which layer served a file.
+//
+// Security: Resolution contains internal filesystem topology information.
+// It MUST NOT be included in HTTP responses, error messages shown to end
+// users, or any other externally visible output. It is intended for
+// server-side observability only (structured logging, OpenTelemetry spans).
+type Resolution struct {
+	// Path is the fs.FS-clean path that was resolved.
+	Path string
+
+	// LayerIndex is the zero-based index of the layer that served the file.
 	LayerIndex int
-	LayerName  string
+
+	// LayerName is the human-readable name of the layer (e.g. "theme", "defaults").
+	LayerName string
 }
 
 // NewOverlayFS creates a new overlay with the given layers.
@@ -591,10 +601,21 @@ func (o *OverlayFS) LayerCount() int {
 	return len(o.layers)
 }
 
+// Resolve returns metadata about which layer would serve the given path.
+//
+// Security: the returned Resolution MUST NOT appear in HTTP responses.
+// It is intended for server-side observability (logging, OTel spans).
+func (o *OverlayFS) Resolve(name string) (Resolution, error) {
+	r, err := o.resolveInfo(name)
+	if err != nil {
+		return Resolution{}, err
+	}
+	return *r, nil
+}
+
 // resolveInfo returns metadata about where a path resolves to.
 // Internal only — must NOT appear in HTTP responses.
-func (o *OverlayFS) resolveInfo(name string) (*resolution, error) {
-	// TODO(security): ContextOverlayFS will log WARN with request_id and remote_addr
+func (o *OverlayFS) resolveInfo(name string) (*Resolution, error) {
 	if !fs.ValidPath(name) {
 		return nil, &fs.PathError{Op: "resolve", Path: name, Err: fs.ErrInvalid}
 	}
@@ -621,7 +642,7 @@ func (o *OverlayFS) resolveInfo(name string) (*resolution, error) {
 			if i < len(names) {
 				layerName = names[i]
 			}
-			return &resolution{
+			return &Resolution{
 				Path:       name,
 				LayerIndex: i,
 				LayerName:  layerName,

--- a/internal/overlayfs/overlayfs.go
+++ b/internal/overlayfs/overlayfs.go
@@ -197,7 +197,6 @@ func NewFromEmbed(defaults embed.FS, prefix string) (*OverlayFS, error) {
 // Only fs.ErrNotExist triggers fallthrough; other errors (EACCES, EIO)
 // are returned immediately.
 func (o *OverlayFS) Open(name string) (fs.File, error) {
-	// TODO(security): ContextOverlayFS will log WARN with request_id and remote_addr
 	if !fs.ValidPath(name) {
 		if o.metrics != nil {
 			o.metrics.pathRejected.WithLabelValues(classifyInvalidPath(name)).Inc()
@@ -268,7 +267,6 @@ func (o *OverlayFS) Open(name string) (fs.File, error) {
 // ReadFile implements fs.ReadFileFS. Reads the entire file from the
 // highest-priority layer that contains it.
 func (o *OverlayFS) ReadFile(name string) ([]byte, error) {
-	// TODO(security): ContextOverlayFS will log WARN with request_id and remote_addr
 	if !fs.ValidPath(name) {
 		if o.metrics != nil {
 			o.metrics.pathRejected.WithLabelValues(classifyInvalidPath(name)).Inc()
@@ -378,7 +376,6 @@ func (o *OverlayFS) ReadFile(name string) ([]byte, error) {
 // entries across all layers. For duplicate names, the entry from the
 // highest-priority layer wins. Entries are sorted by name.
 func (o *OverlayFS) ReadDir(name string) ([]fs.DirEntry, error) {
-	// TODO(security): ContextOverlayFS will log WARN with request_id and remote_addr
 	if !fs.ValidPath(name) {
 		if o.metrics != nil {
 			o.metrics.pathRejected.WithLabelValues(classifyInvalidPath(name)).Inc()
@@ -438,7 +435,6 @@ func (o *OverlayFS) ReadDir(name string) ([]fs.DirEntry, error) {
 // Stat implements fs.StatFS. Returns file info from the highest-priority
 // layer that contains the path.
 func (o *OverlayFS) Stat(name string) (fs.FileInfo, error) {
-	// TODO(security): ContextOverlayFS will log WARN with request_id and remote_addr
 	if !fs.ValidPath(name) {
 		if o.metrics != nil {
 			o.metrics.pathRejected.WithLabelValues(classifyInvalidPath(name)).Inc()


### PR DESCRIPTION
## Summary

Export the `Resolution` struct so consumers (and future OTel integration) can inspect which layer resolved a file.

### Changes

- **Export `Resolution` type** with `Path`, `LayerIndex`, `LayerName` fields and GoDoc security warning (must not appear in HTTP responses)
- **Add `Resolve(name)` method** on `OverlayFS` — public API returning `Resolution` for a given path
- **Add `ContextOverlayFS`** wrapper that stores `Resolution` in `context.Context` after successful `Open`/`ReadFile`/`Stat` operations
- **Add `ResolutionFromContext`** helper to extract `Resolution` from context
- **Add tests** for Resolve correctness, context propagation via ContextOverlayFS, missing-file errors, and interface compliance

### Security

`Resolution` contains internal filesystem topology. GoDoc on the type and on `Resolve()` explicitly warns it **must not** appear in HTTP responses.

Fixes #8