### PR TITLE
fix: correct deploy content paths and add content env var overrides

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,10 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Compute image tag
+        id: image
+        run: echo "tag=sha-$(echo $GITHUB_SHA | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
       - name: Deploy Bicep template
         run: |
           az deployment group create \
@@ -47,4 +51,4 @@ jobs:
               ghcrUsername="${{ github.repository_owner }}" \
               ghcrPassword="${{ secrets.GHCR_PASSWORD }}" \
               appInsightsConnectionString="${{ secrets.APPINSIGHTS_CONNECTION_STRING }}" \
-              containerImage="ghcr.io/${{ github.repository }}:main"
+              containerImage="ghcr.io/${{ github.repository }}:${{ steps.image.outputs.tag }}"

--- a/deploy/azure/modules/container-app.bicep
+++ b/deploy/azure/modules/container-app.bicep
@@ -94,9 +94,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
           image: containerImage
           args: [
             '--content'
-            '/data/content/docs'
-            '--config'
-            '/data/content/docs/config'
+            '/data/content'
           ]
           volumeMounts: [
             {
@@ -146,12 +144,12 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
               value: '5m'
             }
             {
-              name: 'BLOGFLOW_SYNC_SPARSE_DIRS'
-              value: 'docs'
+              name: 'BLOGFLOW_SITE_HOMEPAGE'
+              value: 'static:docs/index.html'
             }
             {
-              name: 'BLOGFLOW_SITE_HOMEPAGE'
-              value: 'static:index.html'
+              name: 'BLOGFLOW_CONTENT_POSTS_DIR'
+              value: 'docs'
             }
             {
               name: 'BLOGFLOW_SITE_TITLE'

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -409,6 +409,14 @@ var envMap = map[string]func(*Config, string) error{
 		c.Site.Homepage = v
 		return nil
 	},
+	"BLOGFLOW_CONTENT_POSTS_DIR": func(c *Config, v string) error {
+		c.Content.PostsDir = v
+		return nil
+	},
+	"BLOGFLOW_CONTENT_PAGES_DIR": func(c *Config, v string) error {
+		c.Content.PagesDir = v
+		return nil
+	},
 }
 
 // secretEnvVars identifies env vars that should be redacted in logs.


### PR DESCRIPTION
Bootstrap clones repo to --content path, creating nested docs/docs/. Fix: use repo root as content, add BLOGFLOW_CONTENT_POSTS_DIR + BLOGFLOW_CONTENT_PAGES_DIR env var overrides to configure scanner from deployment config.