### PR TITLE
feat: add starter content template for new blogs

### DIFF
--- a/examples/starter/.github/workflows/content-deploy.yml
+++ b/examples/starter/.github/workflows/content-deploy.yml
@@ -1,0 +1,67 @@
+# Content Deploy — Trigger BlogFlow webhook on content push
+#
+# This workflow notifies your BlogFlow instance whenever you push to main.
+# It sends a signed webhook payload so BlogFlow can pull the latest content.
+#
+# Required repository secrets:
+#   BLOGFLOW_WEBHOOK_URL    — Your BlogFlow webhook endpoint (e.g. https://blog.example.com/api/webhook)
+#   BLOGFLOW_WEBHOOK_SECRET — Shared secret for HMAC-SHA256 signature (min 32 chars)
+#
+# See: https://github.com/khaines/blogflow/blob/main/docs/deployment-guide.md
+
+name: Deploy Content
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Trigger BlogFlow Webhook
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger webhook
+        env:
+          WEBHOOK_URL: ${{ secrets.BLOGFLOW_WEBHOOK_URL }}
+          WEBHOOK_SECRET: ${{ secrets.BLOGFLOW_WEBHOOK_SECRET }}
+          REF_NAME: ${{ github.ref_name }}
+          REPO_NAME: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          # Build payload safely via jq (prevents JSON injection)
+          PAYLOAD=$(jq -n \
+            --arg ref "refs/heads/$REF_NAME" \
+            --arg repo "$REPO_NAME" \
+            --arg sha "$COMMIT_SHA" \
+            --arg msg "$COMMIT_MSG" \
+            '{ref: $ref, repository: {full_name: $repo}, head_commit: {id: $sha, message: $msg}}')
+
+          # Compute HMAC-SHA256 signature
+          SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | sed 's/.*= //')
+
+          # Send webhook
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -H "X-Hub-Signature-256: sha256=$SIGNATURE" \
+            -H "X-GitHub-Event: push" \
+            -H "X-GitHub-Delivery: $RUN_ID" \
+            -d "$PAYLOAD" \
+            "$WEBHOOK_URL")
+
+          echo "Webhook response: $HTTP_CODE"
+
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "::error::Webhook failed with HTTP $HTTP_CODE"
+            exit 1
+          fi
+
+          echo "✅ Content deploy triggered successfully"
+          echo "📝 Commit: $COMMIT_MSG"
+          echo "🔗 $SERVER_URL/$REPO_NAME/commit/$COMMIT_SHA"

--- a/examples/starter/README.md
+++ b/examples/starter/README.md
@@ -11,8 +11,8 @@ Copy or fork this directory to start your blog in minutes.
 # Copy the starter directory
 cp -r examples/starter ~/my-blog
 
-# Run BlogFlow pointing at your content
-blogflow --content ~/my-blog
+# Run BlogFlow pointing at your content and config
+blogflow --content ~/my-blog --config ~/my-blog/config
 ```
 
 Open <http://localhost:8080> to see your blog.
@@ -24,10 +24,14 @@ Open <http://localhost:8080> to see your blog.
 services:
   blogflow:
     image: ghcr.io/khaines/blogflow:latest
+    command: ["--content", "/data/content", "--config", "/data/config"]
     ports:
       - "8080:8080"
     volumes:
-      - ./my-blog:/content
+      - ./my-blog/posts:/data/content/posts:ro
+      - ./my-blog/pages:/data/content/pages:ro
+      - ./my-blog/static:/data/content/static:ro
+      - ./my-blog/config:/data/config:ro
     environment:
       BLOGFLOW_SYNC_STRATEGY: watch
 ```
