### PR TITLE
feat: add OpenGraph and Twitter social preview cards

### DIFF
--- a/defaults/templates/base.html
+++ b/defaults/templates/base.html
@@ -11,6 +11,13 @@
     <meta property="og:description" content="{{block "og_description" .}}{{.Site.Description}}{{end}}">
     <meta property="og:type" content="{{block "og_type" .}}website{{end}}">
     <meta property="og:url" content="{{block "og_url" .}}{{.Site.BaseURL}}{{end}}">
+    {{if .Post}}{{if .Post.Image}}<meta property="og:image" content="{{.Post.Image}}">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="{{.Post.Image}}">
+    {{else}}<meta name="twitter:card" content="summary">
+    {{end}}{{else}}<meta name="twitter:card" content="summary">
+    {{end}}
+    {{if .Site.Social.Twitter}}<meta name="twitter:site" content="@{{.Site.Social.Twitter}}">{{end}}
     <link rel="icon" href="/static/images/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/static/css/main.css">
     {{if .Feed.Enabled}}<link rel="alternate" type="application/atom+xml" href="/feed.xml" title="{{.Site.Title}} Feed">{{end}}

--- a/examples/content/posts/hello-world.md
+++ b/examples/content/posts/hello-world.md
@@ -4,6 +4,7 @@ slug: "hello-world"
 date: 2026-03-23
 tags: ["intro", "blogflow"]
 description: "Welcome to BlogFlow — a compact blog engine powered by Go and Markdown."
+image: "https://images.unsplash.com/photo-1499750310107-5fef28a66643?w=1200"
 draft: false
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,12 @@ type SiteConfig struct {
 	Language    string       `yaml:"language"`
 	Author      AuthorConfig `yaml:"author"`
 	Homepage    string       `yaml:"homepage"` // "post_list" (default), "page:<slug>", or "static:<path>"
+	Social      SocialConfig `yaml:"social"`
+}
+
+// SocialConfig holds social media account identifiers.
+type SocialConfig struct {
+	Twitter string `yaml:"twitter"` // Twitter/X username (without @)
 }
 
 // AuthorConfig holds the site author details.


### PR DESCRIPTION
## Summary

Adds OpenGraph image and Twitter Card meta tags to blog posts, enabling rich social media preview cards when posts are shared.

### Changes

- **`defaults/templates/base.html`** — Added `og:image`, `twitter:card`, `twitter:image`, and `twitter:site` meta tags. Posts with an `image` front matter field get `summary_large_image` cards; posts without fall back to `summary`.
- **`internal/config/config.go`** — Added `SocialConfig` struct with `Twitter` field to `SiteConfig` (`social.twitter` in YAML) for the `twitter:site` meta tag.
- **`examples/content/posts/hello-world.md`** — Added `image` field to demonstrate the feature.

### How it works

1. Set `image:` in post front matter (already supported, just not rendered in templates)
2. Optionally set `social.twitter:` in `site.yaml` for `twitter:site`
3. Templates conditionally render OG/Twitter tags based on presence of image

Fixes #130