### PR TITLE
feat: support _FILE suffix convention for secret env vars

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/khaines/blogflow/internal/envfile"
 	"gopkg.in/yaml.v3"
 )
 
@@ -157,7 +158,7 @@ func (l *Loader) Load() (*Config, error) {
 		l.logger.Debug("no config file found, using defaults")
 	}
 
-	applied, envErr := applyEnvOverrides(cfg)
+	applied, envErr := applyEnvOverrides(cfg, l.logger)
 	if envErr != nil {
 		return nil, fmt.Errorf("applying environment overrides: %w", envErr)
 	}
@@ -403,10 +404,27 @@ var secretEnvVars = map[string]bool{
 	"BLOGFLOW_WEBHOOK_SECRET": true,
 }
 
-func applyEnvOverrides(cfg *Config) ([]string, error) {
+func applyEnvOverrides(cfg *Config, logger ...*slog.Logger) ([]string, error) {
+	var log *slog.Logger
+	if len(logger) > 0 {
+		log = logger[0]
+	}
+
 	var applied []string
 	for name, setter := range envMap {
-		v, ok := os.LookupEnv(name)
+		var v string
+		var ok bool
+
+		if secretEnvVars[name] {
+			var err error
+			v, ok, err = envfile.ReadEnvOrFile(name, log)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			v, ok = os.LookupEnv(name)
+		}
+
 		if !ok {
 			continue
 		}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -404,12 +404,7 @@ var secretEnvVars = map[string]bool{
 	"BLOGFLOW_WEBHOOK_SECRET": true,
 }
 
-func applyEnvOverrides(cfg *Config, logger ...*slog.Logger) ([]string, error) {
-	var log *slog.Logger
-	if len(logger) > 0 {
-		log = logger[0]
-	}
-
+func applyEnvOverrides(cfg *Config, log *slog.Logger) ([]string, error) {
 	var applied []string
 	for name, setter := range envMap {
 		var v string

--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -6,10 +6,15 @@ package envfile
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"strings"
 )
+
+// maxSecretSize caps secret file reads at 1 MiB to prevent OOM from
+// misconfigured paths (e.g. pointing at a device or huge file).
+const maxSecretSize = 1 << 20
 
 // ReadEnvOrFile returns the value for the given env var key, supporting the
 // _FILE suffix convention:
@@ -33,11 +38,11 @@ func ReadEnvOrFile(key string, logger *slog.Logger) (string, bool, error) {
 			logger.Warn("both env var and _FILE variant set; using _FILE",
 				"key", key, "file_key", fileKey)
 		}
-		data, err := os.ReadFile(filePath) //nolint:gosec // G304: reading secret from user-specified path is the core purpose of this function
+		val, err := readSecretFile(filePath, logger)
 		if err != nil {
 			return "", false, fmt.Errorf("reading %s=%q: %w", fileKey, filePath, err)
 		}
-		return strings.TrimSpace(string(data)), true, nil
+		return strings.TrimSpace(val), true, nil
 	}
 
 	if plainSet && plainVal != "" {
@@ -45,4 +50,44 @@ func ReadEnvOrFile(key string, logger *slog.Logger) (string, bool, error) {
 	}
 
 	return "", false, nil
+}
+
+// readSecretFile opens path, validates it is a regular file within the size
+// limit, warns on overly permissive permissions, and returns the contents.
+// It uses Fstat on the opened fd to avoid TOCTOU races.
+func readSecretFile(path string, logger *slog.Logger) (string, error) {
+	f, err := os.Open(path) //nolint:gosec // G304: path is from operator-controlled env var; this is the core purpose
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return "", err
+	}
+
+	if !fi.Mode().IsRegular() {
+		return "", fmt.Errorf("not a regular file (mode: %s)", fi.Mode().Type())
+	}
+
+	if fi.Mode().Perm()&0o004 != 0 {
+		logger.Warn("secret file is world-readable; consider chmod 0600",
+			"path", path, "mode", fmt.Sprintf("%04o", fi.Mode().Perm()))
+	}
+
+	if fi.Size() > maxSecretSize {
+		return "", fmt.Errorf("file too large (%d bytes, max %d)", fi.Size(), maxSecretSize)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(f, maxSecretSize+1))
+	if err != nil {
+		return "", err
+	}
+
+	if int64(len(data)) > maxSecretSize {
+		return "", fmt.Errorf("file too large (read %d bytes, max %d)", len(data), maxSecretSize)
+	}
+
+	return string(data), nil
 }

--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -1,0 +1,48 @@
+// Package envfile supports the Docker/K8s _FILE suffix convention for secrets.
+//
+// When FOO_FILE=/path/to/secret is set, the value is read from the file
+// instead of the FOO env var. This keeps secrets out of /proc/pid/environ.
+package envfile
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// ReadEnvOrFile returns the value for the given env var key, supporting the
+// _FILE suffix convention:
+//
+//  1. If key+"_FILE" is set, read the file and return its trimmed contents.
+//  2. Otherwise, fall back to the plain key env var.
+//  3. If both are set, _FILE wins and a warning is logged.
+//
+// Returns ("", false) if neither is set.
+func ReadEnvOrFile(key string, logger *slog.Logger) (string, bool, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	fileKey := key + "_FILE"
+	filePath, fileSet := os.LookupEnv(fileKey)
+	plainVal, plainSet := os.LookupEnv(key)
+
+	if fileSet && filePath != "" {
+		if plainSet && plainVal != "" {
+			logger.Warn("both env var and _FILE variant set; using _FILE",
+				"key", key, "file_key", fileKey)
+		}
+		data, err := os.ReadFile(filePath) //nolint:gosec // G304: reading secret from user-specified path is the core purpose of this function
+		if err != nil {
+			return "", false, fmt.Errorf("reading %s=%q: %w", fileKey, filePath, err)
+		}
+		return strings.TrimSpace(string(data)), true, nil
+	}
+
+	if plainSet && plainVal != "" {
+		return plainVal, true, nil
+	}
+
+	return "", false, nil
+}

--- a/internal/envfile/envfile_test.go
+++ b/internal/envfile/envfile_test.go
@@ -1,0 +1,127 @@
+package envfile
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadEnvOrFile_FileExists(t *testing.T) {
+	tmp := t.TempDir()
+	secretFile := filepath.Join(tmp, "secret.txt")
+	if err := os.WriteFile(secretFile, []byte("  file-secret-value\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("TEST_SECRET_FILE", secretFile)
+	t.Setenv("TEST_SECRET", "")
+
+	val, ok, err := ReadEnvOrFile("TEST_SECRET", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if val != "file-secret-value" {
+		t.Fatalf("got %q, want %q", val, "file-secret-value")
+	}
+}
+
+func TestReadEnvOrFile_FileMissing_FallsBackToEnv(t *testing.T) {
+	t.Setenv("TEST_SECRET_FILE", "")
+	t.Setenv("TEST_SECRET", "env-value")
+
+	val, ok, err := ReadEnvOrFile("TEST_SECRET", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if val != "env-value" {
+		t.Fatalf("got %q, want %q", val, "env-value")
+	}
+}
+
+func TestReadEnvOrFile_BothSet_FileWins_Warning(t *testing.T) {
+	tmp := t.TempDir()
+	secretFile := filepath.Join(tmp, "secret.txt")
+	if err := os.WriteFile(secretFile, []byte("from-file"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("TEST_SECRET_FILE", secretFile)
+	t.Setenv("TEST_SECRET", "from-env")
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	val, ok, err := ReadEnvOrFile("TEST_SECRET", logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if val != "from-file" {
+		t.Fatalf("got %q, want %q (file should take precedence)", val, "from-file")
+	}
+	if !strings.Contains(buf.String(), "both env var and _FILE variant set") {
+		t.Fatalf("expected warning log, got: %s", buf.String())
+	}
+}
+
+func TestReadEnvOrFile_NeitherSet(t *testing.T) {
+	t.Setenv("TEST_SECRET_FILE", "")
+	t.Setenv("TEST_SECRET", "")
+
+	val, ok, err := ReadEnvOrFile("TEST_SECRET", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false when neither is set")
+	}
+	if val != "" {
+		t.Fatalf("expected empty string, got %q", val)
+	}
+}
+
+func TestReadEnvOrFile_FileNotReadable(t *testing.T) {
+	t.Setenv("TEST_SECRET_FILE", "/nonexistent/path/secret.txt")
+	t.Setenv("TEST_SECRET", "")
+
+	_, _, err := ReadEnvOrFile("TEST_SECRET", nil)
+	if err == nil {
+		t.Fatal("expected error when _FILE points to nonexistent file")
+	}
+	if !strings.Contains(err.Error(), "TEST_SECRET_FILE") {
+		t.Fatalf("error should mention the env var, got: %v", err)
+	}
+}
+
+func TestReadEnvOrFile_EmptyFile(t *testing.T) {
+	tmp := t.TempDir()
+	secretFile := filepath.Join(tmp, "empty.txt")
+	if err := os.WriteFile(secretFile, []byte("   \n  "), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("TEST_SECRET_FILE", secretFile)
+	t.Setenv("TEST_SECRET", "")
+
+	val, ok, err := ReadEnvOrFile("TEST_SECRET", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true (file exists)")
+	}
+	if val != "" {
+		t.Fatalf("expected empty string after trimming, got %q", val)
+	}
+}

--- a/internal/envfile/envfile_test.go
+++ b/internal/envfile/envfile_test.go
@@ -125,3 +125,111 @@ func TestReadEnvOrFile_EmptyFile(t *testing.T) {
 		t.Fatalf("expected empty string after trimming, got %q", val)
 	}
 }
+
+func TestReadEnvOrFile_RejectsDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("TEST_SECRET_FILE", tmp)
+	t.Setenv("TEST_SECRET", "")
+
+	_, _, err := ReadEnvOrFile("TEST_SECRET", nil)
+	if err == nil {
+		t.Fatal("expected error for directory path")
+	}
+	if !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("expected 'not a regular file' error, got: %v", err)
+	}
+}
+
+func TestReadEnvOrFile_WorldReadableWarning(t *testing.T) {
+	tmp := t.TempDir()
+	secretFile := filepath.Join(tmp, "world-readable.txt")
+	if err := os.WriteFile(secretFile, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(secretFile, 0o644); err != nil { //nolint:gosec // intentionally world-readable for test
+		t.Fatal(err)
+	}
+
+	t.Setenv("TEST_SECRET_FILE", secretFile)
+	t.Setenv("TEST_SECRET", "")
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	val, ok, err := ReadEnvOrFile("TEST_SECRET", logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok || val != "secret" {
+		t.Fatalf("expected ok=true, val=%q; got ok=%v, val=%q", "secret", ok, val)
+	}
+	if !strings.Contains(buf.String(), "world-readable") {
+		t.Fatalf("expected world-readable warning, got: %s", buf.String())
+	}
+}
+
+func TestReadEnvOrFile_RestrictedPermsNoWarning(t *testing.T) {
+	tmp := t.TempDir()
+	secretFile := filepath.Join(tmp, "restricted.txt")
+	if err := os.WriteFile(secretFile, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("TEST_SECRET_FILE", secretFile)
+	t.Setenv("TEST_SECRET", "")
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	_, _, err := ReadEnvOrFile("TEST_SECRET", logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(buf.String(), "world-readable") {
+		t.Fatalf("should not warn for 0600 file, got: %s", buf.String())
+	}
+}
+
+func TestReadEnvOrFile_FileTooLarge(t *testing.T) {
+	tmp := t.TempDir()
+	secretFile := filepath.Join(tmp, "huge.txt")
+	// Write maxSecretSize + 1 byte
+	data := make([]byte, maxSecretSize+1)
+	if err := os.WriteFile(secretFile, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("TEST_SECRET_FILE", secretFile)
+	t.Setenv("TEST_SECRET", "")
+
+	_, _, err := ReadEnvOrFile("TEST_SECRET", nil)
+	if err == nil {
+		t.Fatal("expected error for oversized file")
+	}
+	if !strings.Contains(err.Error(), "file too large") {
+		t.Fatalf("expected 'file too large' error, got: %v", err)
+	}
+}
+
+func TestReadEnvOrFile_SymlinkFollowed(t *testing.T) {
+	tmp := t.TempDir()
+	secretFile := filepath.Join(tmp, "real-secret.txt")
+	if err := os.WriteFile(secretFile, []byte("symlink-value"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linkPath := filepath.Join(tmp, "link-secret.txt")
+	if err := os.Symlink(secretFile, linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("TEST_SECRET_FILE", linkPath)
+	t.Setenv("TEST_SECRET", "")
+
+	val, ok, err := ReadEnvOrFile("TEST_SECRET", nil)
+	if err != nil {
+		t.Fatalf("symlinks should be followed (Docker/K8s convention): %v", err)
+	}
+	if !ok || val != "symlink-value" {
+		t.Fatalf("expected symlink-value, got ok=%v val=%q", ok, val)
+	}
+}

--- a/internal/gitops/auth.go
+++ b/internal/gitops/auth.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+
+	"github.com/khaines/blogflow/internal/envfile"
 )
 
 // AuthMethod represents a git authentication configuration.
@@ -86,8 +88,12 @@ func LoadAuthFromEnv(logger *slog.Logger) (*AuthConfig, error) {
 		return cfg, nil
 	}
 
-	// Check token
-	if token := os.Getenv("BLOGFLOW_GIT_TOKEN"); token != "" {
+	// Check token (supports _FILE suffix for mounted secrets)
+	token, tokenSet, err := envfile.ReadEnvOrFile("BLOGFLOW_GIT_TOKEN", logger)
+	if err != nil {
+		return nil, fmt.Errorf("gitops: reading git token: %w", err)
+	}
+	if tokenSet && token != "" {
 		cfg := &AuthConfig{Method: AuthToken, Token: token}
 		if err := cfg.Validate(); err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary

Adds support for the Docker/K8s `_FILE` suffix convention for secret environment variables. When `BLOGFLOW_*_FILE=/path/to/secret` is set, the value is read from the file instead of the env var directly. This keeps secrets out of `/proc/pid/environ`.

### Changes

- **New package `internal/envfile`** — `ReadEnvOrFile(key, logger)` helper that checks `KEY_FILE` first, falls back to `KEY`, warns if both are set
- **`internal/config/loader.go`** — secret env vars (`BLOGFLOW_WEBHOOK_SECRET`) now use `ReadEnvOrFile`
- **`internal/gitops/auth.go`** — `BLOGFLOW_GIT_TOKEN` now uses `ReadEnvOrFile`
- **Comprehensive tests** — file exists, fallback to env, both set (file wins + warning), neither set, unreadable file, empty/whitespace-only file

### Supported env vars

| Plain env var | `_FILE` variant |
|---|---|
| `BLOGFLOW_WEBHOOK_SECRET` | `BLOGFLOW_WEBHOOK_SECRET_FILE` |
| `BLOGFLOW_GIT_TOKEN` | `BLOGFLOW_GIT_TOKEN_FILE` |

Fixes #127