### PR TITLE
feat: add separate metrics listener port

### DIFF
--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -245,6 +245,7 @@ func main() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
+		// Shutdown shuts down both the main and metrics servers.
 		if err := srv.Shutdown(ctx); err != nil {
 			logger.Error("shutdown error", "error", err)
 		}
@@ -256,6 +257,12 @@ func main() {
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- srv.Start()
+	}()
+
+	// Start metrics server on dedicated port (no-op when MetricsPort == 0).
+	metricsErrCh := make(chan error, 1)
+	go func() {
+		metricsErrCh <- srv.StartMetrics()
 	}()
 
 	// Wait for listener to bind or an immediate failure
@@ -274,6 +281,10 @@ func main() {
 	// Wait for server to finish (shutdown or error)
 	if err := <-errCh; err != nil {
 		logger.Error("server error", "error", err)
+		os.Exit(1)
+	}
+	if err := <-metricsErrCh; err != nil {
+		logger.Error("metrics server error", "error", err)
 		os.Exit(1)
 	}
 	logger.Info("server stopped")

--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -278,14 +278,25 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Wait for server to finish (shutdown or error)
-	if err := <-errCh; err != nil {
-		logger.Error("server error", "error", err)
-		os.Exit(1)
-	}
-	if err := <-metricsErrCh; err != nil {
-		logger.Error("metrics server error", "error", err)
-		os.Exit(1)
+	// Wait for both servers to finish (shutdown or error).
+	// Using a select ensures that a metrics-server failure (e.g. port
+	// conflict) is detected immediately rather than going unnoticed until
+	// the main server shuts down.
+	for errCh != nil || metricsErrCh != nil {
+		select {
+		case err := <-errCh:
+			errCh = nil
+			if err != nil {
+				logger.Error("server error", "error", err)
+				os.Exit(1)
+			}
+		case err := <-metricsErrCh:
+			metricsErrCh = nil
+			if err != nil {
+				logger.Error("metrics server error", "error", err)
+				os.Exit(1)
+			}
+		}
 	}
 	logger.Info("server stopped")
 }

--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -265,10 +265,22 @@ func main() {
 		metricsErrCh <- srv.StartMetrics()
 	}()
 
+	// metricsStartCh mirrors metricsErrCh only when a separate metrics
+	// port is configured.  A nil channel is never selected, so the
+	// readiness select below naturally ignores it when MetricsPort == 0
+	// (where StartMetrics returns nil immediately).
+	var metricsStartCh <-chan error
+	if cfg.Server.MetricsPort > 0 {
+		metricsStartCh = metricsErrCh
+	}
+
 	// Wait for listener to bind or an immediate failure
 	select {
 	case err := <-errCh:
 		logger.Error("server failed to start", "error", err)
+		os.Exit(1)
+	case err := <-metricsStartCh:
+		logger.Error("metrics server failed to start", "error", err)
 		os.Exit(1)
 	case <-srv.Ready():
 		srv.SetReady(true)

--- a/deploy/helm/blogflow/templates/configmap.yaml
+++ b/deploy/helm/blogflow/templates/configmap.yaml
@@ -6,4 +6,8 @@ metadata:
     {{- include "blogflow.labels" . | nindent 4 }}
 data:
   site.yaml: |
-    {{- .Values.siteConfig | toYaml | nindent 4 }}
+    {{- $config := deepCopy .Values.siteConfig -}}
+    {{- if and .Values.service.metricsPort (gt (int .Values.service.metricsPort) 0) -}}
+      {{- $_ := set $config.server "metrics_port" (int .Values.service.metricsPort) -}}
+    {{- end }}
+    {{- $config | toYaml | nindent 4 }}

--- a/deploy/helm/blogflow/templates/deployment.yaml
+++ b/deploy/helm/blogflow/templates/deployment.yaml
@@ -38,6 +38,11 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            {{- if and .Values.service.metricsPort (gt (int .Values.service.metricsPort) 0) }}
+            - name: metrics
+              containerPort: {{ .Values.service.metricsPort }}
+              protocol: TCP
+            {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- /* NOTE: BlogFlow currently reads the webhook secret from the

--- a/deploy/helm/blogflow/templates/service.yaml
+++ b/deploy/helm/blogflow/templates/service.yaml
@@ -11,5 +11,11 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if and .Values.service.metricsPort (gt (int .Values.service.metricsPort) 0) }}
+    - port: {{ .Values.service.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    {{- end }}
   selector:
     {{- include "blogflow.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/blogflow/values.yaml
+++ b/deploy/helm/blogflow/values.yaml
@@ -74,6 +74,8 @@ siteConfig:
     name: default
   server:
     port: 8080
+    # -- Dedicated metrics port (0 = serve metrics on main port)
+    # metrics_port: 9090
     read_timeout: 5s
     write_timeout: 10s
     idle_timeout: 120s
@@ -99,6 +101,8 @@ service:
   type: ClusterIP
   # -- Service port
   port: 8080
+  # -- Dedicated metrics port (0 = disabled, metrics served on main port)
+  metricsPort: 0
 
 ingress:
   # -- Enable ingress resource

--- a/examples/config/site.yaml
+++ b/examples/config/site.yaml
@@ -53,6 +53,11 @@ theme:
 # ---------------------------------------------------------------------------
 server:
   port: 8080                  # Listen port (1–65535). Override: BLOGFLOW_SERVER_PORT
+  # metrics_port: 9090        # Dedicated metrics port (1–65535, must differ from port).
+                              # When set, /metrics and /healthz are served on this port
+                              # only — the main port has no /metrics endpoint.
+                              # Set to 0 (default) to serve metrics on the main port.
+                              # Override: BLOGFLOW_SERVER_METRICS_PORT
   read_timeout: "5s"          # Max time to read request (Go duration)
   write_timeout: "10s"        # Max time to write response
   idle_timeout: "120s"        # Max time for idle keep-alive connections

--- a/examples/config/site.yaml
+++ b/examples/config/site.yaml
@@ -54,8 +54,9 @@ theme:
 server:
   port: 8080                  # Listen port (1–65535). Override: BLOGFLOW_SERVER_PORT
   # metrics_port: 9090        # Dedicated metrics port (1–65535, must differ from port).
-                              # When set, /metrics and /healthz are served on this port
-                              # only — the main port has no /metrics endpoint.
+                              # When set, /metrics is served on this port only — the
+                              # main port has no /metrics endpoint.  /healthz remains
+                              # available on both ports.
                               # Set to 0 (default) to serve metrics on the main port.
                               # Override: BLOGFLOW_SERVER_METRICS_PORT
   read_timeout: "5s"          # Max time to read request (Go duration)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,7 @@ type ThemeConfig struct {
 // ServerConfig holds HTTP server settings.
 type ServerConfig struct {
 	Port              int           `yaml:"port"`
+	MetricsPort       int           `yaml:"metrics_port"`
 	ReadTimeout       time.Duration `yaml:"read_timeout"`
 	WriteTimeout      time.Duration `yaml:"write_timeout"`
 	IdleTimeout       time.Duration `yaml:"idle_timeout"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -966,3 +966,79 @@ func TestIsSecretError_WrappedError(t *testing.T) {
 		t.Error("isSecretError should find SecretInYAMLError via errors.As on wrapped errors")
 	}
 }
+
+// --- Validate: metrics_port ---
+
+func TestValidate_MetricsPort_Zero_Valid(t *testing.T) {
+	cfg := Default()
+	cfg.Server.MetricsPort = 0
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+}
+
+func TestValidate_MetricsPort_Valid(t *testing.T) {
+	cfg := Default()
+	cfg.Server.MetricsPort = 9090
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+}
+
+func TestValidate_MetricsPort_SameAsPort(t *testing.T) {
+	cfg := Default()
+	cfg.Server.MetricsPort = cfg.Server.Port
+
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected validation error when metrics_port == port")
+	}
+	cfgErr, ok := err.(*ConfigError)
+	if !ok {
+		t.Fatalf("expected *ConfigError, got %T", err)
+	}
+	found := false
+	for _, fe := range cfgErr.Errors {
+		if fe.Field == "server.metrics_port" && strings.Contains(fe.Message, "different") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected server.metrics_port field error about being different from port")
+	}
+}
+
+func TestValidate_MetricsPort_OutOfRange(t *testing.T) {
+	tests := []struct {
+		name string
+		port int
+	}{
+		{"negative", -1},
+		{"too high", 99999},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Default()
+			cfg.Server.MetricsPort = tt.port
+			err := Validate(cfg)
+			if err == nil {
+				t.Fatal("expected validation error for invalid metrics_port")
+			}
+			cfgErr, ok := err.(*ConfigError)
+			if !ok {
+				t.Fatalf("expected *ConfigError, got %T", err)
+			}
+			found := false
+			for _, fe := range cfgErr.Errors {
+				if fe.Field == "server.metrics_port" {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Error("expected server.metrics_port field error")
+			}
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -978,10 +978,22 @@ func TestValidate_MetricsPort_Zero_Valid(t *testing.T) {
 }
 
 func TestValidate_MetricsPort_Valid(t *testing.T) {
-	cfg := Default()
-	cfg.Server.MetricsPort = 9090
-	if err := Validate(cfg); err != nil {
-		t.Fatalf("unexpected validation error: %v", err)
+	tests := []struct {
+		name string
+		port int
+	}{
+		{"typical", 9090},
+		{"min valid", 1},
+		{"max valid", 65535},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Default()
+			cfg.Server.MetricsPort = tt.port
+			if err := Validate(cfg); err != nil {
+				t.Fatalf("unexpected validation error for port %d: %v", tt.port, err)
+			}
+		})
 	}
 }
 
@@ -1015,6 +1027,7 @@ func TestValidate_MetricsPort_OutOfRange(t *testing.T) {
 		port int
 	}{
 		{"negative", -1},
+		{"boundary too high", 65536},
 		{"too high", 99999},
 	}
 	for _, tt := range tests {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -397,6 +397,14 @@ var envMap = map[string]func(*Config, string) error{
 		c.Server.HSTSMaxAge = n
 		return nil
 	},
+	"BLOGFLOW_SERVER_METRICS_PORT": func(c *Config, v string) error {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("cannot parse env var BLOGFLOW_SERVER_METRICS_PORT as int: %w", err)
+		}
+		c.Server.MetricsPort = n
+		return nil
+	},
 }
 
 // secretEnvVars identifies env vars that should be redacted in logs.
@@ -452,6 +460,24 @@ func Validate(cfg *Config) error {
 			Value:   cfg.Server.Port,
 			Message: "must be between 1 and 65535",
 		})
+	}
+
+	// Server.MetricsPort: 0 = disabled (metrics on main port); 1-65535 = separate listener
+	if cfg.Server.MetricsPort != 0 {
+		if cfg.Server.MetricsPort < 1 || cfg.Server.MetricsPort > 65535 {
+			errs = append(errs, FieldError{
+				Field:   "server.metrics_port",
+				Value:   cfg.Server.MetricsPort,
+				Message: "must be between 1 and 65535",
+			})
+		}
+		if cfg.Server.MetricsPort == cfg.Server.Port {
+			errs = append(errs, FieldError{
+				Field:   "server.metrics_port",
+				Value:   cfg.Server.MetricsPort,
+				Message: "must be different from server.port",
+			})
+		}
 	}
 
 	// Server timeouts: must be > 0

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -201,19 +201,29 @@ func (s *Server) Serve(ln net.Listener) error {
 }
 
 // Shutdown gracefully stops the server with the given context deadline.
-// If a separate metrics server is running, it is shut down as well.
+// If a separate metrics server is running, both servers are shut down
+// concurrently so that one cannot consume the other's timeout budget.
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.logger.Info("server shutting down")
-	var errs []error
+
+	var metricsErr error
+	var wg sync.WaitGroup
 	if s.metricsServer != nil {
-		if err := s.metricsServer.Shutdown(ctx); err != nil {
-			errs = append(errs, fmt.Errorf("metrics server: %w", err))
-		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := s.metricsServer.Shutdown(ctx); err != nil {
+				metricsErr = fmt.Errorf("metrics server: %w", err)
+			}
+		}()
 	}
+
+	var mainErr error
 	if err := s.httpServer.Shutdown(ctx); err != nil {
-		errs = append(errs, fmt.Errorf("main server: %w", err))
+		mainErr = fmt.Errorf("main server: %w", err)
 	}
-	return errors.Join(errs...)
+	wg.Wait()
+	return errors.Join(mainErr, metricsErr)
 }
 
 // StartMetrics starts the metrics server on its dedicated port.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -76,7 +76,7 @@ func New(cfg *config.Config, logger *slog.Logger) *Server {
 		metricsMux.HandleFunc("GET /healthz", s.healthHandler)
 		s.metricsServer = &http.Server{
 			Addr:              fmt.Sprintf(":%d", cfg.Server.MetricsPort),
-			Handler:           metricsMux,
+			Handler:           s.recoveryMiddleware(metricsMux),
 			ReadTimeout:       cfg.Server.ReadTimeout,
 			ReadHeaderTimeout: 5 * time.Second,
 			WriteTimeout:      cfg.Server.WriteTimeout,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,6 +4,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -27,6 +28,7 @@ type ContentChecker interface {
 // Server is the BlogFlow HTTP server.
 type Server struct {
 	httpServer     *http.Server
+	metricsServer  *http.Server // nil when MetricsPort == 0
 	mux            *http.ServeMux
 	config         *config.Config
 	logger         *slog.Logger
@@ -66,6 +68,20 @@ func New(cfg *config.Config, logger *slog.Logger) *Server {
 		ReadHeaderTimeout: 5 * time.Second,
 		WriteTimeout:      cfg.Server.WriteTimeout,
 		IdleTimeout:       cfg.Server.IdleTimeout,
+	}
+
+	if cfg.Server.MetricsPort > 0 {
+		metricsMux := http.NewServeMux()
+		metricsMux.Handle("GET /metrics", MetricsHandler())
+		metricsMux.HandleFunc("GET /healthz", s.healthHandler)
+		s.metricsServer = &http.Server{
+			Addr:              fmt.Sprintf(":%d", cfg.Server.MetricsPort),
+			Handler:           metricsMux,
+			ReadTimeout:       cfg.Server.ReadTimeout,
+			ReadHeaderTimeout: 5 * time.Second,
+			WriteTimeout:      cfg.Server.WriteTimeout,
+			IdleTimeout:       cfg.Server.IdleTimeout,
+		}
 	}
 
 	return s
@@ -126,8 +142,10 @@ func (s *Server) RegisterRoutes(opts RouteOptions) {
 	s.mux.HandleFunc("GET /readyz", s.readyHandler)
 	s.mux.HandleFunc("GET /readyz/content", s.contentReadyHandler)
 
-	// Prometheus metrics (registered directly on the mux, outside metrics middleware)
-	s.mux.Handle("GET /metrics", MetricsHandler())
+	// Prometheus metrics: on main mux only when no separate metrics port is configured
+	if s.config.Server.MetricsPort == 0 {
+		s.mux.Handle("GET /metrics", MetricsHandler())
+	}
 
 	// Static assets
 	if opts.StaticFS != nil {
@@ -183,9 +201,44 @@ func (s *Server) Serve(ln net.Listener) error {
 }
 
 // Shutdown gracefully stops the server with the given context deadline.
+// If a separate metrics server is running, it is shut down as well.
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.logger.Info("server shutting down")
-	return s.httpServer.Shutdown(ctx)
+	var errs []error
+	if s.metricsServer != nil {
+		if err := s.metricsServer.Shutdown(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("metrics server: %w", err))
+		}
+	}
+	if err := s.httpServer.Shutdown(ctx); err != nil {
+		errs = append(errs, fmt.Errorf("main server: %w", err))
+	}
+	return errors.Join(errs...)
+}
+
+// StartMetrics starts the metrics server on its dedicated port.
+// Returns nil immediately if no separate metrics port is configured.
+// Blocks until the metrics server stops.
+func (s *Server) StartMetrics() error {
+	if s.metricsServer == nil {
+		return nil
+	}
+	addr := s.metricsServer.Addr
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("metrics server: %w", err)
+	}
+	s.logger.Info("metrics server listening", "addr", ln.Addr().String())
+	if err := s.metricsServer.Serve(ln); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("metrics server: %w", err)
+	}
+	return nil
+}
+
+// MetricsServer returns the dedicated metrics *http.Server, or nil
+// if metrics are served on the main port.
+func (s *Server) MetricsServer() *http.Server {
+	return s.metricsServer
 }
 
 // middleware chains standard middleware: request-ID, logging, security headers, recovery, metrics.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -746,9 +746,6 @@ func TestMetricsNotOnMainPort_WhenSeparatePort(t *testing.T) {
 
 func TestMetricsOnSeparatePort(t *testing.T) {
 	cfg := defaultTestConfig()
-	cfg.Server.MetricsPort = 0 // will pick a free port via listener
-
-	// Manually set MetricsPort to something non-zero to trigger separate server creation
 	cfg.Server.MetricsPort = 19091
 
 	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -705,3 +705,165 @@ func TestReadyChannel_NotClosedBeforeStart(t *testing.T) {
 		// expected — channel is still open
 	}
 }
+
+// --- Metrics port tests ---
+
+func TestMetricsOnMainPort_Default(t *testing.T) {
+	// When MetricsPort is 0 (default), /metrics should be registered on the main mux.
+	s := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "go_goroutines") {
+		t.Error("expected prometheus metrics in response body")
+	}
+}
+
+func TestMetricsNotOnMainPort_WhenSeparatePort(t *testing.T) {
+	cfg := defaultTestConfig()
+	cfg.Server.MetricsPort = 9090
+
+	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	s.RegisterRoutes(testRouteOptions())
+
+	// /metrics should NOT be on the main mux
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	// Go 1.22 ServeMux returns 405 for unmatched method or 404 for unmatched path.
+	// /metrics is not registered, so we expect 404 or 405 — definitely not 200.
+	if rec.Code == http.StatusOK {
+		t.Error("expected /metrics NOT to be on main mux when MetricsPort is set")
+	}
+}
+
+func TestMetricsOnSeparatePort(t *testing.T) {
+	cfg := defaultTestConfig()
+	cfg.Server.MetricsPort = 0 // will pick a free port via listener
+
+	// Manually set MetricsPort to something non-zero to trigger separate server creation
+	cfg.Server.MetricsPort = 19091
+
+	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	s.RegisterRoutes(testRouteOptions())
+
+	if s.MetricsServer() == nil {
+		t.Fatal("MetricsServer() should not be nil when MetricsPort > 0")
+	}
+
+	// Start the metrics server on a random port
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.metricsServer.Serve(ln)
+	}()
+
+	// Request /metrics on the metrics listener
+	resp, err := http.Get(fmt.Sprintf("http://%s/metrics", ln.Addr().String()))
+	if err != nil {
+		t.Fatalf("failed to GET /metrics: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("/metrics status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	// Shut down metrics server
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := s.metricsServer.Shutdown(ctx); err != nil {
+		t.Fatalf("metrics server shutdown error: %v", err)
+	}
+	if err := <-errCh; err != nil && err != http.ErrServerClosed {
+		t.Fatalf("metrics server returned unexpected error: %v", err)
+	}
+}
+
+func TestHealthzOnMetricsPort(t *testing.T) {
+	cfg := defaultTestConfig()
+	cfg.Server.MetricsPort = 19092
+
+	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	s.RegisterRoutes(testRouteOptions())
+
+	// Start metrics server on a random port
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.metricsServer.Serve(ln)
+	}()
+
+	// /healthz should be available on the metrics port
+	resp, err := http.Get(fmt.Sprintf("http://%s/healthz", ln.Addr().String()))
+	if err != nil {
+		t.Fatalf("failed to GET /healthz: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("/healthz on metrics port: status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	body := make([]byte, 64)
+	n, _ := resp.Body.Read(body)
+	if got := string(body[:n]); got != "ok" {
+		t.Errorf("/healthz body = %q, want %q", got, "ok")
+	}
+
+	// /healthz should also still be on the main port
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("/healthz on main port: status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := s.metricsServer.Shutdown(ctx); err != nil {
+		t.Fatalf("metrics server shutdown error: %v", err)
+	}
+	if err := <-errCh; err != nil && err != http.ErrServerClosed {
+		t.Fatalf("metrics server returned unexpected error: %v", err)
+	}
+}
+
+func TestMetricsServer_NilWhenPortZero(t *testing.T) {
+	cfg := defaultTestConfig()
+	cfg.Server.MetricsPort = 0
+
+	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	if s.MetricsServer() != nil {
+		t.Error("MetricsServer() should be nil when MetricsPort is 0")
+	}
+}
+
+func TestStartMetrics_NilWhenPortZero(t *testing.T) {
+	cfg := defaultTestConfig()
+	cfg.Server.MetricsPort = 0
+
+	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	// StartMetrics should return nil immediately when no metrics server
+	if err := s.StartMetrics(); err != nil {
+		t.Errorf("StartMetrics() = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## Summary

When `server.metrics_port` is set (1–65535), BlogFlow serves `/metrics` and `/healthz` on a dedicated port not exposed to public traffic. Prometheus scrapes the internal port; the main port has no `/metrics` endpoint.

When `metrics_port` is 0 (default), behavior is unchanged — metrics are served on the main port.

## Changes

- **Config**: Added `MetricsPort` to `ServerConfig` (yaml: `metrics_port`, env: `BLOGFLOW_SERVER_METRICS_PORT`)
- **Validation**: Must be 1–65535 and different from main port (when set)
- **Server**: Creates a second `http.Server` with its own mux (`/metrics` + `/healthz`) when `MetricsPort > 0`
- **Graceful shutdown**: Both servers shut down together
- **main.go**: Wired metrics server lifecycle (start after main, shutdown together)
- **Helm**: Added `service.metricsPort` to values, Service template, and Deployment template
- **Tests**: 8 new tests covering default behavior, separate port, healthz on both ports, validation

## Security

Separating the metrics endpoint from public traffic prevents information disclosure through Prometheus metrics.