@@ -61,8 +65,8 @@ Every Markdown file starts with YAML front matter between `---` fences:
 ```yaml
 ---
 title: "My Post Title"          # Required — displayed as the heading
-slug: "my-post-title"           # Required — URL path segment (/posts/my-post-title)
 date: 2026-03-30                # Required — publish date (YYYY-MM-DD)
+slug: "my-post-title"           # Optional — URL path segment (derived from filename if omitted)
 tags: ["go", "blogging"]        # Optional — list of tags for filtering
 description: "A short summary"  # Optional — used in feeds and meta tags
 draft: false                    # Optional — set to true to hide from listings

--- a/examples/starter/README.md
+++ b/examples/starter/README.md
@@ -1,0 +1,98 @@
+# BlogFlow Starter Content
+
+A ready-to-use content directory for [BlogFlow](https://github.com/khaines/blogflow).
+Copy or fork this directory to start your blog in minutes.
+
+## Quick start
+
+### Option 1 — Local development
+
+```bash
+# Copy the starter directory
+cp -r examples/starter ~/my-blog
+
+# Run BlogFlow pointing at your content
+blogflow --content ~/my-blog
+```
+
+Open <http://localhost:8080> to see your blog.
+
+### Option 2 — Docker Compose
+
+```yaml
+# docker-compose.yml
+services:
+  blogflow:
+    image: ghcr.io/khaines/blogflow:latest
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./my-blog:/content
+    environment:
+      BLOGFLOW_SYNC_STRATEGY: watch
+```
+
+```bash
+docker compose up
+```
+
+## Directory structure
+
+```
+starter/
+├── config/
+│   └── site.yaml          # Site configuration (title, author, theme, etc.)
+├── posts/                  # Blog posts (Markdown with YAML front matter)
+│   ├── welcome.md
+│   └── getting-started.md
+├── pages/                  # Static pages (about, contact, etc.)
+│   └── about.md
+├── static/                 # Static assets (images, CSS, JS)
+│   └── .gitkeep
+└── .github/
+    └── workflows/
+        └── content-deploy.yml  # CI workflow to trigger BlogFlow webhook
+```
+
+## Front matter reference
+
+Every Markdown file starts with YAML front matter between `---` fences:
+
+```yaml
+---
+title: "My Post Title"          # Required — displayed as the heading
+slug: "my-post-title"           # Required — URL path segment (/posts/my-post-title)
+date: 2026-03-30                # Required — publish date (YYYY-MM-DD)
+tags: ["go", "blogging"]        # Optional — list of tags for filtering
+description: "A short summary"  # Optional — used in feeds and meta tags
+draft: false                    # Optional — set to true to hide from listings
+---
+
+Your content here in Markdown…
+```
+
+### Posts vs. Pages
+
+| Feature         | Posts (`posts/`)                | Pages (`pages/`)              |
+| --------------- | ------------------------------- | ----------------------------- |
+| URL pattern     | `/posts/<slug>`                 | `/<slug>`                     |
+| Listed on index | ✅ Yes                          | ❌ No                         |
+| Date required   | ✅ Yes                          | ❌ Optional                   |
+| Appears in feed | ✅ Yes                          | ❌ No                         |
+
+## Customization
+
+- **Site settings** — edit `config/site.yaml` (title, author, base URL, etc.)
+- **Theme overrides** — set `theme.path` in site.yaml to a custom theme directory
+- **Static files** — drop images, CSS, or JS into `static/`
+
+## CI / Deployment
+
+The included `.github/workflows/content-deploy.yml` triggers a BlogFlow webhook
+whenever you push to `main`. To set it up:
+
+1. Add `BLOGFLOW_WEBHOOK_URL` and `BLOGFLOW_WEBHOOK_SECRET` as repository secrets
+2. Push to `main` — the workflow sends a signed webhook to your BlogFlow instance
+
+See the [BlogFlow deployment guide](https://github.com/khaines/blogflow/blob/main/docs/deployment-guide.md)
+for full details.

--- a/examples/starter/config/site.yaml
+++ b/examples/starter/config/site.yaml
@@ -1,0 +1,82 @@
+# BlogFlow Site Configuration — Starter Template
+# ================================================
+#
+# Customize your blog by editing the values below. BlogFlow merges these
+# with its built-in defaults — you only need to specify what you want to
+# override.
+#
+# Configuration priority (highest first):
+#   1. Environment variables (BLOGFLOW_*)
+#   2. This file (site.yaml)
+#   3. Built-in defaults
+#
+# Security note: NEVER put secrets (tokens, passwords, API keys) in this
+# file. Use environment variables for sensitive values.
+
+# ---------------------------------------------------------------------------
+# Site identity — displayed in templates, feeds, and meta tags
+# ---------------------------------------------------------------------------
+site:
+  title: "My Blog"                          # Site title (header and <title>)
+  description: "A blog powered by BlogFlow" # Meta description for SEO and feeds
+  base_url: "http://localhost:8080"          # Canonical base URL (use HTTPS in production)
+                                             # Override: BLOGFLOW_SITE_BASE_URL
+  language: "en"                             # BCP 47 language code
+  author:
+    name: ""                                 # Default author name for posts
+    email: ""                                # Author email (used in feeds)
+
+# ---------------------------------------------------------------------------
+# Content — where posts and pages live, how they're displayed
+# ---------------------------------------------------------------------------
+content:
+  posts_dir: "posts"          # Blog post directory (relative to content root)
+  pages_dir: "pages"          # Static pages directory (about, contact, etc.)
+  # media_dir: "media"        # Images and other media
+  posts_per_page: 10          # Posts on the index page (1–100)
+  date_format: "January 2, 2006"  # Go time layout for displayed dates
+  # summary_length: 200       # Characters for post summaries (50–1000)
+
+# ---------------------------------------------------------------------------
+# Theme — visual theme selection
+# ---------------------------------------------------------------------------
+theme:
+  name: "default"             # Theme name ("default" or a custom theme)
+  # path: ""                  # Path to custom theme directory (leave empty for default)
+
+# ---------------------------------------------------------------------------
+# Server — HTTP server settings
+# ---------------------------------------------------------------------------
+server:
+  port: 8080                  # Listen port. Override: BLOGFLOW_SERVER_PORT
+  # read_timeout: "5s"        # Max request read time
+  # write_timeout: "10s"      # Max response write time
+  # idle_timeout: "120s"      # Keep-alive idle timeout
+
+# ---------------------------------------------------------------------------
+# Cache — in-memory rendered content cache
+# ---------------------------------------------------------------------------
+cache:
+  enabled: true               # Enable/disable render cache
+  ttl: "1h"                   # Cache entry time-to-live (max 24h)
+  # max_entries: 1000         # Maximum cached pages (0–100000)
+
+# ---------------------------------------------------------------------------
+# Sync — how BlogFlow detects content changes
+# ---------------------------------------------------------------------------
+sync:
+  strategy: "watch"           # "watch" (local dev), "webhook", or "sidecar" (k8s)
+                              # Override: BLOGFLOW_SYNC_STRATEGY
+  # webhook:
+  #   path: "/api/webhook"
+  #   branch_filter: "main"
+  #   rate_limit: 10          # Max webhook requests per minute
+  #   secret: (use BLOGFLOW_WEBHOOK_SECRET env var — never put secrets here)
+
+# ---------------------------------------------------------------------------
+# Feed — RSS/Atom feed generation
+# ---------------------------------------------------------------------------
+feed:
+  enabled: true               # Serve a feed at /feed.xml (or /feed.atom)
+  type: "atom"                # "atom" or "rss"
+  items: 20                   # Posts in the feed (1–100)

--- a/examples/starter/pages/about.md
+++ b/examples/starter/pages/about.md
@@ -1,0 +1,24 @@
+---
+title: "About"
+slug: "about"
+description: "Learn more about this blog and its author."
+---
+
+# About
+
+Welcome! This blog is powered by [BlogFlow](https://github.com/khaines/blogflow),
+a lightweight blogging engine built with Go.
+
+## About the author
+
+<!-- Replace this section with your own bio -->
+
+Hi, I'm **Your Name**. I write about topics I find interesting. Thanks for
+stopping by!
+
+## About this site
+
+This site runs on BlogFlow — a Git-native, Markdown-first blog engine. Posts are
+written in Markdown, stored in a Git repository, and served with zero build step.
+
+Learn more at [github.com/khaines/blogflow](https://github.com/khaines/blogflow).

--- a/examples/starter/posts/getting-started.md
+++ b/examples/starter/posts/getting-started.md
@@ -1,0 +1,100 @@
+---
+title: "Getting Started with BlogFlow"
+slug: "getting-started"
+date: 2026-03-30
+tags: ["guide", "blogflow"]
+description: "How to add posts, customize your site, and deploy with BlogFlow."
+---
+
+This guide covers the basics of running and customizing your BlogFlow blog.
+
+## Adding posts
+
+Creating a new post is simple:
+
+1. **Create a file** — add a `.md` file in the `posts/` directory
+2. **Add front matter** — include the required YAML metadata at the top:
+
+   ```yaml
+   ---
+   title: "Your Post Title"
+   slug: "your-post-title"
+   date: 2026-04-15
+   tags: ["topic"]
+   description: "A brief summary."
+   ---
+   ```
+
+3. **Write content** — use standard Markdown below the front matter
+4. **Publish** — push to your `main` branch (webhook mode) or save the file (watch mode)
+
+BlogFlow detects changes automatically and updates your site without a restart.
+
+## Adding pages
+
+Static pages like "About" or "Contact" go in the `pages/` directory. They work
+just like posts but appear at the root URL path (`/about` instead of `/posts/about`).
+
+## Customizing your site
+
+### Site configuration
+
+Edit `config/site.yaml` to change your blog's identity:
+
+```yaml
+site:
+  title: "My Awesome Blog"
+  description: "Thoughts on code and coffee"
+  base_url: "https://myblog.example.com"
+  author:
+    name: "Your Name"
+    email: "you@example.com"
+```
+
+Every setting has a sensible default — you only need to override what you want to
+change. See the comments in `site.yaml` for all available options.
+
+### Theme overrides
+
+BlogFlow ships with a clean default theme. To customize it:
+
+1. Create a theme directory (e.g. `themes/custom/`)
+2. Add template overrides — only the files you include will replace the defaults
+3. Point to it in `site.yaml`:
+
+   ```yaml
+   theme:
+     name: "custom"
+     path: "themes/custom"
+   ```
+
+### Environment variables
+
+Any setting can be overridden with an environment variable prefixed with
+`BLOGFLOW_`. For example:
+
+```bash
+export BLOGFLOW_SITE_BASE_URL="https://myblog.example.com"
+export BLOGFLOW_SERVER_PORT=3000
+```
+
+Sensitive values like webhook secrets should **always** use environment variables
+rather than `site.yaml`.
+
+## Deployment
+
+The included CI workflow (`.github/workflows/content-deploy.yml`) triggers a
+BlogFlow webhook on every push to `main`. To set it up:
+
+1. Deploy BlogFlow to your server or container platform
+2. Add these repository secrets:
+   - `BLOGFLOW_WEBHOOK_URL` — your BlogFlow instance's webhook endpoint
+   - `BLOGFLOW_WEBHOOK_SECRET` — a shared secret (minimum 32 characters)
+3. Push content to `main` — BlogFlow pulls the latest changes automatically
+
+## Learn more
+
+- [BlogFlow README](https://github.com/khaines/blogflow#readme)
+- [Configuration reference](https://github.com/khaines/blogflow/blob/main/examples/config/site.yaml)
+- [Deployment guide](https://github.com/khaines/blogflow/blob/main/docs/deployment-guide.md)
+- [Kubernetes examples](https://github.com/khaines/blogflow/tree/main/examples/k8s)

--- a/examples/starter/posts/welcome.md
+++ b/examples/starter/posts/welcome.md
@@ -1,0 +1,42 @@
+---
+title: "Welcome to My Blog"
+slug: "welcome"
+date: 2026-03-30
+tags: ["welcome"]
+description: "Your first blog post with BlogFlow."
+---
+
+Welcome to your new blog, powered by [BlogFlow](https://github.com/khaines/blogflow)!
+
+This is a starter post to help you get going. Feel free to edit or delete it once
+you're comfortable.
+
+## Creating new posts
+
+To add a new blog post:
+
+1. Create a Markdown file in the `posts/` directory (e.g. `posts/my-first-post.md`)
+2. Add YAML front matter at the top of the file:
+
+   ```yaml
+   ---
+   title: "My First Post"
+   slug: "my-first-post"
+   date: 2026-04-01
+   tags: ["hello"]
+   description: "A short description for feeds and SEO."
+   ---
+   ```
+
+3. Write your content below the front matter using standard Markdown
+4. Push to `main` (or save locally if using file-watch mode)
+
+BlogFlow picks up changes automatically — no rebuild step required.
+
+## What's next?
+
+- Check out the [Getting Started](../posts/getting-started) guide for configuration tips
+- Edit `config/site.yaml` to set your blog title and author info
+- Replace the [About](../pages/about) page with your own bio
+
+Happy writing! ✍️

--- a/examples/starter/posts/welcome.md
+++ b/examples/starter/posts/welcome.md
@@ -35,8 +35,8 @@ BlogFlow picks up changes automatically — no rebuild step required.
 
 ## What's next?
 
-- Check out the [Getting Started](../posts/getting-started) guide for configuration tips
+- Check out the [Getting Started](/posts/getting-started) guide for configuration tips
 - Edit `config/site.yaml` to set your blog title and author info
-- Replace the [About](../pages/about) page with your own bio
+- Replace the [About](/about) page with your own bio
 
 Happy writing! ✍️


### PR DESCRIPTION
## Summary

Self-contained content directory (`examples/starter/`) that users can fork or copy to start a new BlogFlow blog.

### What's included

- **`README.md`** — Quick start guide, directory structure, front matter reference
- **`posts/welcome.md`** — Welcome post explaining how to create new posts
- **`posts/getting-started.md`** — How-to guide covering posts, config, themes, and deployment
- **`pages/about.md`** — About page placeholder
- **`config/site.yaml`** — Fully commented config with sensible defaults
- **`static/.gitkeep`** — Placeholder for user assets
- **`.github/workflows/content-deploy.yml`** — CI workflow for webhook-based deploys

### Usage

```bash
cp -r examples/starter ~/my-blog
blogflow --content ~/my-blog
```

Fixes #128
Fixes #132