### PR TITLE
fix: correct pre-project dates from 2025 to 2026

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 BlogFlow
-Copyright 2025-2026 Ken Haines
+Copyright 2026 Ken Haines
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Posts live in `content/posts/` as markdown files with YAML front matter:
 ```yaml
 ---
 title: "My First Post"
-date: 2025-06-15T09:00:00Z
+date: 2026-03-23T09:00:00Z
 tags: ["go", "blogging"]
 draft: false
 ---

--- a/docs/content-authoring.md
+++ b/docs/content-authoring.md
@@ -9,7 +9,7 @@ description: "How to write blog content for BlogFlow: markdown, front matter, me
 
 > **Audience**: Blog authors and content editors  
 > **Prerequisite**: BlogFlow binary installed or running via Docker  
-> **Last Updated**: 2025-07-16
+> **Last Updated**: 2026-03-30
 
 This guide covers everything you need to write, organize, and publish content
 with BlogFlow. Start at [Writing Posts](#1-writing-posts) if you just want to
@@ -29,8 +29,8 @@ parses front matter up to **64 KB**.
 ---
 title: "Deploying to Kubernetes"
 slug: "deploying-to-kubernetes"
-date: 2025-06-20
-updated: 2025-07-01
+date: 2026-03-20
+updated: 2026-03-25
 tags: ["kubernetes", "devops"]
 categories: ["infrastructure"]
 author: "Jane Doe"
@@ -67,9 +67,9 @@ reading_time: 8
 
 Dates in front matter accept:
 
-- **Date only**: `2025-06-20` (interpreted as midnight UTC)
-- **Full RFC 3339**: `2025-06-20T14:30:00Z`
-- **With timezone**: `2025-06-20T14:30:00-07:00`
+- **Date only**: `2026-03-20` (interpreted as midnight UTC)
+- **Full RFC 3339**: `2026-03-20T14:30:00Z`
+- **With timezone**: `2026-03-20T14:30:00-07:00`
 
 Display format is controlled by `content.date_format` in `site.yaml` (default:
 `"January 2, 2006"`, following Go time layout conventions).
@@ -97,7 +97,7 @@ Draft posts are skipped during content scanning and never served.
 ```yaml
 ---
 title: "Work in Progress"
-date: 2025-07-10
+date: 2026-03-25
 draft: true
 ---
 ```
@@ -109,7 +109,7 @@ Override the default `post.html` template for a specific post:
 ```yaml
 ---
 title: "Photo Gallery"
-date: 2025-07-01
+date: 2026-03-22
 template: "gallery.html"
 ---
 ```

--- a/docs/theme-development.md
+++ b/docs/theme-development.md
@@ -9,7 +9,7 @@ description: "How to create and customize BlogFlow themes."
 
 > **Audience**: Theme developers and front-end engineers  
 > **Prerequisite**: Familiarity with HTML, CSS, and Go `html/template` syntax  
-> **Last Updated**: 2025-07-16
+> **Last Updated**: 2026-03-30
 
 This guide covers how to build, customize, and override BlogFlow themes. Start
 with the [directory structure](#1-theme-directory-structure) to understand the

--- a/examples/content/posts/getting-started-with-blogflow.md
+++ b/examples/content/posts/getting-started-with-blogflow.md
@@ -1,7 +1,7 @@
 ---
 title: "Getting Started with BlogFlow"
 slug: "getting-started-with-blogflow"
-date: 2025-01-20
+date: 2026-03-23
 tags: ["tutorial", "blogflow", "go"]
 description: "A step-by-step guide to setting up your blog with BlogFlow, from first post to custom configuration."
 author: "BlogFlow Team"
@@ -56,7 +56,7 @@ Create `my-blog/content/posts/first-post.md`:
 ---
 title: "My First Post"
 slug: "my-first-post"
-date: 2025-01-20
+date: 2026-03-23
 tags: ["hello"]
 description: "My very first blog post."
 ---

--- a/examples/content/posts/hello-world.md
+++ b/examples/content/posts/hello-world.md
@@ -1,7 +1,7 @@
 ---
 title: "Hello, World!"
 slug: "hello-world"
-date: 2025-01-15
+date: 2026-03-23
 tags: ["intro", "blogflow"]
 description: "Welcome to BlogFlow — a compact blog engine powered by Go and Markdown."
 draft: false

--- a/examples/content/posts/markdown-features.md
+++ b/examples/content/posts/markdown-features.md
@@ -1,7 +1,7 @@
 ---
 title: "Markdown Features"
 slug: "markdown-features"
-date: 2025-01-25
+date: 2026-03-23
 tags: ["markdown", "reference", "blogflow"]
 description: "A showcase of all Markdown features supported by BlogFlow's goldmark renderer."
 draft: false
@@ -96,7 +96,7 @@ YAML (front matter example):
 ---
 title: "My Post"
 slug: "my-post"
-date: 2025-01-25
+date: 2026-03-23
 tags: ["go", "blog"]
 draft: false
 ---


### PR DESCRIPTION
All dates referenced 2025 but the project started March 2026. Fixed across 7 files: guides, example content, NOTICE copyright, README.