### PR TITLE
feat: propagate config reload to handlers atomically

### DIFF
--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -159,6 +159,15 @@ func main() {
 	// 7. Build handler dependencies
 	deps := handlers.NewDeps(cfg, idx, themeEngine)
 
+	// Wire config reload → handlers: when config changes, update deps atomically
+	cfgLoader.OnChange(func(newCfg *config.Config) {
+		deps.SetConfig(newCfg)
+		logger.Info("handlers config updated after reload",
+			"site_title", newCfg.Site.Title,
+			"base_url", newCfg.Site.BaseURL,
+		)
+	})
+
 	// 8. Content reloader for sync strategies
 	reloader := newContentReloader(scanner, contentOverlay, deps, renderCache, logger)
 
@@ -190,8 +199,8 @@ func main() {
 		staticFS = nil
 	}
 
-	feedHandler := handlers.NewFeedHandler(cfg, idx)
-	sitemapHandler := handlers.NewSitemapHandler(cfg, idx)
+	feedHandler := handlers.NewFeedHandler(deps)
+	sitemapHandler := handlers.NewSitemapHandler(deps)
 
 	routeOpts := server.RouteOptions{
 		ListHandler:    handlers.ListHandler(deps),

--- a/internal/server/handlers/cache_test.go
+++ b/internal/server/handlers/cache_test.go
@@ -14,7 +14,7 @@ import (
 func TestFeedHandler_CacheHeaders(t *testing.T) {
 	cfg := testConfig()
 	idx := testIndex(3)
-	h := handlers.NewFeedHandler(cfg, idx)
+	h := handlers.NewFeedHandler(handlers.NewDeps(cfg, idx, nil))
 
 	req := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
 	rec := httptest.NewRecorder()
@@ -39,7 +39,7 @@ func TestFeedHandler_CacheHeaders(t *testing.T) {
 func TestFeedHandler_ETag304(t *testing.T) {
 	cfg := testConfig()
 	idx := testIndex(3)
-	h := handlers.NewFeedHandler(cfg, idx)
+	h := handlers.NewFeedHandler(handlers.NewDeps(cfg, idx, nil))
 
 	// First request to obtain ETag.
 	req1 := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
@@ -68,7 +68,7 @@ func TestFeedHandler_ETag304(t *testing.T) {
 func TestFeedHandler_IfModifiedSince304(t *testing.T) {
 	cfg := testConfig()
 	idx := testIndex(3)
-	h := handlers.NewFeedHandler(cfg, idx)
+	h := handlers.NewFeedHandler(handlers.NewDeps(cfg, idx, nil))
 
 	// Newest post date is 2025-01-15 12:00:00 UTC (from testIndex).
 	future := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
@@ -86,7 +86,7 @@ func TestFeedHandler_IfModifiedSince304(t *testing.T) {
 func TestFeedHandler_IfModifiedSince200WhenNewer(t *testing.T) {
 	cfg := testConfig()
 	idx := testIndex(3)
-	h := handlers.NewFeedHandler(cfg, idx)
+	h := handlers.NewFeedHandler(handlers.NewDeps(cfg, idx, nil))
 
 	// Date well before the newest post.
 	old := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -106,7 +106,7 @@ func TestFeedHandler_IfModifiedSince200WhenNewer(t *testing.T) {
 func TestSitemapHandler_CacheHeaders(t *testing.T) {
 	cfg := testConfig()
 	idx := testIndex(2)
-	h := handlers.NewSitemapHandler(cfg, idx)
+	h := handlers.NewSitemapHandler(handlers.NewDeps(cfg, idx, nil))
 
 	req := httptest.NewRequest(http.MethodGet, "/sitemap.xml", nil)
 	rec := httptest.NewRecorder()
@@ -129,7 +129,7 @@ func TestSitemapHandler_CacheHeaders(t *testing.T) {
 func TestSitemapHandler_ETag304(t *testing.T) {
 	cfg := testConfig()
 	idx := testIndex(2)
-	h := handlers.NewSitemapHandler(cfg, idx)
+	h := handlers.NewSitemapHandler(handlers.NewDeps(cfg, idx, nil))
 
 	// First request to obtain ETag.
 	req1 := httptest.NewRequest(http.MethodGet, "/sitemap.xml", nil)
@@ -155,7 +155,7 @@ func TestSitemapHandler_ETag304(t *testing.T) {
 func TestSitemapHandler_IfModifiedSince304(t *testing.T) {
 	cfg := testConfig()
 	idx := testIndex(2)
-	h := handlers.NewSitemapHandler(cfg, idx)
+	h := handlers.NewSitemapHandler(handlers.NewDeps(cfg, idx, nil))
 
 	future := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
 
@@ -174,7 +174,7 @@ func TestSitemapHandler_IfModifiedSince304(t *testing.T) {
 func TestFeedHandler_IfNoneMatchMultiValue(t *testing.T) {
 	cfg := testConfig()
 	idx := testIndex(3)
-	h := handlers.NewFeedHandler(cfg, idx)
+	h := handlers.NewFeedHandler(handlers.NewDeps(cfg, idx, nil))
 
 	// Get the real ETag.
 	req1 := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
@@ -196,7 +196,7 @@ func TestFeedHandler_IfNoneMatchMultiValue(t *testing.T) {
 func TestFeedHandler_IfNoneMatchWildcard(t *testing.T) {
 	cfg := testConfig()
 	idx := testIndex(3)
-	h := handlers.NewFeedHandler(cfg, idx)
+	h := handlers.NewFeedHandler(handlers.NewDeps(cfg, idx, nil))
 
 	req := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
 	req.Header.Set("If-None-Match", "*")
@@ -211,7 +211,7 @@ func TestFeedHandler_IfNoneMatchWildcard(t *testing.T) {
 func TestFeedHandler_IfNoneMatchMiss_IgnoresIfModifiedSince(t *testing.T) {
 	cfg := testConfig()
 	idx := testIndex(3)
-	h := handlers.NewFeedHandler(cfg, idx)
+	h := handlers.NewFeedHandler(handlers.NewDeps(cfg, idx, nil))
 
 	// Send mismatched ETag AND a future If-Modified-Since.
 	// Per RFC 7232 §3.3, If-Modified-Since MUST be ignored when

--- a/internal/server/handlers/config_reload_test.go
+++ b/internal/server/handlers/config_reload_test.go
@@ -1,0 +1,130 @@
+package handlers_test
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/khaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/content"
+	"github.com/khaines/blogflow/internal/server/handlers"
+)
+
+// TestListHandler_ConfigReload verifies that after SetConfig, the list
+// handler serves the updated site title.
+func TestListHandler_ConfigReload(t *testing.T) {
+	posts := []*content.Post{makePost("a", "Alpha", nil)}
+	deps := testDeps(t, posts, nil)
+
+	// Initial request — default title from config.Default().
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handlers.ListHandler(deps)(rec, req)
+
+	initial := rec.Body.String()
+	if !strings.Contains(initial, config.Default().Site.Title) {
+		t.Fatalf("expected default title in initial response, got: %s", initial)
+	}
+
+	// Swap config with updated site title.
+	newCfg := config.Default()
+	newCfg.Site.Title = "Reloaded Blog"
+	newCfg.Content.PostsPerPage = 2
+	deps.SetConfig(newCfg)
+
+	// Second request should reflect the new title.
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec2 := httptest.NewRecorder()
+	handlers.ListHandler(deps)(rec2, req2)
+
+	body := rec2.Body.String()
+	if !strings.Contains(body, "Reloaded Blog") {
+		t.Errorf("expected 'Reloaded Blog' after config reload, got: %s", body)
+	}
+}
+
+// TestFeedHandler_ConfigReload verifies that the feed handler picks up
+// a config change (site title + base URL) after SetConfig.
+func TestFeedHandler_ConfigReload(t *testing.T) {
+	cfg := testConfig()
+	idx := testIndex(2)
+	deps := handlers.NewDeps(cfg, idx, nil)
+	h := handlers.NewFeedHandler(deps)
+
+	// Initial request.
+	req := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	var feed1 handlers.AtomFeed
+	if err := xml.Unmarshal(rec.Body.Bytes(), &feed1); err != nil {
+		t.Fatalf("invalid Atom XML: %v", err)
+	}
+	if feed1.Title != "Test Blog" {
+		t.Fatalf("initial title = %q, want %q", feed1.Title, "Test Blog")
+	}
+
+	// Reload config with new title and base URL.
+	newCfg := testConfig()
+	newCfg.Site.Title = "Updated Blog"
+	newCfg.Site.BaseURL = "https://new.example.com"
+	deps.SetConfig(newCfg)
+
+	// Second request should reflect updated values.
+	req2 := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+
+	var feed2 handlers.AtomFeed
+	if err := xml.Unmarshal(rec2.Body.Bytes(), &feed2); err != nil {
+		t.Fatalf("invalid Atom XML: %v", err)
+	}
+	if feed2.Title != "Updated Blog" {
+		t.Errorf("title after reload = %q, want %q", feed2.Title, "Updated Blog")
+	}
+	if feed2.ID != "https://new.example.com/" {
+		t.Errorf("ID after reload = %q, want %q", feed2.ID, "https://new.example.com/")
+	}
+}
+
+// TestSitemapHandler_ConfigReload verifies that the sitemap handler
+// picks up a base URL change after SetConfig.
+func TestSitemapHandler_ConfigReload(t *testing.T) {
+	cfg := testConfig()
+	idx := testIndex(1)
+	deps := handlers.NewDeps(cfg, idx, nil)
+	h := handlers.NewSitemapHandler(deps)
+
+	// Initial request.
+	req := httptest.NewRequest(http.MethodGet, "/sitemap.xml", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	var sm1 handlers.URLSet
+	if err := xml.Unmarshal(rec.Body.Bytes(), &sm1); err != nil {
+		t.Fatalf("invalid sitemap XML: %v", err)
+	}
+	if sm1.URLs[0].Loc != "https://example.com/" {
+		t.Fatalf("initial home loc = %q", sm1.URLs[0].Loc)
+	}
+
+	// Reload config with new base URL.
+	newCfg := testConfig()
+	newCfg.Site.BaseURL = "https://reloaded.example.com"
+	deps.SetConfig(newCfg)
+
+	// Second request should reflect updated base URL.
+	req2 := httptest.NewRequest(http.MethodGet, "/sitemap.xml", nil)
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+
+	var sm2 handlers.URLSet
+	if err := xml.Unmarshal(rec2.Body.Bytes(), &sm2); err != nil {
+		t.Fatalf("invalid sitemap XML: %v", err)
+	}
+	if sm2.URLs[0].Loc != "https://reloaded.example.com/" {
+		t.Errorf("home loc after reload = %q, want %q", sm2.URLs[0].Loc, "https://reloaded.example.com/")
+	}
+}

--- a/internal/server/handlers/feed.go
+++ b/internal/server/handlers/feed.go
@@ -77,39 +77,39 @@ type RSSItem struct {
 
 // FeedHandler serves an Atom or RSS 2.0 feed from the content index.
 type FeedHandler struct {
-	cfg   *config.Config
-	index *content.Index
+	deps *Deps
 }
 
-// NewFeedHandler creates a FeedHandler.
-func NewFeedHandler(cfg *config.Config, index *content.Index) *FeedHandler {
-	return &FeedHandler{cfg: cfg, index: index}
+// NewFeedHandler creates a FeedHandler backed by the shared Deps.
+func NewFeedHandler(deps *Deps) *FeedHandler {
+	return &FeedHandler{deps: deps}
 }
 
 func (h *FeedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	posts := h.limitedPosts()
+	cfg := h.deps.LoadConfig()
+	posts := h.limitedPosts(cfg)
 
-	if h.cfg.Feed.Type == "rss" {
-		h.serveRSS(w, r, posts)
+	if cfg.Feed.Type == "rss" {
+		h.serveRSS(w, r, cfg, posts)
 		return
 	}
-	h.serveAtom(w, r, posts)
+	h.serveAtom(w, r, cfg, posts)
 }
 
-func (h *FeedHandler) limitedPosts() []*content.Post {
-	limit := h.cfg.Feed.Items
+func (h *FeedHandler) limitedPosts(cfg *config.Config) []*content.Post {
+	limit := cfg.Feed.Items
 	if limit <= 0 {
 		limit = 20
 	}
-	posts := h.index.Posts
+	posts := h.deps.LoadIndex().Posts
 	if len(posts) > limit {
 		posts = posts[:limit]
 	}
 	return posts
 }
 
-func (h *FeedHandler) serveAtom(w http.ResponseWriter, r *http.Request, posts []*content.Post) {
-	baseURL := h.cfg.Site.BaseURL
+func (h *FeedHandler) serveAtom(w http.ResponseWriter, r *http.Request, cfg *config.Config, posts []*content.Post) {
+	baseURL := cfg.Site.BaseURL
 
 	var lastMod time.Time
 	updated := time.Now().UTC().Format(time.RFC3339)
@@ -134,15 +134,15 @@ func (h *FeedHandler) serveAtom(w http.ResponseWriter, r *http.Request, posts []
 
 	feed := AtomFeed{
 		XMLNS: "http://www.w3.org/2005/Atom",
-		Title: h.cfg.Site.Title,
+		Title: cfg.Site.Title,
 		Links: []AtomLink{
 			{Href: baseURL + "/feed.xml", Rel: "self", Type: "application/atom+xml"},
 			{Href: baseURL + "/", Rel: "alternate", Type: "text/html"},
 		},
 		Updated: updated,
 		Author: AtomAuthor{
-			Name:  h.cfg.Site.Author.Name,
-			Email: h.cfg.Site.Author.Email,
+			Name:  cfg.Site.Author.Name,
+			Email: cfg.Site.Author.Email,
 		},
 		ID:      baseURL + "/",
 		Entries: entries,
@@ -151,8 +151,8 @@ func (h *FeedHandler) serveAtom(w http.ResponseWriter, r *http.Request, posts []
 	writeXMLCached(w, r, "application/atom+xml; charset=utf-8", feed, lastMod)
 }
 
-func (h *FeedHandler) serveRSS(w http.ResponseWriter, r *http.Request, posts []*content.Post) {
-	baseURL := h.cfg.Site.BaseURL
+func (h *FeedHandler) serveRSS(w http.ResponseWriter, r *http.Request, cfg *config.Config, posts []*content.Post) {
+	baseURL := cfg.Site.BaseURL
 
 	var lastMod time.Time
 	var pubDate string
@@ -175,10 +175,10 @@ func (h *FeedHandler) serveRSS(w http.ResponseWriter, r *http.Request, posts []*
 	feed := RSSFeed{
 		Version: "2.0",
 		Channel: RSSChannel{
-			Title:       h.cfg.Site.Title,
+			Title:       cfg.Site.Title,
 			Link:        baseURL,
-			Description: h.cfg.Site.Description,
-			Language:    h.cfg.Site.Language,
+			Description: cfg.Site.Description,
+			Language:    cfg.Site.Language,
 			PubDate:     pubDate,
 			Items:       items,
 		},

--- a/internal/server/handlers/feed_test.go
+++ b/internal/server/handlers/feed_test.go
@@ -51,7 +51,8 @@ func testIndex(n int) *content.Index {
 func TestFeedHandler_Atom(t *testing.T) {
 	cfg := testConfig()
 	idx := testIndex(3)
-	h := handlers.NewFeedHandler(cfg, idx)
+	deps := handlers.NewDeps(cfg, idx, nil)
+	h := handlers.NewFeedHandler(deps)
 
 	req := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
 	rec := httptest.NewRecorder()
@@ -99,7 +100,8 @@ func TestFeedHandler_RSS(t *testing.T) {
 	cfg := testConfig()
 	cfg.Feed.Type = "rss"
 	idx := testIndex(3)
-	h := handlers.NewFeedHandler(cfg, idx)
+	deps := handlers.NewDeps(cfg, idx, nil)
+	h := handlers.NewFeedHandler(deps)
 
 	req := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
 	rec := httptest.NewRecorder()
@@ -150,7 +152,8 @@ func TestFeedHandler_RSS(t *testing.T) {
 func TestFeedHandler_EmptyIndex(t *testing.T) {
 	cfg := testConfig()
 	idx := testIndex(0)
-	h := handlers.NewFeedHandler(cfg, idx)
+	deps := handlers.NewDeps(cfg, idx, nil)
+	h := handlers.NewFeedHandler(deps)
 
 	req := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
 	rec := httptest.NewRecorder()
@@ -173,7 +176,8 @@ func TestFeedHandler_LimitItems(t *testing.T) {
 	cfg := testConfig()
 	cfg.Feed.Items = 2
 	idx := testIndex(5)
-	h := handlers.NewFeedHandler(cfg, idx)
+	deps := handlers.NewDeps(cfg, idx, nil)
+	h := handlers.NewFeedHandler(deps)
 
 	req := httptest.NewRequest(http.MethodGet, "/feed.xml", nil)
 	rec := httptest.NewRecorder()

--- a/internal/server/handlers/handlers.go
+++ b/internal/server/handlers/handlers.go
@@ -17,20 +17,27 @@ import (
 )
 
 // Deps holds shared dependencies for all handlers.
-// The content index is stored as an atomic pointer so that background
-// sync-strategy reloaders can swap it without racing with HTTP handlers.
+// Both the content index and config are stored as atomic pointers so that
+// background reloaders can swap them without racing with HTTP handlers.
 type Deps struct {
-	Config *config.Config
+	config atomic.Pointer[config.Config]
 	index  atomic.Pointer[content.Index]
 	Theme  *theme.Engine
 }
 
 // NewDeps creates a Deps with the given dependencies.
 func NewDeps(cfg *config.Config, idx *content.Index, themeEngine *theme.Engine) *Deps {
-	d := &Deps{Config: cfg, Theme: themeEngine}
+	d := &Deps{Theme: themeEngine}
+	d.config.Store(cfg)
 	d.index.Store(idx)
 	return d
 }
+
+// LoadConfig returns the current config. Safe for concurrent use.
+func (d *Deps) LoadConfig() *config.Config { return d.config.Load() }
+
+// SetConfig atomically replaces the config. Safe for concurrent use.
+func (d *Deps) SetConfig(cfg *config.Config) { d.config.Store(cfg) }
 
 // LoadIndex returns the current content index. Safe for concurrent use.
 func (d *Deps) LoadIndex() *content.Index { return d.index.Load() }
@@ -75,8 +82,9 @@ type Pagination struct {
 // Route: GET /{$} and GET /page/{page}
 func ListHandler(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		cfg := deps.LoadConfig()
 		idx := deps.LoadIndex()
-		perPage := deps.Config.Content.PostsPerPage
+		perPage := cfg.Content.PostsPerPage
 
 		page, pathBased := parsePage(r)
 		if page < 0 {
@@ -100,10 +108,10 @@ func ListHandler(deps *Deps) http.HandlerFunc {
 		setPageURLs(pag, listPageURL)
 
 		data := &PageData{
-			Site:       deps.Config.Site,
-			Feed:       deps.Config.Feed,
+			Site:       cfg.Site,
+			Feed:       cfg.Feed,
 			Posts:      paged,
-			Title:      deps.Config.Site.Title,
+			Title:      cfg.Site.Title,
 			Pagination: pag,
 		}
 
@@ -124,9 +132,10 @@ func PostHandler(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		cfg := deps.LoadConfig()
 		data := &PageData{
-			Site:  deps.Config.Site,
-			Feed:  deps.Config.Feed,
+			Site:  cfg.Site,
+			Feed:  cfg.Feed,
 			Post:  post,
 			Title: post.Title,
 		}
@@ -148,9 +157,10 @@ func PageHandler(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		cfg := deps.LoadConfig()
 		data := &PageData{
-			Site:  deps.Config.Site,
-			Feed:  deps.Config.Feed,
+			Site:  cfg.Site,
+			Feed:  cfg.Feed,
 			Page:  page,
 			Title: page.Title,
 		}
@@ -172,15 +182,16 @@ func TagHandler(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		cfg := deps.LoadConfig()
 		page := queryInt(r, "page", 1)
-		perPage := deps.Config.Content.PostsPerPage
+		perPage := cfg.Content.PostsPerPage
 
 		paged, pag := paginate(posts, page, perPage)
 		setPageURLs(pag, func(p int) string { return tagPageURL(tag, p) })
 
 		data := &PageData{
-			Site:       deps.Config.Site,
-			Feed:       deps.Config.Feed,
+			Site:       cfg.Site,
+			Feed:       cfg.Feed,
 			Posts:      paged,
 			Tag:        tag,
 			Title:      "Posts tagged \"" + tag + "\"",
@@ -194,9 +205,10 @@ func TagHandler(deps *Deps) http.HandlerFunc {
 // NotFoundHandler returns a handler that renders the 404 page.
 func NotFoundHandler(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		cfg := deps.LoadConfig()
 		data := &PageData{
-			Site:  deps.Config.Site,
-			Feed:  deps.Config.Feed,
+			Site:  cfg.Site,
+			Feed:  cfg.Feed,
 			Title: "Page Not Found",
 		}
 

--- a/internal/server/handlers/sitemap.go
+++ b/internal/server/handlers/sitemap.go
@@ -6,9 +6,6 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
-
-	"github.com/khaines/blogflow/internal/config"
-	"github.com/khaines/blogflow/internal/content"
 )
 
 // Sitemap XML structures per sitemaps.org protocol.
@@ -30,26 +27,27 @@ type URL struct {
 
 // SitemapHandler serves a sitemap.xml from the content index.
 type SitemapHandler struct {
-	cfg   *config.Config
-	index *content.Index
+	deps *Deps
 }
 
-// NewSitemapHandler creates a SitemapHandler.
-func NewSitemapHandler(cfg *config.Config, index *content.Index) *SitemapHandler {
-	return &SitemapHandler{cfg: cfg, index: index}
+// NewSitemapHandler creates a SitemapHandler backed by the shared Deps.
+func NewSitemapHandler(deps *Deps) *SitemapHandler {
+	return &SitemapHandler{deps: deps}
 }
 
 func (h *SitemapHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	baseURL := h.cfg.Site.BaseURL
+	cfg := h.deps.LoadConfig()
+	idx := h.deps.LoadIndex()
+	baseURL := cfg.Site.BaseURL
 
 	// Derive homepage lastmod from the most recent post.
 	homeURL := URL{Loc: baseURL + "/", ChangeFreq: "daily", Priority: "1.0"}
-	if len(h.index.Posts) > 0 && !h.index.Posts[0].Date.IsZero() {
-		homeURL.LastMod = h.index.Posts[0].Date.UTC().Format("2006-01-02")
+	if len(idx.Posts) > 0 && !idx.Posts[0].Date.IsZero() {
+		homeURL.LastMod = idx.Posts[0].Date.UTC().Format("2006-01-02")
 	}
 	urls := []URL{homeURL}
 
-	for _, p := range h.index.Posts {
+	for _, p := range idx.Posts {
 		u := URL{
 			Loc:        fmt.Sprintf("%s/posts/%s", baseURL, p.Slug),
 			ChangeFreq: "weekly",
@@ -61,7 +59,7 @@ func (h *SitemapHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		urls = append(urls, u)
 	}
 
-	for _, p := range h.index.Pages {
+	for _, p := range idx.Pages {
 		u := URL{
 			Loc:        fmt.Sprintf("%s/%s", baseURL, p.Slug),
 			ChangeFreq: "monthly",
@@ -85,12 +83,12 @@ func (h *SitemapHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var lastMod time.Time
-	for _, p := range h.index.Posts {
+	for _, p := range idx.Posts {
 		if p.Date.After(lastMod) {
 			lastMod = p.Date
 		}
 	}
-	for _, p := range h.index.Pages {
+	for _, p := range idx.Pages {
 		if p.Date.After(lastMod) {
 			lastMod = p.Date
 		}

--- a/internal/server/handlers/sitemap_test.go
+++ b/internal/server/handlers/sitemap_test.go
@@ -27,7 +27,7 @@ func TestSitemapHandler(t *testing.T) {
 	idx.Pages = append(idx.Pages, page)
 	idx.PageBySlug["about"] = page
 
-	h := handlers.NewSitemapHandler(cfg, idx)
+	h := handlers.NewSitemapHandler(handlers.NewDeps(cfg, idx, nil))
 
 	req := httptest.NewRequest(http.MethodGet, "/sitemap.xml", nil)
 	rec := httptest.NewRecorder()
@@ -79,7 +79,7 @@ func TestSitemapHandler(t *testing.T) {
 func TestSitemapHandler_Empty(t *testing.T) {
 	cfg := testConfig()
 	idx := testIndex(0)
-	h := handlers.NewSitemapHandler(cfg, idx)
+	h := handlers.NewSitemapHandler(handlers.NewDeps(cfg, idx, nil))
 
 	req := httptest.NewRequest(http.MethodGet, "/sitemap.xml", nil)
 	rec := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

Handlers (list, post, page, tag, feed, sitemap) previously held static `*config.Config` references captured at startup. When config was reloaded via `Loader.Reload()`, handlers continued serving stale values for site title, base URL, feed settings, etc.

## Changes

- **Deps**: replace exported `Config` field with `atomic.Pointer[config.Config]`, add `LoadConfig()`/`SetConfig()` methods matching the existing `LoadIndex`/`SetIndex` pattern
- **FeedHandler/SitemapHandler**: accept `*Deps` instead of separate `*config.Config` + `*content.Index`; read config and index atomically per request
- **Template handlers** (List, Post, Page, Tag, NotFound): call `deps.LoadConfig()` per request instead of capturing config at init
- **main.go**: register `cfgLoader.OnChange` callback that calls `deps.SetConfig` to propagate reloaded config
- **Tests**: `config_reload_test.go` verifies list, feed, and sitemap handlers serve updated values after `SetConfig`

All existing tests pass with `-race`. No new lint issues.