### PR TITLE
feat: add path-based pagination to post list handler

### DIFF
--- a/defaults/templates/partials/pagination.html
+++ b/defaults/templates/partials/pagination.html
@@ -2,10 +2,10 @@
 {{if or .Pagination.HasPrev .Pagination.HasNext}}
 <nav class="pagination" aria-label="Page navigation">
     {{if .Pagination.HasPrev}}
-    <a href="?page={{.Pagination.PrevPage}}" class="pagination-prev" rel="prev">&larr; Newer posts</a>
+    <a href="{{.Pagination.PrevURL}}" class="pagination-prev" rel="prev">&larr; Newer posts</a>
     {{end}}
     {{if .Pagination.HasNext}}
-    <a href="?page={{.Pagination.NextPage}}" class="pagination-next" rel="next">Older posts &rarr;</a>
+    <a href="{{.Pagination.NextURL}}" class="pagination-next" rel="next">Older posts &rarr;</a>
     {{end}}
 </nav>
 {{end}}

--- a/internal/server/handlers/handlers.go
+++ b/internal/server/handlers/handlers.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"math"
 	"net/http"
+	"net/url"
 	"strconv"
 	"sync/atomic"
 
@@ -80,6 +81,12 @@ func ListHandler(deps *Deps) http.HandlerFunc {
 		page, pathBased := parsePage(r)
 		if page < 0 {
 			NotFoundHandler(deps)(w, r)
+			return
+		}
+
+		// /page/1 duplicates /; redirect for canonical URLs.
+		if pathBased && page == 1 {
+			http.Redirect(w, r, "/", http.StatusMovedPermanently)
 			return
 		}
 
@@ -269,10 +276,11 @@ func listPageURL(page int) string {
 
 // tagPageURL returns the URL for a page in a tag-filtered listing.
 func tagPageURL(tag string, page int) string {
+	escaped := url.PathEscape(tag)
 	if page <= 1 {
-		return "/tags/" + tag
+		return "/tags/" + escaped
 	}
-	return "/tags/" + tag + "?page=" + strconv.Itoa(page)
+	return "/tags/" + escaped + "?page=" + strconv.Itoa(page)
 }
 
 // setPageURLs populates PrevURL/NextURL on a Pagination using the given

--- a/internal/server/handlers/handlers.go
+++ b/internal/server/handlers/handlers.go
@@ -66,17 +66,31 @@ type Pagination struct {
 	HasNext     bool
 	PrevPage    int
 	NextPage    int
+	PrevURL     string
+	NextURL     string
 }
 
 // ListHandler returns a handler for the home page (paginated post list).
-// Route: GET /{$}
+// Route: GET /{$} and GET /page/{page}
 func ListHandler(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idx := deps.LoadIndex()
-		page := queryInt(r, "page", 1)
 		perPage := deps.Config.Content.PostsPerPage
 
+		page, pathBased := parsePage(r)
+		if page < 0 {
+			NotFoundHandler(deps)(w, r)
+			return
+		}
+
+		// For path-based requests, return 404 for out-of-range pages.
+		if pathBased && !validPage(len(idx.Posts), page, perPage) {
+			NotFoundHandler(deps)(w, r)
+			return
+		}
+
 		paged, pag := paginate(idx.Posts, page, perPage)
+		setPageURLs(pag, listPageURL)
 
 		data := &PageData{
 			Site:       deps.Config.Site,
@@ -155,6 +169,7 @@ func TagHandler(deps *Deps) http.HandlerFunc {
 		perPage := deps.Config.Content.PostsPerPage
 
 		paged, pag := paginate(posts, page, perPage)
+		setPageURLs(pag, func(p int) string { return tagPageURL(tag, p) })
 
 		data := &PageData{
 			Site:       deps.Config.Site,
@@ -184,7 +199,11 @@ func NotFoundHandler(deps *Deps) http.HandlerFunc {
 
 // paginate returns a page slice and pagination metadata for the given posts.
 func paginate(posts []*content.Post, page, perPage int) ([]*content.Post, *Pagination) {
-	if perPage <= 0 {
+	// perPage == 0 disables pagination: return all posts on a single page.
+	if perPage == 0 {
+		return posts, &Pagination{CurrentPage: 1, TotalPages: 1}
+	}
+	if perPage < 0 {
 		perPage = 10
 	}
 	total := len(posts)
@@ -210,6 +229,60 @@ func paginate(posts []*content.Post, page, perPage int) ([]*content.Post, *Pagin
 		HasNext:     page < totalPages,
 		PrevPage:    page - 1,
 		NextPage:    page + 1,
+	}
+}
+
+// parsePage extracts the page number from the request. It checks the path
+// value first (/page/{page}), then falls back to the ?page= query parameter.
+// Returns (-1, true) if a path value is present but invalid.
+func parsePage(r *http.Request) (int, bool) {
+	if p := r.PathValue("page"); p != "" {
+		v, err := strconv.Atoi(p)
+		if err != nil || v < 1 {
+			return -1, true
+		}
+		return v, true
+	}
+	return queryInt(r, "page", 1), false
+}
+
+// validPage reports whether page is within the valid range for the given
+// total post count and per-page size.
+func validPage(totalPosts, page, perPage int) bool {
+	if perPage <= 0 {
+		return page == 1
+	}
+	totalPages := int(math.Ceil(float64(totalPosts) / float64(perPage)))
+	if totalPages < 1 {
+		totalPages = 1
+	}
+	return page >= 1 && page <= totalPages
+}
+
+// listPageURL returns the canonical URL for a page in the main post list.
+func listPageURL(page int) string {
+	if page <= 1 {
+		return "/"
+	}
+	return "/page/" + strconv.Itoa(page)
+}
+
+// tagPageURL returns the URL for a page in a tag-filtered listing.
+func tagPageURL(tag string, page int) string {
+	if page <= 1 {
+		return "/tags/" + tag
+	}
+	return "/tags/" + tag + "?page=" + strconv.Itoa(page)
+}
+
+// setPageURLs populates PrevURL/NextURL on a Pagination using the given
+// URL-building function.
+func setPageURLs(pag *Pagination, urlFunc func(int) string) {
+	if pag.HasPrev {
+		pag.PrevURL = urlFunc(pag.PrevPage)
+	}
+	if pag.HasNext {
+		pag.NextURL = urlFunc(pag.NextPage)
 	}
 }
 

--- a/internal/server/handlers/handlers_test.go
+++ b/internal/server/handlers/handlers_test.go
@@ -44,7 +44,7 @@ func testDeps(t *testing.T, posts, pages []*content.Post) *handlers.Deps {
 			Data: []byte(`{{block "content" .}}{{end}}`),
 		},
 		"templates/list.html": &fstest.MapFile{
-			Data: []byte(`{{define "content"}}{{.Title}}|posts={{len .Posts}}|page={{.Pagination.CurrentPage}}|total={{.Pagination.TotalPages}}{{end}}`),
+			Data: []byte(`{{define "content"}}{{.Title}}|posts={{len .Posts}}|page={{.Pagination.CurrentPage}}|total={{.Pagination.TotalPages}}|prev={{.Pagination.PrevURL}}|next={{.Pagination.NextURL}}{{end}}`),
 		},
 		"templates/post.html": &fstest.MapFile{
 			Data: []byte(`{{define "content"}}post:{{.Post.Slug}}|{{.Title}}{{end}}`),
@@ -478,4 +478,196 @@ func TestTagHandler_Paginated(t *testing.T) {
 	if !strings.Contains(body, "total=2") {
 		t.Errorf("expected total=2, got body: %s", body)
 	}
+}
+
+// testDepsWithPerPage builds a Deps like testDeps but with a custom PostsPerPage.
+func testDepsWithPerPage(t *testing.T, posts, pages []*content.Post, perPage int) *handlers.Deps {
+	t.Helper()
+
+	idx := &content.Index{
+		Posts:      posts,
+		BySlug:     make(map[string]*content.Post),
+		ByTag:      make(map[string][]*content.Post),
+		ByYear:     make(map[int][]*content.Post),
+		Pages:      pages,
+		PageBySlug: make(map[string]*content.Post),
+	}
+	for _, p := range posts {
+		idx.BySlug[p.Slug] = p
+		for _, tag := range p.Tags {
+			idx.ByTag[tag] = append(idx.ByTag[tag], p)
+		}
+	}
+	for _, p := range pages {
+		idx.PageBySlug[p.Slug] = p
+	}
+
+	tmplFS := fstest.MapFS{
+		"templates/base.html": &fstest.MapFile{
+			Data: []byte(`{{block "content" .}}{{end}}`),
+		},
+		"templates/list.html": &fstest.MapFile{
+			Data: []byte(`{{define "content"}}{{.Title}}|posts={{len .Posts}}|page={{.Pagination.CurrentPage}}|total={{.Pagination.TotalPages}}|prev={{.Pagination.PrevURL}}|next={{.Pagination.NextURL}}{{end}}`),
+		},
+		"templates/post.html": &fstest.MapFile{
+			Data: []byte(`{{define "content"}}post:{{.Post.Slug}}|{{.Title}}{{end}}`),
+		},
+		"templates/page.html": &fstest.MapFile{
+			Data: []byte(`{{define "content"}}page:{{.Page.Slug}}|{{.Title}}{{end}}`),
+		},
+		"templates/404.html": &fstest.MapFile{
+			Data: []byte(`{{define "content"}}404:{{.Title}}{{end}}`),
+		},
+	}
+	eng, err := theme.NewEngine(tmplFS)
+	if err != nil {
+		t.Fatalf("creating theme engine: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.Content.PostsPerPage = perPage
+
+	return handlers.NewDeps(cfg, idx, eng)
+}
+
+func TestListHandler_PathPage(t *testing.T) {
+	posts := []*content.Post{
+		makePost("a", "Alpha", nil),
+		makePost("b", "Beta", nil),
+		makePost("c", "Gamma", nil),
+	}
+	deps := testDeps(t, posts, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/page/2", nil)
+	req.SetPathValue("page", "2")
+	rec := httptest.NewRecorder()
+	handlers.ListHandler(deps)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "posts=1") {
+		t.Errorf("expected 1 post on page 2, got body: %s", body)
+	}
+	if !strings.Contains(body, "page=2") {
+		t.Errorf("expected page=2, got body: %s", body)
+	}
+	if !strings.Contains(body, "prev=/") {
+		t.Errorf("expected prev=/, got body: %s", body)
+	}
+}
+
+func TestListHandler_PathPageInvalid(t *testing.T) {
+	posts := []*content.Post{makePost("a", "Alpha", nil)}
+	deps := testDeps(t, posts, nil)
+
+	for _, val := range []string{"0", "-1", "abc"} {
+		t.Run(val, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/page/"+val, nil)
+			req.SetPathValue("page", val)
+			rec := httptest.NewRecorder()
+			handlers.ListHandler(deps)(rec, req)
+
+			if rec.Code != http.StatusNotFound {
+				t.Fatalf("expected 404 for /page/%s, got %d", val, rec.Code)
+			}
+		})
+	}
+}
+
+func TestListHandler_PathPageBeyondTotal(t *testing.T) {
+	posts := []*content.Post{
+		makePost("a", "Alpha", nil),
+		makePost("b", "Beta", nil),
+	}
+	deps := testDeps(t, posts, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/page/999", nil)
+	req.SetPathValue("page", "999")
+	rec := httptest.NewRecorder()
+	handlers.ListHandler(deps)(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for /page/999, got %d", rec.Code)
+	}
+}
+
+func TestListHandler_NoPagination(t *testing.T) {
+	posts := []*content.Post{
+		makePost("a", "Alpha", nil),
+		makePost("b", "Beta", nil),
+		makePost("c", "Gamma", nil),
+	}
+	deps := testDepsWithPerPage(t, posts, nil, 0)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handlers.ListHandler(deps)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "posts=3") {
+		t.Errorf("expected all 3 posts, got body: %s", body)
+	}
+	if !strings.Contains(body, "total=1") {
+		t.Errorf("expected total=1 (no pagination), got body: %s", body)
+	}
+}
+
+func TestListHandler_PageURLs(t *testing.T) {
+	posts := []*content.Post{
+		makePost("a", "Alpha", nil),
+		makePost("b", "Beta", nil),
+		makePost("c", "Gamma", nil),
+		makePost("d", "Delta", nil),
+		makePost("e", "Epsilon", nil),
+	}
+	deps := testDeps(t, posts, nil) // 2 per page → 3 pages
+
+	t.Run("page1", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		handlers.ListHandler(deps)(rec, req)
+
+		body := rec.Body.String()
+		if !strings.Contains(body, "next=/page/2") {
+			t.Errorf("expected next=/page/2, got body: %s", body)
+		}
+		if strings.Contains(body, "prev=/") {
+			t.Errorf("expected no prev URL on page 1, got body: %s", body)
+		}
+	})
+
+	t.Run("page2", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/page/2", nil)
+		req.SetPathValue("page", "2")
+		rec := httptest.NewRecorder()
+		handlers.ListHandler(deps)(rec, req)
+
+		body := rec.Body.String()
+		if !strings.Contains(body, "prev=/") {
+			t.Errorf("expected prev=/, got body: %s", body)
+		}
+		if !strings.Contains(body, "next=/page/3") {
+			t.Errorf("expected next=/page/3, got body: %s", body)
+		}
+	})
+
+	t.Run("page3_last", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/page/3", nil)
+		req.SetPathValue("page", "3")
+		rec := httptest.NewRecorder()
+		handlers.ListHandler(deps)(rec, req)
+
+		body := rec.Body.String()
+		if !strings.Contains(body, "prev=/page/2") {
+			t.Errorf("expected prev=/page/2, got body: %s", body)
+		}
+		if strings.Contains(body, "next=/") {
+			t.Errorf("expected no next URL on last page, got body: %s", body)
+		}
+	})
 }

--- a/internal/server/handlers/handlers_test.go
+++ b/internal/server/handlers/handlers_test.go
@@ -617,6 +617,51 @@ func TestListHandler_NoPagination(t *testing.T) {
 	}
 }
 
+func TestListHandler_PathPage1Redirect(t *testing.T) {
+	posts := []*content.Post{
+		makePost("a", "Alpha", nil),
+		makePost("b", "Beta", nil),
+		makePost("c", "Gamma", nil),
+	}
+	deps := testDeps(t, posts, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/page/1", nil)
+	req.SetPathValue("page", "1")
+	rec := httptest.NewRecorder()
+	handlers.ListHandler(deps)(rec, req)
+
+	if rec.Code != http.StatusMovedPermanently {
+		t.Fatalf("expected 301 for /page/1, got %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/" {
+		t.Errorf("expected redirect to /, got Location: %s", loc)
+	}
+}
+
+func TestTagHandler_URLEscaping(t *testing.T) {
+	tag := "c sharp"
+	posts := []*content.Post{
+		makePost("a", "Alpha", []string{tag}),
+		makePost("b", "Beta", []string{tag}),
+		makePost("c", "Gamma", []string{tag}),
+	}
+	deps := testDeps(t, posts, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/tags/c%20sharp", nil)
+	req.SetPathValue("tag", tag)
+	rec := httptest.NewRecorder()
+	handlers.TagHandler(deps)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	// url.PathEscape("c sharp") → "c%20sharp"
+	if !strings.Contains(body, "next=/tags/c%20sharp?page=2") {
+		t.Errorf("expected URL-escaped tag in next URL, got body: %s", body)
+	}
+}
+
 func TestListHandler_PageURLs(t *testing.T) {
 	posts := []*content.Post{
 		makePost("a", "Alpha", nil),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -105,6 +105,7 @@ func (s *Server) RegisterRoutes(opts RouteOptions) {
 
 	// Content routes
 	s.mux.HandleFunc("GET /{$}", opts.ListHandler)
+	s.mux.HandleFunc("GET /page/{page}", opts.ListHandler)
 	s.mux.HandleFunc("GET /posts/{slug}", opts.PostHandler)
 	s.mux.HandleFunc("GET /pages/{slug}", opts.PageHandler)
 	s.mux.HandleFunc("GET /tags/{tag}", opts.TagHandler)


### PR DESCRIPTION
## Summary

Adds **path-based pagination** (`GET /page/{page}`) to the post list handler, alongside the existing query-param support.

### Changes

- **Route**: `GET /page/{page}` registered alongside `GET /{$}` (page 1 = home `/`)
- **ListHandler**: Parses page from path value first, falls back to `?page=` query param
- **Validation**: Path-based requests return 404 for invalid or out-of-range pages
- **No pagination mode**: `posts_per_page=0` disables pagination (all posts on one page)
- **URL generation**: `PrevURL`/`NextURL` added to `Pagination` struct; templates use these instead of building URLs from page numbers
- **Tag handler**: Also generates prev/next URLs (`/tags/{tag}?page=N`)
- **Template**: `pagination.html` updated to use `PrevURL`/`NextURL`

### Tests added

- Path-based page 2 (`/page/2`) returns correct slice
- Invalid path pages (`/page/0`, `/page/-1`, `/page/abc`) → 404
- Beyond-total path page (`/page/999`) → 404
- `posts_per_page=0` → all posts on one page, no pagination
- URL generation: prev/next URLs verified across page 1, 2, and last page

### Verification

- `go test -race ./...` — all passing
- `golangci-lint run ./...` — no new issues