### PR TITLE
fix: update landing page — title, tagline, metrics

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>BlogFlow — Git-driven blog engine</title>
-  <meta name="description" content="Compact Go blog engine — git-driven content, overlay filesystem, distroless container. Just add markdown.">
+  <title>blogflow.io — Git-driven blog engine</title>
+  <meta name="description" content="Compact Go blog engine — git-driven content, distroless container. Just add markdown.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -284,7 +284,7 @@
   <section class="hero">
     <div class="hero-content">
       <h1 class="logo">BlogFlow<span class="dot">.</span></h1>
-      <p class="tagline">Compact Go blog engine — git-driven content, overlay filesystem, distroless container.</p>
+      <p class="tagline">Compact Go blog engine — git-driven content, distroless container.</p>
       <p class="subtitle">Just add markdown.</p>
 
       <div class="install-box" onclick="navigator.clipboard.writeText('docker pull ghcr.io/khaines/blogflow:latest')">
@@ -316,10 +316,6 @@
     <div>
       <div class="metric-value">&lt; 100 ms</div>
       <div class="metric-label">startup time</div>
-    </div>
-    <div>
-      <div class="metric-value">0</div>
-      <div class="metric-label">config required</div>
     </div>
   </div>
 


### PR DESCRIPTION
- Title: `blogflow.io`
- Tagline: shortened to "Compact Go blog engine — git-driven content, distroless container."
- Metrics bar: removed "0 config required" stat (now 3 metrics)