### PR TITLE
fix: update codeql-action to v4 and make SARIF upload non-blocking

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,7 +84,8 @@ jobs:
           exit-code: '0'
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
+        continue-on-error: true
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,8 @@ jobs:
           exit-code: '0'
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
+        continue-on-error: true
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Problem
The v0.2.0 release workflow failed at step 13 "Upload Trivy scan results". Both Trivy vulnerability scans **passed** (no CRITICAL/HIGH CVEs) — the failure was in the `github/codeql-action/upload-sarif@v3` SARIF upload to the GitHub Security tab.

v3 of codeql-action is deprecated and failing.

## Fix
1. Updated `github/codeql-action/upload-sarif` from **v3 → v4** in both `release.yml` and `publish.yml`
2. Added `continue-on-error: true` so SARIF upload failures don't block releases (the upload is informational — the actual vulnerability gate is the Trivy exit-code step)

## Note
The v0.2.0 container image **was successfully pushed to GHCR** — the failure was post-push. After this merges, re-tag v0.2.0 to pick up the fix for future releases.