### PR TITLE
feat: add OTel spans to scanner, git ops, theme render, config reload

### DIFF
--- a/internal/config/reload.go
+++ b/internal/config/reload.go
@@ -20,8 +20,12 @@ const debounceDuration = 500 * time.Millisecond
 // On validation (or parse) failure the previous config is preserved and
 // the error is returned.
 func (l *Loader) Reload() (*Config, error) {
+	return l.reloadCtx(context.Background())
+}
+
+func (l *Loader) reloadCtx(ctx context.Context) (*Config, error) {
 	tracer := otel.Tracer("github.com/khaines/blogflow/config")
-	_, span := tracer.Start(context.Background(), "config.Reload")
+	_, span := tracer.Start(ctx, "config.Reload")
 	defer span.End()
 	span.SetAttributes(attribute.String("config.path", "site.yaml"))
 
@@ -104,7 +108,7 @@ func (l *Loader) Watch(ctx context.Context) error {
 		case <-debounceCh:
 			debounceCh = nil
 			// Best-effort reload: validation failures preserve old config.
-			_, _ = l.Reload()
+			_, _ = l.reloadCtx(ctx)
 
 		case _, ok := <-watcher.Errors:
 			if !ok {

--- a/internal/config/reload.go
+++ b/internal/config/reload.go
@@ -7,6 +7,9 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 )
 
 const debounceDuration = 500 * time.Millisecond
@@ -17,13 +20,22 @@ const debounceDuration = 500 * time.Millisecond
 // On validation (or parse) failure the previous config is preserved and
 // the error is returned.
 func (l *Loader) Reload() (*Config, error) {
+	tracer := otel.Tracer("github.com/khaines/blogflow/config")
+	_, span := tracer.Start(context.Background(), "config.Reload")
+	defer span.End()
+	span.SetAttributes(attribute.String("config.path", "site.yaml"))
+
 	l.reloadMu.Lock()
 	defer l.reloadMu.Unlock()
 
 	cfg, err := l.Load()
 	if err != nil {
+		span.SetAttributes(attribute.Bool("config.success", false))
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
 		return nil, err
 	}
+	span.SetAttributes(attribute.Bool("config.success", true))
 	l.fireCallbacks(cfg)
 	return cfg, nil
 }

--- a/internal/config/reload_otel_test.go
+++ b/internal/config/reload_otel_test.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func setupConfigTestTracer(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+	})
+	return exp
+}
+
+func TestReload_CreatesSpan(t *testing.T) {
+	exp := setupConfigTestTracer(t)
+
+	dir := t.TempDir()
+	writeYAML(t, dir, `site:
+  title: "Test"
+  base_url: "http://localhost:8080"
+`)
+	loader := NewLoader(os.DirFS(dir))
+	if _, err := loader.Load(); err != nil {
+		t.Fatalf("initial Load: %v", err)
+	}
+
+	_, err := loader.Reload()
+	if err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	spans := exp.GetSpans()
+	var found bool
+	for _, s := range spans {
+		if s.Name == "config.Reload" {
+			found = true
+			attrs := make(map[string]any)
+			for _, a := range s.Attributes {
+				attrs[string(a.Key)] = a.Value.AsInterface()
+			}
+			if v, ok := attrs["config.path"]; !ok || v != "site.yaml" {
+				t.Errorf("config.path = %v, want 'site.yaml'", v)
+			}
+			if v, ok := attrs["config.success"]; !ok || v != true {
+				t.Errorf("config.success = %v, want true", v)
+			}
+		}
+	}
+	if !found {
+		names := make([]string, len(spans))
+		for i, s := range spans {
+			names[i] = s.Name
+		}
+		t.Errorf("span 'config.Reload' not found; got: %s", strings.Join(names, ", "))
+	}
+}
+
+func TestReload_ErrorSetsSpanStatus(t *testing.T) {
+	exp := setupConfigTestTracer(t)
+
+	dir := t.TempDir()
+	// Write valid YAML first so Load() succeeds.
+	writeYAML(t, dir, `site:
+  title: "Test"
+  base_url: "http://localhost:8080"
+`)
+	loader := NewLoader(os.DirFS(dir))
+	if _, err := loader.Load(); err != nil {
+		t.Fatalf("initial Load: %v", err)
+	}
+
+	// Write invalid YAML so Reload fails.
+	writeYAML(t, dir, `site:
+  title: ""
+  base_url: "not-a-url"
+`)
+	_, err := loader.Reload()
+	if err == nil {
+		t.Fatal("expected Reload to fail with invalid config")
+	}
+
+	spans := exp.GetSpans()
+	var found bool
+	for _, s := range spans {
+		if s.Name == "config.Reload" {
+			found = true
+			if s.Status.Code.String() != "Error" {
+				t.Errorf("span status = %v, want Error", s.Status.Code)
+			}
+			attrs := make(map[string]any)
+			for _, a := range s.Attributes {
+				attrs[string(a.Key)] = a.Value.AsInterface()
+			}
+			if v, ok := attrs["config.success"]; !ok || v != false {
+				t.Errorf("config.success = %v, want false", v)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected 'config.Reload' span on error path")
+	}
+}

--- a/internal/content/scanner.go
+++ b/internal/content/scanner.go
@@ -12,6 +12,10 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 )
 
 // Post represents a fully processed blog post.
@@ -97,6 +101,39 @@ func NewScanner(renderer *Renderer, postsDir, pagesDir string, summaryLen int, l
 		logger = slog.New(discardHandler{})
 	}
 	return &Scanner{renderer: renderer, logger: logger, postsDir: postsDir, pagesDir: pagesDir, summaryLen: summaryLen}
+}
+
+// ScanContext walks the given fs.FS and builds a content Index, recording
+// an OpenTelemetry span for the operation. It behaves identically to Scan
+// but accepts a context for trace propagation.
+func (s *Scanner) ScanContext(ctx context.Context, contentFS fs.FS, opts ...ScanOption) (*Index, error) {
+	tracer := otel.Tracer("github.com/khaines/blogflow/content")
+	_, span := tracer.Start(ctx, "content.Scan")
+	defer span.End()
+
+	start := time.Now()
+	idx, err := s.Scan(contentFS, opts...)
+	duration := time.Since(start)
+
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
+		return nil, err
+	}
+
+	var errCount int
+	if errs := idx.Errors(); errs != nil {
+		errCount = len(errs)
+	}
+
+	span.SetAttributes(
+		attribute.Int("content.posts_found", len(idx.Posts)),
+		attribute.Int("content.pages_found", len(idx.Pages)),
+		attribute.Int("content.errors_skipped", errCount),
+		attribute.Int64("content.duration_ms", duration.Milliseconds()),
+	)
+
+	return idx, nil
 }
 
 // Scan walks the given fs.FS and builds a content Index.

