### PR TITLE
feat: add GitHub Pages landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,427 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BlogFlow — Git-driven blog engine</title>
+  <meta name="description" content="Compact Go blog engine — git-driven content, overlay filesystem, distroless container. Just add markdown.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #0a0a0b;
+      --surface: #141416;
+      --border: #27272a;
+      --text: #fafafa;
+      --muted: #a1a1aa;
+      --accent: #2563eb;
+      --accent-dim: rgba(37, 99, 235, 0.1);
+      --green: #4ade80;
+      --mono: 'JetBrains Mono', monospace;
+      --sans: 'Inter', -apple-system, sans-serif;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: var(--sans);
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    /* Hero */
+    .hero {
+      min-height: 90vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+      text-align: center;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .hero::before {
+      content: '';
+      position: absolute;
+      top: -50%;
+      left: -50%;
+      width: 200%;
+      height: 200%;
+      background: radial-gradient(ellipse at 50% 50%, var(--accent-dim) 0%, transparent 50%);
+      animation: pulse 8s ease-in-out infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 0.3; transform: scale(1); }
+      50% { opacity: 0.6; transform: scale(1.1); }
+    }
+
+    .hero-content { position: relative; z-index: 1; max-width: 720px; }
+
+    .logo {
+      font-family: var(--mono);
+      font-size: clamp(2.5rem, 6vw, 4rem);
+      font-weight: 700;
+      letter-spacing: -0.03em;
+      margin-bottom: 0.5rem;
+    }
+
+    .logo .dot { color: var(--accent); }
+
+    .tagline {
+      font-size: clamp(1.1rem, 2.5vw, 1.35rem);
+      color: var(--muted);
+      margin-bottom: 0.5rem;
+      font-weight: 400;
+    }
+
+    .subtitle {
+      font-size: clamp(1rem, 2vw, 1.15rem);
+      color: var(--text);
+      font-weight: 500;
+      margin-bottom: 2.5rem;
+      font-family: var(--mono);
+      opacity: 0.8;
+    }
+
+    .install-box {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1rem 1.5rem;
+      font-family: var(--mono);
+      font-size: 0.95rem;
+      display: inline-flex;
+      align-items: center;
+      gap: 1rem;
+      margin-bottom: 2rem;
+      cursor: pointer;
+      transition: border-color 0.2s;
+    }
+
+    .install-box:hover { border-color: var(--accent); }
+
+    .install-box code { color: var(--text); }
+    .install-box .prompt { color: var(--muted); user-select: none; }
+    .install-box .copy {
+      color: var(--muted);
+      font-size: 0.75rem;
+      font-family: var(--sans);
+      user-select: none;
+    }
+
+    .hero-links {
+      display: flex;
+      gap: 1rem;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.65rem 1.5rem;
+      border-radius: 8px;
+      font-size: 0.9rem;
+      font-weight: 500;
+      text-decoration: none;
+      transition: all 0.2s;
+    }
+
+    .btn-primary {
+      background: var(--accent);
+      color: var(--text);
+    }
+    .btn-primary:hover { opacity: 0.85; transform: translateY(-1px); }
+
+    .btn-ghost {
+      border: 1px solid var(--border);
+      color: var(--text);
+    }
+    .btn-ghost:hover { border-color: var(--muted); background: var(--surface); }
+
+    /* Metrics bar */
+    .metrics {
+      max-width: 720px;
+      margin: 0 auto 4rem;
+      padding: 0 2rem;
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 1.5rem;
+      text-align: center;
+    }
+
+    .metric-value {
+      font-family: var(--mono);
+      font-size: 2rem;
+      font-weight: 700;
+      color: var(--accent);
+    }
+
+    .metric-label {
+      font-size: 0.85rem;
+      color: var(--muted);
+      margin-top: 0.25rem;
+    }
+
+    /* Features */
+    .features {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 6rem 2rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 2rem;
+    }
+
+    .feature {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1.75rem;
+      transition: border-color 0.2s;
+    }
+
+    .feature:hover { border-color: var(--accent); }
+
+    .feature-icon {
+      font-size: 1.5rem;
+      margin-bottom: 0.75rem;
+      display: block;
+    }
+
+    .feature h3 {
+      font-size: 1.05rem;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+    }
+
+    .feature p {
+      color: var(--muted);
+      font-size: 0.9rem;
+      line-height: 1.5;
+    }
+
+    /* Code examples */
+    .examples {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 0 2rem 6rem;
+    }
+
+    .examples h2 {
+      text-align: center;
+      font-size: 1.75rem;
+      margin-bottom: 2.5rem;
+      font-weight: 600;
+    }
+
+    .code-block {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+      margin-bottom: 2rem;
+    }
+
+    .code-block-header {
+      padding: 0.75rem 1.25rem;
+      font-size: 0.8rem;
+      font-weight: 500;
+      color: var(--muted);
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .code-block-header .dot-r { width: 8px; height: 8px; border-radius: 50%; background: #ef4444; }
+    .code-block-header .dot-y { width: 8px; height: 8px; border-radius: 50%; background: #eab308; }
+    .code-block-header .dot-g { width: 8px; height: 8px; border-radius: 50%; background: #22c55e; }
+
+    .code-block pre {
+      padding: 1.25rem;
+      font-family: var(--mono);
+      font-size: 0.85rem;
+      line-height: 1.7;
+      overflow-x: auto;
+      color: var(--muted);
+    }
+
+    .code-block pre .kw { color: #c084fc; }
+    .code-block pre .type { color: var(--accent); }
+    .code-block pre .str { color: #f9a8d4; }
+    .code-block pre .comment { color: #52525b; }
+    .code-block pre .fn { color: #fbbf24; }
+    .code-block pre .val { color: var(--green); }
+
+    /* Footer */
+    footer {
+      border-top: 1px solid var(--border);
+      padding: 2rem;
+      text-align: center;
+      color: var(--muted);
+      font-size: 0.85rem;
+    }
+
+    footer a { color: var(--accent); text-decoration: none; }
+    footer a:hover { text-decoration: underline; }
+
+    @media (max-width: 600px) {
+      .metrics { grid-template-columns: repeat(2, 1fr); gap: 1rem; }
+      .install-box { font-size: 0.8rem; padding: 0.75rem 1rem; }
+    }
+  </style>
+</head>
+<body>
+
+  <section class="hero">
+    <div class="hero-content">
+      <h1 class="logo">BlogFlow<span class="dot">.</span></h1>
+      <p class="tagline">Compact Go blog engine — git-driven content, overlay filesystem, distroless container.</p>
+      <p class="subtitle">Just add markdown.</p>
+
+      <div class="install-box" onclick="navigator.clipboard.writeText('docker pull ghcr.io/khaines/blogflow:latest')">
+        <span class="prompt">$</span>
+        <code>docker pull ghcr.io/khaines/blogflow:latest</code>
+        <span class="copy">click to copy</span>
+      </div>
+
+      <div class="hero-links">
+        <a href="https://github.com/khaines/blogflow" class="btn btn-primary">
+          View on GitHub
+        </a>
+        <a href="https://github.com/khaines/blogflow/blob/main/docs/deployment-guide.md" class="btn btn-ghost">
+          Read the Docs
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <div class="metrics">
+    <div>
+      <div class="metric-value">~18 MB</div>
+      <div class="metric-label">binary size</div>
+    </div>
+    <div>
+      <div class="metric-value">&lt; 25 MB</div>
+      <div class="metric-label">container image</div>
+    </div>
+    <div>
+      <div class="metric-value">&lt; 100 ms</div>
+      <div class="metric-label">startup time</div>
+    </div>
+    <div>
+      <div class="metric-value">0</div>
+      <div class="metric-label">config required</div>
+    </div>
+  </div>
+
+  <section class="features">
+    <div class="feature">
+      <span class="feature-icon">📝</span>
+      <h3>Git-Driven Content</h3>
+      <p>Push markdown to a git repo. BlogFlow syncs and serves. No build step.</p>
+    </div>
+    <div class="feature">
+      <span class="feature-icon">🧅</span>
+      <h3>Overlay Filesystem</h3>
+      <p>Theme → content → config → embedded defaults. First match wins. Override anything.</p>
+    </div>
+    <div class="feature">
+      <span class="feature-icon">🔒</span>
+      <h3>Distroless Container</h3>
+      <p>Nonroot (UID 65532), read-only root FS, no shell, no package manager.</p>
+    </div>
+    <div class="feature">
+      <span class="feature-icon">📡</span>
+      <h3>Four Sync Strategies</h3>
+      <p>Watch (dev), webhook (instant), sidecar (K8s), poll (HA). Pick what fits.</p>
+    </div>
+    <div class="feature">
+      <span class="feature-icon">📊</span>
+      <h3>Prometheus Metrics</h3>
+      <p>RED metrics, overlay FS counters, Grafana dashboard included.</p>
+    </div>
+    <div class="feature">
+      <span class="feature-icon">⚙️</span>
+      <h3>Runtime Config Reload</h3>
+      <p>Update site.yaml, BlogFlow picks it up. Zero-downtime reconfiguration.</p>
+    </div>
+  </section>
+
+  <section class="examples">
+    <h2>Get started in seconds</h2>
+
+    <div class="code-block">
+      <div class="code-block-header">
+        <span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span>
+        &nbsp; Run with Docker
+      </div>
+      <pre><span class="comment"># A working blog with embedded sample content</span>
+<span class="fn">docker</span> run <span class="kw">-p</span> <span class="val">8080:8080</span> ghcr.io/khaines/blogflow:latest</pre>
+    </div>
+
+    <div class="code-block">
+      <div class="code-block-header">
+        <span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span>
+        &nbsp; Add Your Content
+      </div>
+      <pre><span class="comment"># docker-compose.yaml</span>
+<span class="type">services</span>:
+  <span class="type">blogflow</span>:
+    <span class="kw">image</span>: ghcr.io/khaines/blogflow:latest
+    <span class="kw">ports</span>:
+      - <span class="str">"8080:8080"</span>
+    <span class="kw">volumes</span>:
+      - <span class="str">./content:/data/content:ro</span></pre>
+    </div>
+
+    <div class="code-block">
+      <div class="code-block-header">
+        <span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span>
+        &nbsp; Deploy to Kubernetes
+      </div>
+      <pre><span class="comment"># Install with Helm — sidecar, webhook, or watch strategy</span>
+<span class="fn">helm</span> install blogflow deploy/helm/blogflow/
+
+<span class="comment"># Or apply plain manifests</span>
+<span class="fn">kubectl</span> apply <span class="kw">-f</span> examples/k8s/sidecar/</pre>
+    </div>
+
+    <div class="code-block">
+      <div class="code-block-header">
+        <span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span>
+        &nbsp; Configure
+      </div>
+      <pre><span class="comment"># site.yaml — only override what you need</span>
+<span class="type">site</span>:
+  <span class="kw">title</span>: <span class="str">"My Blog"</span>
+  <span class="kw">base_url</span>: <span class="str">"https://blog.example.com"</span>
+  <span class="kw">description</span>: <span class="str">"Thoughts on code and craft"</span>
+
+<span class="type">sync</span>:
+  <span class="kw">strategy</span>: <span class="val">webhook</span>
+
+<span class="type">cache</span>:
+  <span class="kw">enabled</span>: <span class="val">true</span></pre>
+    </div>
+  </section>
+
+  <footer>
+    <p>
+      Apache 2.0 License ·
+      <a href="https://github.com/khaines/blogflow">GitHub</a> ·
+      <a href="https://github.com/khaines/blogflow/pkgs/container/blogflow">Container Registry</a> ·
+      <a href="https://github.com/khaines/blogflow/blob/main/docs/deployment-guide.md">Documentation</a>
+    </p>
+  </footer>
+
+</body>
+</html>


### PR DESCRIPTION
Single-page dark minimalist landing page for GitHub Pages, following the logfmt.net design approach.

## What
- `docs/index.html` — 427-line self-contained HTML5 page with inline CSS
- Dark minimalist design with JetBrains Mono + Inter fonts
- Pulsing gradient hero, feature cards grid, macOS window-chrome code blocks
- Responsive layout with @media breakpoint
- No external CSS files, no JavaScript frameworks

## Sections
1. **Hero** — logo, tagline, docker pull install box, CTA buttons
2. **Metrics bar** — binary size, container size, startup time, zero config
3. **Features grid** — 6 cards covering git-driven content, overlay FS, distroless, sync strategies, Prometheus, runtime reload
4. **Quick start code blocks** — Docker, Docker Compose, Helm/kubectl, site.yaml config
5. **Footer** — license, GitHub, container registry, docs links

## Color scheme
BlogFlow blue (`#2563eb`) accent on dark `#0a0a0b` background.