### PR TITLE
feat: add OTel spans to ContextOverlayFS operations

### DIFF
--- a/internal/overlayfs/context.go
+++ b/internal/overlayfs/context.go
@@ -6,6 +6,11 @@ import (
 	"io/fs"
 	"log/slog"
 	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // contextKey is an unexported type for context keys defined in this package,
@@ -24,6 +29,10 @@ const (
 
 // resolutionKey is a distinct unexported type for the Resolution context key.
 type resolutionContextKey struct{}
+
+// tracer is the package-level OpenTelemetry tracer for ContextOverlayFS.
+// Obtained from the global provider on each call to support test swapping.
+const tracerName = "github.com/khaines/blogflow/internal/overlayfs"
 
 // ContextOverlayFS wraps OverlayFS with context.Context support for
 // cancellation, tracing, and security log correlation. This is the
@@ -70,8 +79,15 @@ func (c *ContextOverlayFS) Open(ctx context.Context, name string) (fs.File, erro
 		return nil, fmt.Errorf("overlayfs: open %q: %w", name, err)
 	}
 
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "overlayfs.open", trace.WithAttributes(
+		attribute.String("path", name),
+	))
+	defer span.End()
+
 	start := time.Now()
 	f, err := c.inner.Open(name)
+	c.recordResolution(ctx, span, name)
+	c.finishSpan(span, err)
 	c.logOperation(ctx, "open", name, start, err)
 	return f, err
 }
@@ -85,8 +101,15 @@ func (c *ContextOverlayFS) ReadFile(ctx context.Context, name string) ([]byte, e
 		return nil, fmt.Errorf("overlayfs: readfile %q: %w", name, err)
 	}
 
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "overlayfs.readfile", trace.WithAttributes(
+		attribute.String("path", name),
+	))
+	defer span.End()
+
 	start := time.Now()
 	data, err := c.inner.ReadFile(name)
+	c.recordResolution(ctx, span, name)
+	c.finishSpan(span, err)
 	c.logOperation(ctx, "readfile", name, start, err)
 	return data, err
 }
@@ -100,8 +123,14 @@ func (c *ContextOverlayFS) ReadDir(ctx context.Context, name string) ([]fs.DirEn
 		return nil, fmt.Errorf("overlayfs: readdir %q: %w", name, err)
 	}
 
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "overlayfs.readdir", trace.WithAttributes(
+		attribute.String("path", name),
+	))
+	defer span.End()
+
 	start := time.Now()
 	entries, err := c.inner.ReadDir(name)
+	c.finishSpan(span, err)
 	c.logOperation(ctx, "readdir", name, start, err)
 	return entries, err
 }
@@ -115,8 +144,15 @@ func (c *ContextOverlayFS) Stat(ctx context.Context, name string) (fs.FileInfo, 
 		return nil, fmt.Errorf("overlayfs: stat %q: %w", name, err)
 	}
 
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "overlayfs.stat", trace.WithAttributes(
+		attribute.String("path", name),
+	))
+	defer span.End()
+
 	start := time.Now()
 	info, err := c.inner.Stat(name)
+	c.recordResolution(ctx, span, name)
+	c.finishSpan(span, err)
 	c.logOperation(ctx, "stat", name, start, err)
 	return info, err
 }
@@ -131,8 +167,15 @@ func (c *ContextOverlayFS) OpenFile(ctx context.Context, name string) (fs.File, 
 		return nil, nil, fmt.Errorf("overlayfs: openfile %q: %w", name, err)
 	}
 
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "overlayfs.openfile", trace.WithAttributes(
+		attribute.String("path", name),
+	))
+	defer span.End()
+
 	start := time.Now()
 	f, info, err := c.inner.OpenFile(name)
+	c.recordResolution(ctx, span, name)
+	c.finishSpan(span, err)
 	c.logOperation(ctx, "openfile", name, start, err)
 	return f, info, err
 }