--- a/internal/content/scanner_otel_test.go
+++ b/internal/content/scanner_otel_test.go
@@ -1,0 +1,110 @@
+package content
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func setupTestTracer(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+	})
+	return exp
+}
+
+func TestScanContext_CreatesSpan(t *testing.T) {
+	exp := setupTestTracer(t)
+
+	fs := fstest.MapFS{
+		"posts/hello.md": &fstest.MapFile{
+			Data: []byte(mkPost("Hello", "hello", "2025-06-01", []string{"go"}, false, "Some content.\n")),
+		},
+		"pages/about.md": &fstest.MapFile{
+			Data: []byte(mkPage("About", "about", 1, "About page.\n")),
+		},
+	}
+
+	scanner := newTestScanner()
+	idx, err := scanner.ScanContext(context.Background(), fs)
+	if err != nil {
+		t.Fatalf("ScanContext failed: %v", err)
+	}
+	if len(idx.Posts) != 1 {
+		t.Fatalf("expected 1 post, got %d", len(idx.Posts))
+	}
+	if len(idx.Pages) != 1 {
+		t.Fatalf("expected 1 page, got %d", len(idx.Pages))
+	}
+
+	spans := exp.GetSpans()
+	if len(spans) == 0 {
+		t.Fatal("expected at least one span, got none")
+	}
+
+	var found bool
+	for _, s := range spans {
+		if s.Name == "content.Scan" {
+			found = true
+			attrs := make(map[string]any)
+			for _, a := range s.Attributes {
+				attrs[string(a.Key)] = a.Value.AsInterface()
+			}
+			if v, ok := attrs["content.posts_found"]; !ok || v.(int64) != 1 {
+				t.Errorf("content.posts_found = %v, want 1", v)
+			}
+			if v, ok := attrs["content.pages_found"]; !ok || v.(int64) != 1 {
+				t.Errorf("content.pages_found = %v, want 1", v)
+			}
+			if _, ok := attrs["content.errors_skipped"]; !ok {
+				t.Error("missing content.errors_skipped attribute")
+			}
+			if _, ok := attrs["content.duration_ms"]; !ok {
+				t.Error("missing content.duration_ms attribute")
+			}
+		}
+	}
+	if !found {
+		names := make([]string, len(spans))
+		for i, s := range spans {
+			names[i] = s.Name
+		}
+		t.Errorf("span 'content.Scan' not found; got: %s", strings.Join(names, ", "))
+	}
+}
+
+func TestScanContext_ErrorSetsSpanStatus(t *testing.T) {
+	exp := setupTestTracer(t)
+
+	// Use an empty FS — ScanContext should still create a span.
+	fs := fstest.MapFS{}
+
+	scanner := newTestScanner()
+	idx, err := scanner.ScanContext(context.Background(), fs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(idx.Posts) != 0 {
+		t.Errorf("expected 0 posts, got %d", len(idx.Posts))
+	}
+
+	spans := exp.GetSpans()
+	var found bool
+	for _, s := range spans {
+		if s.Name == "content.Scan" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected 'content.Scan' span")
+	}
+}

--- a/internal/gitops/pull.go
+++ b/internal/gitops/pull.go
@@ -155,10 +155,16 @@ func SanitizeURL(raw string) string {
 	return u.String()
 }
 
-func (p *Puller) clone(ctx context.Context, repoURL, branch, destPath string) error {
+func (p *Puller) clone(ctx context.Context, repoURL, branch, destPath string) (retErr error) {
 	tracer := otel.Tracer("github.com/khaines/blogflow/gitops")
 	ctx, span := tracer.Start(ctx, "gitops.clone")
-	defer span.End()
+	defer func() {
+		if retErr != nil {
+			span.SetStatus(codes.Error, retErr.Error())
+			span.RecordError(retErr)
+		}
+		span.End()
+	}()
 	span.SetAttributes(attribute.String("gitops.repo_url", SanitizeURL(repoURL)))
 
 	p.logger.Info("cloning repository", "url", SanitizeURL(repoURL), "branch", branch, "dest", destPath)
@@ -177,8 +183,6 @@ func (p *Puller) clone(ctx context.Context, repoURL, branch, destPath string) er
 
 	repo, err := git.PlainCloneContext(ctx, destPath, false, opts)
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
-		span.RecordError(err)
 		return fmt.Errorf("gitops: clone %s: %w", SanitizeURL(repoURL), err)
 	}
 
@@ -200,10 +204,16 @@ func (p *Puller) clone(ctx context.Context, repoURL, branch, destPath string) er
 	return nil
 }
 
-func (p *Puller) pull(ctx context.Context, repoURL, branch, destPath string) (_ bool, _ error) {
+func (p *Puller) pull(ctx context.Context, repoURL, branch, destPath string) (_ bool, retErr error) {
 	tracer := otel.Tracer("github.com/khaines/blogflow/gitops")
 	ctx, span := tracer.Start(ctx, "gitops.pull")
-	defer span.End()
+	defer func() {
+		if retErr != nil {
+			span.SetStatus(codes.Error, retErr.Error())
+			span.RecordError(retErr)
+		}
+		span.End()
+	}()
 
 	p.logger.Debug("pulling repository", "dest", destPath, "branch", branch)
 

--- a/internal/gitops/pull.go
+++ b/internal/gitops/pull.go
@@ -17,6 +17,9 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 )
 
 // Puller handles git clone and pull operations for content/theme repos.
@@ -83,18 +86,42 @@ func NewPuller(authCfg *AuthConfig, logger *slog.Logger, opts ...PullerOption) (
 // fallback re-clone path is triggered (e.g. shallow-clone corruption). To
 // intentionally switch URLs, delete destPath first and let CloneOrPull re-clone.
 func (p *Puller) CloneOrPull(ctx context.Context, repoURL, branch, destPath string) (changed bool, err error) {
+	tracer := otel.Tracer("github.com/khaines/blogflow/gitops")
+	ctx, span := tracer.Start(ctx, "gitops.CloneOrPull")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("gitops.repo_url", SanitizeURL(repoURL)),
+		attribute.String("gitops.branch", branch),
+	)
+
 	if len(p.SparseDirs) > 0 {
 		cleaned, valErr := validateSparseDirs(p.SparseDirs)
 		if valErr != nil {
+			span.SetStatus(codes.Error, valErr.Error())
+			span.RecordError(valErr)
 			return false, fmt.Errorf("gitops: %w", valErr)
 		}
 		p.SparseDirs = cleaned
 	}
 
 	if _, err := os.Stat(filepath.Join(destPath, ".git")); err == nil {
-		return p.pull(ctx, repoURL, branch, destPath)
+		span.SetAttributes(attribute.String("gitops.operation", "pull"))
+		changed, pullErr := p.pull(ctx, repoURL, branch, destPath)
+		if pullErr != nil {
+			span.SetStatus(codes.Error, pullErr.Error())
+			span.RecordError(pullErr)
+		}
+		return changed, pullErr
 	}
-	return true, p.clone(ctx, repoURL, branch, destPath)
+
+	span.SetAttributes(attribute.String("gitops.operation", "clone"))
+	cloneErr := p.clone(ctx, repoURL, branch, destPath)
+	if cloneErr != nil {
+		span.SetStatus(codes.Error, cloneErr.Error())
+		span.RecordError(cloneErr)
+	}
+	return true, cloneErr
 }
 
 // validateSparseDirs sanitizes and validates sparse directory entries.
@@ -129,6 +156,11 @@ func SanitizeURL(raw string) string {
 }
 
 func (p *Puller) clone(ctx context.Context, repoURL, branch, destPath string) error {
+	tracer := otel.Tracer("github.com/khaines/blogflow/gitops")
+	ctx, span := tracer.Start(ctx, "gitops.clone")
+	defer span.End()
+	span.SetAttributes(attribute.String("gitops.repo_url", SanitizeURL(repoURL)))
+
 	p.logger.Info("cloning repository", "url", SanitizeURL(repoURL), "branch", branch, "dest", destPath)
 
 	sparse := len(p.SparseDirs) > 0
@@ -145,6 +177,8 @@ func (p *Puller) clone(ctx context.Context, repoURL, branch, destPath string) er
 
 	repo, err := git.PlainCloneContext(ctx, destPath, false, opts)
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
 		return fmt.Errorf("gitops: clone %s: %w", SanitizeURL(repoURL), err)
 	}
 
@@ -166,7 +200,11 @@ func (p *Puller) clone(ctx context.Context, repoURL, branch, destPath string) er
 	return nil
 }
 
-func (p *Puller) pull(ctx context.Context, repoURL, branch, destPath string) (bool, error) {
+func (p *Puller) pull(ctx context.Context, repoURL, branch, destPath string) (_ bool, _ error) {
+	tracer := otel.Tracer("github.com/khaines/blogflow/gitops")
+	ctx, span := tracer.Start(ctx, "gitops.pull")
+	defer span.End()
+
 	p.logger.Debug("pulling repository", "dest", destPath, "branch", branch)
 
 	repo, err := git.PlainOpen(destPath)
@@ -234,6 +272,7 @@ func (p *Puller) pull(ctx context.Context, repoURL, branch, destPath string) (bo
 	}
 
 	changed := headBefore.Hash() != headAfter.Hash()
+	span.SetAttributes(attribute.Bool("gitops.changed", changed))
 
 	// Re-apply sparse checkout after pull — PullContext checks out all files,
 	// so we remove entries outside the sparse set.

--- a/internal/gitops/pull_otel_test.go
+++ b/internal/gitops/pull_otel_test.go
@@ -1,0 +1,160 @@
+package gitops
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func setupGitopsTestTracer(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+	})
+	return exp
+}
+
+func TestCloneOrPull_CreatesSpans(t *testing.T) {
+	exp := setupGitopsTestTracer(t)
+
+	bareDir := newBareRepoWithCommit(t)
+	destDir := filepath.Join(t.TempDir(), "dest")
+
+	puller, err := NewPuller(&AuthConfig{Method: AuthNone}, nil)
+	if err != nil {
+		t.Fatalf("NewPuller: %v", err)
+	}
+
+	changed, err := puller.CloneOrPull(context.Background(), bareDir, "master", destDir)
+	if err != nil {
+		t.Fatalf("CloneOrPull: %v", err)
+	}
+	if !changed {
+		t.Error("expected changed=true for fresh clone")
+	}
+
+	spans := exp.GetSpans()
+	spanNames := make(map[string]bool)
+	for _, s := range spans {
+		spanNames[s.Name] = true
+	}
+
+	if !spanNames["gitops.CloneOrPull"] {
+		t.Errorf("missing 'gitops.CloneOrPull' span; got: %v", spanNames)
+	}
+	if !spanNames["gitops.clone"] {
+		t.Errorf("missing 'gitops.clone' child span; got: %v", spanNames)
+	}
+
+	// Verify attributes on parent span.
+	for _, s := range spans {
+		if s.Name == "gitops.CloneOrPull" {
+			attrs := make(map[string]any)
+			for _, a := range s.Attributes {
+				attrs[string(a.Key)] = a.Value.AsInterface()
+			}
+			if v, ok := attrs["gitops.repo_url"]; !ok {
+				t.Error("missing gitops.repo_url attribute")
+			} else if _, isStr := v.(string); !isStr {
+				t.Errorf("gitops.repo_url is not a string: %T", v)
+			}
+			if v, ok := attrs["gitops.branch"]; !ok || v != "master" {
+				t.Errorf("gitops.branch = %v, want 'master'", v)
+			}
+			if v, ok := attrs["gitops.operation"]; !ok || v != "clone" {
+				t.Errorf("gitops.operation = %v, want 'clone'", v)
+			}
+		}
+	}
+}
+
+func TestCloneOrPull_Pull_CreatesSpans(t *testing.T) {
+	exp := setupGitopsTestTracer(t)
+
+	bareDir := newBareRepoWithCommit(t)
+	destDir := filepath.Join(t.TempDir(), "dest")
+
+	puller, err := NewPuller(&AuthConfig{Method: AuthNone}, nil)
+	if err != nil {
+		t.Fatalf("NewPuller: %v", err)
+	}
+
+	// Initial clone
+	if _, err := puller.CloneOrPull(context.Background(), bareDir, "master", destDir); err != nil {
+		t.Fatalf("initial clone: %v", err)
+	}
+
+	exp.Reset()
+
+	// Pull (already up to date)
+	_, err = puller.CloneOrPull(context.Background(), bareDir, "master", destDir)
+	if err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+
+	spans := exp.GetSpans()
+	spanNames := make(map[string]bool)
+	for _, s := range spans {
+		spanNames[s.Name] = true
+	}
+
+	if !spanNames["gitops.CloneOrPull"] {
+		t.Errorf("missing 'gitops.CloneOrPull' span; got: %v", spanNames)
+	}
+	if !spanNames["gitops.pull"] {
+		t.Errorf("missing 'gitops.pull' child span; got: %v", spanNames)
+	}
+
+	// Check operation attribute is "pull"
+	for _, s := range spans {
+		if s.Name == "gitops.CloneOrPull" {
+			for _, a := range s.Attributes {
+				if string(a.Key) == "gitops.operation" && a.Value.AsInterface() != "pull" {
+					t.Errorf("gitops.operation = %v, want 'pull'", a.Value.AsInterface())
+				}
+			}
+		}
+	}
+}
+
+func TestCloneOrPull_ErrorSetsSpanStatus(t *testing.T) {
+	exp := setupGitopsTestTracer(t)
+
+	puller, err := NewPuller(&AuthConfig{Method: AuthNone}, nil)
+	if err != nil {
+		t.Fatalf("NewPuller: %v", err)
+	}
+
+	// Clone from invalid path — will fail
+	destDir := filepath.Join(t.TempDir(), "dest")
+	_, err = puller.CloneOrPull(context.Background(), "/nonexistent/repo", "master", destDir)
+	if err == nil {
+		t.Fatal("expected error cloning from invalid path")
+	}
+
+	spans := exp.GetSpans()
+	var found bool
+	for _, s := range spans {
+		if s.Name == "gitops.CloneOrPull" {
+			found = true
+			if s.Status.Code.String() != "Error" {
+				t.Errorf("span status = %v, want Error", s.Status.Code)
+			}
+		}
+	}
+	if !found {
+		names := make([]string, len(spans))
+		for i, s := range spans {
+			names[i] = s.Name
+		}
+		t.Errorf("span 'gitops.CloneOrPull' not found; got: %s", strings.Join(names, ", "))
+	}
+}

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -15,6 +15,9 @@ import (
 	"time"
 	"unicode"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"golang.org/x/text/unicode/norm"
 )
 
@@ -43,32 +46,55 @@ func NewEngine(fsys fs.FS) (*Engine, error) {
 // Each page template is cloned+parsed per request so defines don't collide.
 // The context allows callers to cancel long-running renders.
 func (e *Engine) Render(ctx context.Context, w io.Writer, name string, data any) error {
+	tracer := otel.Tracer("github.com/khaines/blogflow/theme")
+	ctx, span := tracer.Start(ctx, "theme.Render")
+	defer span.End()
+	span.SetAttributes(attribute.String("theme.template_name", name))
+
 	pages := *e.pages.Load()
 	src, ok := pages[name]
 	if !ok {
-		return fmt.Errorf("theme: template %q not found", name)
+		err := fmt.Errorf("theme: template %q not found", name)
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
+		return err
 	}
 
 	clone, err := e.base.Load().Clone()
 	if err != nil {
-		return fmt.Errorf("theme: clone: %w", err)
+		err = fmt.Errorf("theme: clone: %w", err)
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
+		return err
 	}
 	if _, err := clone.Parse(src); err != nil {
-		return fmt.Errorf("theme: parse page %s: %w", name, err)
+		err = fmt.Errorf("theme: parse page %s: %w", name, err)
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
+		return err
 	}
 
 	// Check for cancellation before expensive template execution.
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		err := ctx.Err()
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
+		return err
 	default:
 	}
 
 	var buf bytes.Buffer
 	if err := clone.ExecuteTemplate(&buf, "templates/base.html", data); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
 		return err
 	}
 	_, writeErr := buf.WriteTo(w)
+	if writeErr != nil {
+		span.SetStatus(codes.Error, writeErr.Error())
+		span.RecordError(writeErr)
+	}
 	return writeErr
 }
 

