### PR TITLE
fix: wire theme and config reload into sync callback

### DIFF
--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -186,7 +186,7 @@ func main() {
 	})
 
 	// 8. Content reloader for sync strategies
-	reloader := newContentReloader(scanner, contentOverlay, deps, renderCache, logger)
+	reloader := newContentReloader(scanner, contentOverlay, deps, renderCache, cfgLoader, themeEngine, logger)
 
 	// 9. Initialize sync strategy
 	syncStrategy, err := gitops.NewStrategy(&cfg.Sync, reloader, logger)

--- a/cmd/blogflow/reload.go
+++ b/cmd/blogflow/reload.go
@@ -5,22 +5,46 @@ import (
 	"io/fs"
 	"log/slog"
 
+	"github.com/khaines/blogflow/internal/config"
 	"github.com/khaines/blogflow/internal/content"
 	"github.com/khaines/blogflow/internal/gitops"
 	"github.com/khaines/blogflow/internal/server/handlers"
+	"github.com/khaines/blogflow/internal/theme"
 )
 
-// newContentReloader builds a ContentReloader that re-scans content from fsys
-// and flushes the render cache (if non-nil). The deps index is swapped
-// atomically so existing HTTP handlers see fresh content on subsequent requests.
+// newContentReloader builds a ContentReloader that reloads config, theme
+// templates, and content (in that order), then flushes the render cache.
+// Config and theme reload failures are logged but do not prevent content
+// from being served — partial reload is better than no reload.
 func newContentReloader(
 	scanner *content.Scanner,
 	fsys fs.FS,
 	deps *handlers.Deps,
 	cache *content.Cache,
+	cfgLoader *config.Loader,
+	themeEngine *theme.Engine,
 	logger *slog.Logger,
 ) gitops.ContentReloader {
 	return func() error {
+		// 1. Config reload — may affect content scanning behaviour.
+		if cfgLoader != nil {
+			if _, err := cfgLoader.Reload(); err != nil {
+				logger.Error("config reload failed", "error", err)
+			} else {
+				logger.Info("config reloaded")
+			}
+		}
+
+		// 2. Theme reload — re-parse templates from the overlay FS.
+		if themeEngine != nil {
+			if err := themeEngine.Reload(); err != nil {
+				logger.Error("theme reload failed", "error", err)
+			} else {
+				logger.Info("theme reloaded")
+			}
+		}
+
+		// 3. Content rescan.
 		newIdx, err := scanner.Scan(fsys)
 		if err != nil {
 			return fmt.Errorf("content reload: %w", err)
@@ -28,6 +52,7 @@ func newContentReloader(
 		deps.SetIndex(newIdx)
 		logger.Info("content reloaded", "posts", len(newIdx.Posts), "pages", len(newIdx.Pages))
 
+		// 4. Cache flush.
 		if cache != nil {
 			cache.InvalidateAll()
 			logger.Info("render cache flushed after content reload")

--- a/cmd/blogflow/reload_test.go
+++ b/cmd/blogflow/reload_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io/fs"
 	"log/slog"
 	"testing"
 	"testing/fstest"
@@ -9,6 +10,7 @@ import (
 	"github.com/khaines/blogflow/internal/config"
 	"github.com/khaines/blogflow/internal/content"
 	"github.com/khaines/blogflow/internal/server/handlers"
+	"github.com/khaines/blogflow/internal/theme"
 )
 
 // testFS returns a minimal content filesystem for reload tests.
@@ -18,6 +20,53 @@ func testFS() fstest.MapFS {
 			Data: []byte("---\ntitle: Hello\ndate: 2024-01-01T00:00:00Z\n---\nHello world\n"),
 		},
 	}
+}
+
+// testThemeFS returns a minimal theme filesystem for theme.Engine.
+func testThemeFS() fstest.MapFS {
+	return fstest.MapFS{
+		"templates/base.html": &fstest.MapFile{
+			Data: []byte(`{{define "templates/base.html"}}{{block "content" .}}{{end}}{{end}}`),
+		},
+		"templates/post.html": &fstest.MapFile{
+			Data: []byte(`{{define "content"}}post{{end}}`),
+		},
+	}
+}
+
+// testConfigFS returns a minimal config filesystem for config.Loader.
+func testConfigFS() fstest.MapFS {
+	return fstest.MapFS{
+		"site.yaml": &fstest.MapFile{
+			Data: []byte("site:\n  title: Test Blog\n  base_url: http://localhost\n"),
+		},
+	}
+}
+
+// mergeFS combines two MapFS into one.
+func mergeFS(a, b fstest.MapFS) fstest.MapFS {
+	m := make(fstest.MapFS, len(a)+len(b))
+	for k, v := range a {
+		m[k] = v
+	}
+	for k, v := range b {
+		m[k] = v
+	}
+	return m
+}
+
+// switchableFS delegates to an underlying fs.FS that can be swapped at runtime.
+// When broken is true, Open returns a fs.PathError for every path.
+type switchableFS struct {
+	inner  fs.FS
+	broken bool
+}
+
+func (s *switchableFS) Open(name string) (fs.File, error) {
+	if s.broken {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+	}
+	return s.inner.Open(name)
 }
 
 func TestContentReloaderFlushesCache(t *testing.T) {
@@ -34,17 +83,17 @@ func TestContentReloaderFlushesCache(t *testing.T) {
 		t.Fatalf("expected 2 cache entries, got %d", cache.Len())
 	}
 
-	fs := testFS()
+	contentFS := testFS()
 	renderer := content.NewRenderer()
 	scanner := content.NewScanner(renderer, "posts", "pages", 200, nil)
 
-	idx, err := scanner.Scan(fs)
+	idx, err := scanner.Scan(contentFS)
 	if err != nil {
 		t.Fatalf("initial scan: %v", err)
 	}
 
 	deps := handlers.NewDeps(nil, idx, nil)
-	reloader := newContentReloader(scanner, fs, deps, cache, slog.Default())
+	reloader := newContentReloader(scanner, contentFS, deps, cache, nil, nil, slog.Default())
 
 	if err := reloader(); err != nil {
 		t.Fatalf("reloader returned error: %v", err)
@@ -58,17 +107,17 @@ func TestContentReloaderFlushesCache(t *testing.T) {
 func TestContentReloaderNilCache(t *testing.T) {
 	t.Parallel()
 
-	fs := testFS()
+	contentFS := testFS()
 	renderer := content.NewRenderer()
 	scanner := content.NewScanner(renderer, "posts", "pages", 200, nil)
 
-	idx, err := scanner.Scan(fs)
+	idx, err := scanner.Scan(contentFS)
 	if err != nil {
 		t.Fatalf("initial scan: %v", err)
 	}
 
 	deps := handlers.NewDeps(nil, idx, nil)
-	reloader := newContentReloader(scanner, fs, deps, nil, slog.Default())
+	reloader := newContentReloader(scanner, contentFS, deps, nil, nil, nil, slog.Default())
 
 	// Must not panic with nil cache.
 	if err := reloader(); err != nil {
@@ -79,27 +128,152 @@ func TestContentReloaderNilCache(t *testing.T) {
 func TestContentReloaderUpdatesIndex(t *testing.T) {
 	t.Parallel()
 
-	fs := testFS()
+	contentFS := testFS()
 	renderer := content.NewRenderer()
 	scanner := content.NewScanner(renderer, "posts", "pages", 200, nil)
 
-	idx, err := scanner.Scan(fs)
+	idx, err := scanner.Scan(contentFS)
 	if err != nil {
 		t.Fatalf("initial scan: %v", err)
 	}
 
 	deps := handlers.NewDeps(nil, idx, nil)
-	reloader := newContentReloader(scanner, fs, deps, nil, slog.Default())
+	reloader := newContentReloader(scanner, contentFS, deps, nil, nil, nil, slog.Default())
 
 	if err := reloader(); err != nil {
 		t.Fatalf("reloader returned error: %v", err)
 	}
 
-	// deps index should be a fresh index (different pointer).
 	if deps.LoadIndex() == idx {
 		t.Error("expected deps index to be updated to a new pointer after reload")
 	}
 
+	if len(deps.LoadIndex().Posts) != 1 {
+		t.Errorf("expected 1 post after reload, got %d", len(deps.LoadIndex().Posts))
+	}
+}
+
+func TestContentReloaderTriggersThemeReload(t *testing.T) {
+	t.Parallel()
+
+	combined := mergeFS(testFS(), testThemeFS())
+	engine, err := theme.NewEngine(combined)
+	if err != nil {
+		t.Fatalf("theme.NewEngine: %v", err)
+	}
+
+	renderer := content.NewRenderer()
+	scanner := content.NewScanner(renderer, "posts", "pages", 200, nil)
+	idx, err := scanner.Scan(combined)
+	if err != nil {
+		t.Fatalf("initial scan: %v", err)
+	}
+
+	deps := handlers.NewDeps(nil, idx, engine)
+	reloader := newContentReloader(scanner, combined, deps, nil, nil, engine, slog.Default())
+
+	// Theme reload should succeed without error.
+	if err := reloader(); err != nil {
+		t.Fatalf("reloader returned error: %v", err)
+	}
+}
+
+func TestContentReloaderTriggersConfigReload(t *testing.T) {
+	t.Parallel()
+
+	cfgFS := testConfigFS()
+	loader := config.NewLoader(cfgFS, config.WithLogger(slog.Default()))
+	if _, err := loader.Load(); err != nil {
+		t.Fatalf("initial load: %v", err)
+	}
+
+	contentFS := testFS()
+	renderer := content.NewRenderer()
+	scanner := content.NewScanner(renderer, "posts", "pages", 200, nil)
+	idx, err := scanner.Scan(contentFS)
+	if err != nil {
+		t.Fatalf("initial scan: %v", err)
+	}
+
+	deps := handlers.NewDeps(loader.Get(), idx, nil)
+	reloader := newContentReloader(scanner, contentFS, deps, nil, loader, nil, slog.Default())
+
+	if err := reloader(); err != nil {
+		t.Fatalf("reloader returned error: %v", err)
+	}
+
+	cfg := loader.Get()
+	if cfg == nil {
+		t.Fatal("expected config to be non-nil after reload")
+	}
+	if cfg.Site.Title != "Test Blog" {
+		t.Errorf("expected title 'Test Blog', got %q", cfg.Site.Title)
+	}
+}
+
+func TestContentReloaderThemeFailureDoesNotBlockContentScan(t *testing.T) {
+	t.Parallel()
+
+	// Create a switchable FS that starts valid and can be broken later.
+	sfs := &switchableFS{inner: testThemeFS()}
+	engine, err := theme.NewEngine(sfs)
+	if err != nil {
+		t.Fatalf("theme.NewEngine: %v", err)
+	}
+	// Break the FS so the next Reload() fails.
+	sfs.broken = true
+
+	contentFS := testFS()
+	renderer := content.NewRenderer()
+	scanner := content.NewScanner(renderer, "posts", "pages", 200, nil)
+	idx, err := scanner.Scan(contentFS)
+	if err != nil {
+		t.Fatalf("initial scan: %v", err)
+	}
+
+	deps := handlers.NewDeps(nil, idx, engine)
+	reloader := newContentReloader(scanner, contentFS, deps, nil, nil, engine, slog.Default())
+
+	// Reloader must NOT return an error — theme failure is logged, not propagated.
+	if err := reloader(); err != nil {
+		t.Fatalf("reloader should not return error on theme failure, got: %v", err)
+	}
+
+	// Content should still be updated despite theme reload failure.
+	if len(deps.LoadIndex().Posts) != 1 {
+		t.Errorf("expected 1 post after reload, got %d", len(deps.LoadIndex().Posts))
+	}
+}
+
+func TestContentReloaderConfigFailureDoesNotBlockContentScan(t *testing.T) {
+	t.Parallel()
+
+	// Create a switchable FS that starts valid and can be broken later.
+	sfs := &switchableFS{inner: testConfigFS()}
+	loader := config.NewLoader(sfs, config.WithLogger(slog.Default()))
+	if _, err := loader.Load(); err != nil {
+		t.Fatalf("initial load: %v", err)
+	}
+	// Break the FS so the next Reload() fails.
+	sfs.broken = true
+
+	contentFS := testFS()
+	renderer := content.NewRenderer()
+	scanner := content.NewScanner(renderer, "posts", "pages", 200, nil)
+	idx, err := scanner.Scan(contentFS)
+	if err != nil {
+		t.Fatalf("initial scan: %v", err)
+	}
+
+	deps := handlers.NewDeps(loader.Get(), idx, nil)
+	reloader := newContentReloader(scanner, contentFS, deps, nil, loader, nil, slog.Default())
+
+	// Reloader must NOT return an error — config failure is logged, not propagated.
+	if err := reloader(); err != nil {
+		t.Fatalf("reloader should not return error on config failure, got: %v", err)
+	}
+
+	// Content should still be updated.
 	if len(deps.LoadIndex().Posts) != 1 {
 		t.Errorf("expected 1 post after reload, got %d", len(deps.LoadIndex().Posts))
 	}


### PR DESCRIPTION
When poll/webhook/sidecar detects changes, now reloads config, theme templates, and content (in that order). Failures in theme/config reload log errors but don't block content serving.

## Changes
- **`cmd/blogflow/reload.go`**: Extended `newContentReloader` to accept `*config.Loader` and `*theme.Engine`, calling config reload → theme reload → content rescan → cache flush
- **`cmd/blogflow/main.go`**: Updated call site to pass config loader and theme engine
- **`cmd/blogflow/reload_test.go`**: Added 4 new tests (theme reload, config reload, theme failure resilience, config failure resilience)

## Reload order
1. Config reload (may affect scanning behaviour)
2. Theme reload (re-parses templates from overlay FS)
3. Content rescan
4. Cache flush

Failures in steps 1–2 are logged but do not prevent content from being served.

Fixes #145