### PR TITLE
fix: allow inline styles in CSP for Mermaid SVG rendering

### DIFF
--- a/defaults/templates/base.html
+++ b/defaults/templates/base.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'none'; script-src 'self'; object-src 'none'; connect-src 'none'; style-src 'self'; img-src 'self' https: data:; font-src 'self' https:; base-uri 'self'; form-action 'self'">
+          content="default-src 'none'; script-src 'self'; object-src 'none'; connect-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' https:; base-uri 'self'; form-action 'self'">
     <title>{{block "title" .}}{{.Site.Title}}{{end}}</title>
     <meta name="description" content="{{block "meta_description" .}}{{.Site.Description}}{{end}}">
     <meta property="og:title" content="{{block "og_title" .}}{{.Site.Title}}{{end}}">

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -301,7 +301,7 @@ func (s *Server) securityHeadersMiddleware(next http.Handler) http.Handler {
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		w.Header().Set("Content-Security-Policy",
 			"default-src 'none'; script-src 'self'; object-src 'none'; "+
-				"connect-src 'none'; style-src 'self'; img-src 'self' https: data:; "+
+				"connect-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; "+
 				"font-src 'self' https:; base-uri 'self'; form-action 'self'; "+
 				"frame-ancestors 'self'")
 		w.Header().Set("Permissions-Policy",

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -395,8 +395,11 @@ func TestCSPHeader(t *testing.T) {
 			t.Errorf("CSP missing %q: %s", directive, csp)
 		}
 	}
-	if strings.Contains(csp, "'unsafe-inline'") {
-		t.Errorf("CSP must not contain 'unsafe-inline': %s", csp)
+	if strings.Contains(csp, "script-src") && strings.Contains(csp, "script-src 'self' 'unsafe-inline'") {
+		t.Errorf("CSP script-src must not contain 'unsafe-inline': %s", csp)
+	}
+	if !strings.Contains(csp, "style-src 'self' 'unsafe-inline'") {
+		t.Errorf("CSP style-src must allow 'unsafe-inline' for Mermaid SVG styles: %s", csp)
 	}
 }
 


### PR DESCRIPTION
Mermaid.js generates inline `<style>` inside SVGs. CSP `style-src 'self'` blocked them. Fix: add `'unsafe-inline'` to style-src only (not script-src). Inline styles are not an XSS vector.