### PR TITLE
fix: ensure content/config dirs exist before overlay FS init

### DIFF
--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -88,6 +88,15 @@ func main() {
 
 	logger.Info("blogflow starting", "version", version)
 
+	// 0. Ensure content/theme/config directories exist (bootstrap may create them later)
+	for _, dir := range []string{*contentPath, *themePath, *configPath} {
+		if dir != "" {
+			if mkErr := os.MkdirAll(dir, 0o750); mkErr != nil {
+				logger.Warn("could not create directory", "path", dir, "error", mkErr)
+			}
+		}
+	}
+
 	// 1. Build overlay FS for content (4-layer: theme → content → config → defaults)
 	contentOverlay, err := overlayfs.NewFromPaths(*themePath, *contentPath, *configPath, blogflow.Defaults)
 	if err != nil {

--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -92,7 +92,8 @@ func main() {
 	for _, dir := range []string{*contentPath, *themePath, *configPath} {
 		if dir != "" {
 			if mkErr := os.MkdirAll(dir, 0o750); mkErr != nil {
-				logger.Warn("could not create directory", "path", dir, "error", mkErr)
+				logger.Error("could not create required directory", "path", dir, "error", mkErr)
+				os.Exit(1)
 			}
 		}
 	}


### PR DESCRIPTION
Bootstrap clones after overlay FS init, but overlay FS fails if the directory doesn't exist. Adds `os.MkdirAll` for content/theme/config paths at startup. Overlay FS starts empty with defaults, bootstrap fills it, reload picks up the content.