### PR TITLE
fix: use SHA tag for container image deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,10 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Compute image tag
+        id: image
+        run: echo "tag=sha-$(echo $GITHUB_SHA | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
       - name: Deploy Bicep template
         run: |
           az deployment group create \
@@ -47,4 +51,4 @@ jobs:
               ghcrUsername="${{ github.repository_owner }}" \
               ghcrPassword="${{ secrets.GHCR_PASSWORD }}" \
               appInsightsConnectionString="${{ secrets.APPINSIGHTS_CONNECTION_STRING }}" \
-              containerImage="ghcr.io/${{ github.repository }}:main"
+              containerImage="ghcr.io/${{ github.repository }}:${{ steps.image.outputs.tag }}"


### PR DESCRIPTION
Container Apps caches `:main` and may not pull fresh images. Switch to `:sha-<short>` which publish.yml already pushes, ensuring every deploy gets the exact image for that commit.