@@ -189,6 +232,27 @@ func (c *ContextOverlayFS) logOperation(ctx context.Context, op, name string, st
 		c.logger.LogAttrs(ctx, slog.LevelDebug, "overlayfs operation failed", attrs...)
 	} else {
 		c.logger.LogAttrs(ctx, slog.LevelDebug, "overlayfs operation", attrs...)
+	}
+}
+
+// recordResolution adds Resolution attributes to the span if the path
+// can be resolved. ReadDir does not resolve to a single layer, so this
+// is not called for readdir operations.
+func (c *ContextOverlayFS) recordResolution(_ context.Context, span trace.Span, name string) {
+	res, err := c.inner.Resolve(name)
+	if err != nil {
+		return
+	}
+	span.SetAttributes(
+		attribute.String("layer.name", res.LayerName),
+		attribute.Int("layer.index", res.LayerIndex),
+	)
+}
+
+// finishSpan sets span status to Error when err is non-nil.
+func (c *ContextOverlayFS) finishSpan(span trace.Span, err error) {
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 	}
 }
 

--- a/internal/overlayfs/context_otel_test.go
+++ b/internal/overlayfs/context_otel_test.go
@@ -1,0 +1,227 @@
+package overlayfs
+
+import (
+	"context"
+	"testing"
+	"testing/fstest"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// setupOTelTest installs a test TracerProvider and returns the span recorder.
+// It restores the previous provider after the test.
+func setupOTelTest(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+	return sr
+}
+
+func findSpan(sr *tracetest.SpanRecorder, name string) (tracetest.SpanStub, bool) {
+	for _, s := range tracetest.SpanStubsFromReadOnlySpans(sr.Ended()) {
+		if s.Name == name {
+			return s, true
+		}
+	}
+	return tracetest.SpanStub{}, false
+}
+
+func spanAttr(s tracetest.SpanStub, key string) (attribute.Value, bool) {
+	for _, a := range s.Attributes {
+		if string(a.Key) == key {
+			return a.Value, true
+		}
+	}
+	return attribute.Value{}, false
+}
+
+func TestOTel_Open_CreatesSpan(t *testing.T) {
+	sr := setupOTelTest(t)
+	theme := fstest.MapFS{"style.css": {Data: []byte("body{}")}}
+	cfs := newTestContextOverlay(nil, theme)
+
+	f, err := cfs.Open(context.Background(), "style.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	s, ok := findSpan(sr, "overlayfs.open")
+	if !ok {
+		t.Fatal("expected overlayfs.open span")
+	}
+
+	v, ok := spanAttr(s, "path")
+	if !ok || v.AsString() != "style.css" {
+		t.Errorf("path attr = %q, want %q", v.AsString(), "style.css")
+	}
+
+	v, ok = spanAttr(s, "layer.name")
+	if !ok {
+		t.Fatal("expected layer.name attribute")
+	}
+	if v.AsString() != "theme" {
+		t.Errorf("layer.name = %q, want %q", v.AsString(), "theme")
+	}
+
+	v, ok = spanAttr(s, "layer.index")
+	if !ok {
+		t.Fatal("expected layer.index attribute")
+	}
+	if v.AsInt64() != 0 {
+		t.Errorf("layer.index = %d, want 0", v.AsInt64())
+	}
+}
+
+func TestOTel_ReadFile_CreatesSpan(t *testing.T) {
+	sr := setupOTelTest(t)
+	layer := fstest.MapFS{"file.txt": {Data: []byte("hello")}}
+	cfs := newTestContextOverlay(nil, layer)
+
+	_, err := cfs.ReadFile(context.Background(), "file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, ok := findSpan(sr, "overlayfs.readfile")
+	if !ok {
+		t.Fatal("expected overlayfs.readfile span")
+	}
+
+	v, _ := spanAttr(s, "path")
+	if v.AsString() != "file.txt" {
+		t.Errorf("path = %q, want %q", v.AsString(), "file.txt")
+	}
+
+	v, ok = spanAttr(s, "layer.name")
+	if !ok || v.AsString() != "theme" {
+		t.Errorf("layer.name = %q, want %q", v.AsString(), "theme")
+	}
+}
+
+func TestOTel_Stat_CreatesSpan(t *testing.T) {
+	sr := setupOTelTest(t)
+	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+	cfs := newTestContextOverlay(nil, layer)
+
+	_, err := cfs.Stat(context.Background(), "file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, ok := findSpan(sr, "overlayfs.stat")
+	if !ok {
+		t.Fatal("expected overlayfs.stat span")
+	}
+
+	v, _ := spanAttr(s, "path")
+	if v.AsString() != "file.txt" {
+		t.Errorf("path = %q, want %q", v.AsString(), "file.txt")
+	}
+}
+
+func TestOTel_ReadDir_CreatesSpan(t *testing.T) {
+	sr := setupOTelTest(t)
+	layer := fstest.MapFS{"dir/a.txt": {Data: []byte("a")}}
+	cfs := newTestContextOverlay(nil, layer)
+
+	_, err := cfs.ReadDir(context.Background(), "dir")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, ok := findSpan(sr, "overlayfs.readdir")
+	if !ok {
+		t.Fatal("expected overlayfs.readdir span")
+	}
+
+	v, _ := spanAttr(s, "path")
+	if v.AsString() != "dir" {
+		t.Errorf("path = %q, want %q", v.AsString(), "dir")
+	}
+
+	// ReadDir should NOT have layer.name since directories span layers.
+	if _, ok := spanAttr(s, "layer.name"); ok {
+		t.Error("readdir should not have layer.name attribute")
+	}
+}
+
+func TestOTel_OpenFile_CreatesSpan(t *testing.T) {
+	sr := setupOTelTest(t)
+	layer := fstest.MapFS{"file.txt": {Data: []byte("data")}}
+	cfs := newTestContextOverlay(nil, layer)
+
+	f, _, err := cfs.OpenFile(context.Background(), "file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	s, ok := findSpan(sr, "overlayfs.openfile")
+	if !ok {
+		t.Fatal("expected overlayfs.openfile span")
+	}
+
+	v, _ := spanAttr(s, "path")
+	if v.AsString() != "file.txt" {
+		t.Errorf("path = %q, want %q", v.AsString(), "file.txt")
+	}
+}
+
+func TestOTel_Open_ErrorSetsSpanStatus(t *testing.T) {
+	sr := setupOTelTest(t)
+	cfs := newTestContextOverlay(nil, fstest.MapFS{})
+
+	_, err := cfs.Open(context.Background(), "missing.txt")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	s, ok := findSpan(sr, "overlayfs.open")
+	if !ok {
+		t.Fatal("expected overlayfs.open span")
+	}
+	if s.Status.Code != codes.Error {
+		t.Errorf("status = %v, want Error", s.Status.Code)
+	}
+}
+
+func TestOTel_ReadFile_FallbackLayerResolution(t *testing.T) {
+	sr := setupOTelTest(t)
+	theme := fstest.MapFS{}
+	defaults := fstest.MapFS{"base.html": {Data: []byte("<html>")}}
+	cfs := newTestContextOverlay(nil, theme, defaults)
+
+	_, err := cfs.ReadFile(context.Background(), "base.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, ok := findSpan(sr, "overlayfs.readfile")
+	if !ok {
+		t.Fatal("expected overlayfs.readfile span")
+	}
+
+	v, ok := spanAttr(s, "layer.name")
+	if !ok {
+		t.Fatal("expected layer.name attribute")
+	}
+	if v.AsString() != "content" {
+		t.Errorf("layer.name = %q, want %q", v.AsString(), "content")
+	}
+
+	v, ok = spanAttr(s, "layer.index")
+	if !ok {
+		t.Fatal("expected layer.index attribute")
+	}
+	if v.AsInt64() != 1 {
+		t.Errorf("layer.index = %d, want 1", v.AsInt64())
+	}
+}


### PR DESCRIPTION
## Summary

Adds real OpenTelemetry spans to all ContextOverlayFS operations (Open, ReadFile, ReadDir, Stat, OpenFile).

### Changes
- Each FS operation creates an OTel span with `overlayfs.<op>` naming
- Span attributes include `path`, `layer.name`, and `layer.index` (from Resolution)
- Span status set to Error on failures
- Existing slog logging preserved alongside spans (both serve different purposes)
- Uses `otel.Tracer("github.com/khaines/blogflow/internal/overlayfs")` per call for test compatibility

### Tests
- 7 new tests using SDK `tracetest.SpanRecorder` to verify spans, attributes, and error status
- All existing tests continue to pass
- `go test -race ./...` clean

Ref #149