### PR TITLE
fix: set min replicas to 1 for always-on docs site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
             --template-file deploy/azure/main.bicep \
             --parameters \
               location="eastus2" \
-              scaleMinReplicas=0 \
+              scaleMinReplicas=1 \
               scaleMaxReplicas=2 \
               environmentName="${{ secrets.AZURE_ENVIRONMENT_NAME }}" \
               ghcrUsername="${{ github.repository_owner }}" \


### PR DESCRIPTION
Scale-to-zero prevents log inspection and causes cold start delays for the docs site. Sets minReplicas from 0 → 1.