--- a/internal/theme/theme_otel_test.go
+++ b/internal/theme/theme_otel_test.go
@@ -1,0 +1,92 @@
+package theme
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func setupThemeTestTracer(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+	})
+	return exp
+}
+
+func TestRender_CreatesSpan(t *testing.T) {
+	exp := setupThemeTestTracer(t)
+
+	fs := testFS(map[string]string{
+		"templates/index.html": `{{define "content"}}<h1>Hello</h1>{{end}}`,
+	})
+
+	e, err := NewEngine(fs)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	var b strings.Builder
+	if err := e.Render(context.Background(), &b, "templates/index.html", nil); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	spans := exp.GetSpans()
+	var found bool
+	for _, s := range spans {
+		if s.Name == "theme.Render" {
+			found = true
+			attrs := make(map[string]any)
+			for _, a := range s.Attributes {
+				attrs[string(a.Key)] = a.Value.AsInterface()
+			}
+			if v, ok := attrs["theme.template_name"]; !ok || v != "templates/index.html" {
+				t.Errorf("theme.template_name = %v, want 'templates/index.html'", v)
+			}
+		}
+	}
+	if !found {
+		names := make([]string, len(spans))
+		for i, s := range spans {
+			names[i] = s.Name
+		}
+		t.Errorf("span 'theme.Render' not found; got: %s", strings.Join(names, ", "))
+	}
+}
+
+func TestRender_ErrorSetsSpanStatus(t *testing.T) {
+	exp := setupThemeTestTracer(t)
+
+	fs := testFS(map[string]string{})
+	e, err := NewEngine(fs)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	var b strings.Builder
+	err = e.Render(context.Background(), &b, "nonexistent.html", nil)
+	if err == nil {
+		t.Fatal("expected error rendering nonexistent template")
+	}
+
+	spans := exp.GetSpans()
+	var found bool
+	for _, s := range spans {
+		if s.Name == "theme.Render" {
+			found = true
+			if s.Status.Code.String() != "Error" {
+				t.Errorf("span status = %v, want Error", s.Status.Code)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected 'theme.Render' span on error path")
+	}
+}


### PR DESCRIPTION
## OTel Phase 2 — Custom operation spans

Adds OpenTelemetry tracing spans to key operations, building on the SDK bootstrap from #151.

### Spans added

| Package | Span name | Attributes |
|---|---|---|
| `internal/content` | `content.Scan` | `posts_found`, `pages_found`, `errors_skipped`, `duration_ms` |
| `internal/gitops` | `gitops.CloneOrPull` + child `gitops.clone`/`gitops.pull` | `repo_url` (sanitized), `branch`, `operation`, `changed` |
| `internal/theme` | `theme.Render` | `template_name` |
| `internal/config` | `config.Reload` | `path`, `success` |

### Implementation notes
- Added `ScanContext(ctx, ...)` to content scanner for trace propagation; `Scan()` remains unchanged
- All spans set error status + `RecordError` on failures
- Child spans in gitops propagate context for proper trace hierarchy
- Each package uses `otel.Tracer("github.com/khaines/blogflow/<package>")`

### Tests
- 9 new OTel-specific tests across 4 test files using SDK `tracetest.InMemoryExporter`
- All existing tests pass with `-race`

Ref #149