### PR TITLE
feat: add draft preview mode with token authentication

### DIFF
--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -235,15 +235,16 @@ func main() {
 	sitemapHandler := handlers.NewSitemapHandler(deps)
 
 	routeOpts := server.RouteOptions{
-		HomeHandler:      handlers.HomeHandler(deps),
-		ListHandler:      handlers.ListHandler(deps),
-		PostsListHandler: handlers.PostsListHandler(deps),
-		PostHandler:      handlers.PostHandler(deps),
-		PageHandler:      handlers.PageHandler(deps),
-		TagHandler:       handlers.TagHandler(deps),
-		FeedHandler:      feedHandler.ServeHTTP,
-		SitemapHandler:   sitemapHandler.ServeHTTP,
-		StaticFS:         staticFS,
+		HomeHandler:       handlers.HomeHandler(deps),
+		ListHandler:       handlers.ListHandler(deps),
+		PostsListHandler:  handlers.PostsListHandler(deps),
+		PostHandler:       handlers.PostHandler(deps),
+		PageHandler:       handlers.PageHandler(deps),
+		TagHandler:        handlers.TagHandler(deps),
+		FeedHandler:       feedHandler.ServeHTTP,
+		SitemapHandler:    sitemapHandler.ServeHTTP,
+		StaticFS:          staticFS,
+		PreviewMiddleware: handlers.PreviewMiddleware(deps),
 	}
 	if ws, ok := syncStrategy.(*gitops.WebhookStrategy); ok {
 		routeOpts.WebhookHandler = ws.Handler()

--- a/defaults/static/css/main.css
+++ b/defaults/static/css/main.css
@@ -627,7 +627,46 @@ main {
 }
 
 /* --------------------------------------------------------------------------
-   17. Reduced Motion
+   17. Preview Mode & Draft Badges
+   -------------------------------------------------------------------------- */
+.preview-banner {
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    padding: 0.5rem 1rem;
+    background: #f59e0b;
+    color: #1a1a2e;
+    text-align: center;
+    font-weight: 600;
+    font-size: 0.875rem;
+    letter-spacing: 0.02em;
+}
+
+.draft-badge {
+    display: inline-block;
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.25rem;
+    background: #f59e0b;
+    color: #1a1a2e;
+    font-size: 0.75em;
+    font-weight: 700;
+    text-transform: uppercase;
+    vertical-align: middle;
+}
+
+@media (prefers-color-scheme: dark) {
+    .preview-banner {
+        background: #d97706;
+        color: #ececf1;
+    }
+    .draft-badge {
+        background: #d97706;
+        color: #ececf1;
+    }
+}
+
+/* --------------------------------------------------------------------------
+   18. Reduced Motion
    -------------------------------------------------------------------------- */
 @media (prefers-reduced-motion: reduce) {
     html { scroll-behavior: auto; }

--- a/defaults/templates/base.html
+++ b/defaults/templates/base.html
@@ -17,6 +17,7 @@
 </head>
 <body>
     <a href="#main" class="skip-link">Skip to content</a>
+    {{template "partials/preview-banner.html" .}}
     {{template "partials/header.html" .}}
     <main id="main">
         {{block "content" .}}{{end}}

--- a/defaults/templates/list.html
+++ b/defaults/templates/list.html
@@ -6,7 +6,7 @@
     {{range .Posts}}
     <article class="post-summary">
         <header>
-            <h2><a href="/posts/{{.Slug}}">{{.Title}}</a></h2>
+            <h2><a href="/posts/{{.Slug}}">{{if .Draft}}<span class="draft-badge">[DRAFT]</span> {{end}}{{.Title}}</a></h2>
             {{template "post-meta" .}}
         </header>
         {{if .Summary}}<p class="summary">{{.Summary}}</p>{{end}}

--- a/defaults/templates/partials/preview-banner.html
+++ b/defaults/templates/partials/preview-banner.html
@@ -1,0 +1,5 @@
+{{define "partials/preview-banner.html"}}
+{{if .Preview}}
+<div class="preview-banner" role="alert">⚠️ Preview Mode — drafts are visible</div>
+{{end}}
+{{end}}

--- a/defaults/templates/post.html
+++ b/defaults/templates/post.html
@@ -9,7 +9,7 @@
 {{/* .Content must be template.HTML — caller is responsible for sanitizing markdown output before wrapping. */}}
 <article class="post">
     <header class="post-header">
-        <h1>{{.Post.Title}}</h1>
+        <h1>{{if .Post.Draft}}<span class="draft-badge">[DRAFT]</span> {{end}}{{.Post.Title}}</h1>
         {{template "post-meta" .Post}}
     </header>
     <div class="post-content">

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,12 +22,13 @@ type Config struct {
 
 // SiteConfig holds site identity settings.
 type SiteConfig struct {
-	Title       string       `yaml:"title"`
-	Description string       `yaml:"description"`
-	BaseURL     string       `yaml:"base_url"`
-	Language    string       `yaml:"language"`
-	Author      AuthorConfig `yaml:"author"`
-	Homepage    string       `yaml:"homepage"` // "post_list" (default), "page:<slug>", or "static:<path>"
+	Title        string       `yaml:"title"`
+	Description  string       `yaml:"description"`
+	BaseURL      string       `yaml:"base_url"`
+	Language     string       `yaml:"language"`
+	Author       AuthorConfig `yaml:"author"`
+	Homepage     string       `yaml:"homepage"` // "post_list" (default), "page:<slug>", or "static:<path>"
+	PreviewToken string       `yaml:"-"`        // never from YAML — env var only (BLOGFLOW_PREVIEW_TOKEN)
 }
 
 // AuthorConfig holds the site author details.
@@ -161,6 +162,9 @@ func (c Config) LogValue() slog.Value {
 	r := noMethods(c)
 	if r.Sync.Webhook.Secret != "" {
 		r.Sync.Webhook.Secret = "[REDACTED]"
+	}
+	if r.Site.PreviewToken != "" {
+		r.Site.PreviewToken = "[REDACTED]"
 	}
 	return slog.AnyValue(r)
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -417,11 +417,16 @@ var envMap = map[string]func(*Config, string) error{
 		c.Content.PagesDir = v
 		return nil
 	},
+	"BLOGFLOW_PREVIEW_TOKEN": func(c *Config, v string) error {
+		c.Site.PreviewToken = v
+		return nil
+	},
 }
 
 // secretEnvVars identifies env vars that should be redacted in logs.
 var secretEnvVars = map[string]bool{
 	"BLOGFLOW_WEBHOOK_SECRET": true,
+	"BLOGFLOW_PREVIEW_TOKEN":  true,
 }
 
 func applyEnvOverrides(cfg *Config, log *slog.Logger) ([]string, error) {

--- a/internal/content/scanner.go
+++ b/internal/content/scanner.go
@@ -30,13 +30,15 @@ type Post struct {
 
 // Index is the in-memory content index, built by scanning the content directory.
 type Index struct {
-	Posts      []*Post            // sorted by date descending
-	BySlug     map[string]*Post   // O(1) slug lookup
-	ByTag      map[string][]*Post // posts by tag
-	ByYear     map[int][]*Post    // posts by year
-	Pages      []*Post            // static pages (from pages/ dir), sorted by weight asc then title
-	PageBySlug map[string]*Post   // O(1) page slug lookup
-	scanErrors []error            // collected errors in best-effort mode
+	Posts       []*Post            // sorted by date descending
+	Drafts      []*Post            // draft posts, sorted by date descending
+	BySlug      map[string]*Post   // O(1) slug lookup (published only)
+	DraftBySlug map[string]*Post   // O(1) slug lookup (drafts only)
+	ByTag       map[string][]*Post // posts by tag
+	ByYear      map[int][]*Post    // posts by year
+	Pages       []*Post            // static pages (from pages/ dir), sorted by weight asc then title
+	PageBySlug  map[string]*Post   // O(1) page slug lookup
+	scanErrors  []error            // collected errors in best-effort mode
 }
 
 // Errors returns any errors collected during a best-effort scan.
@@ -128,6 +130,7 @@ func (s *Scanner) ScanContext(ctx context.Context, contentFS fs.FS, opts ...Scan
 
 	span.SetAttributes(
 		attribute.Int("content.posts_found", len(idx.Posts)),
+		attribute.Int("content.drafts_found", len(idx.Drafts)),
 		attribute.Int("content.pages_found", len(idx.Pages)),
 		attribute.Int("content.errors_skipped", errCount),
 		attribute.Int64("content.duration_ms", duration.Milliseconds()),
@@ -157,10 +160,11 @@ func (s *Scanner) Scan(contentFS fs.FS, opts ...ScanOption) (*Index, error) {
 	)
 
 	idx := &Index{
-		BySlug:     make(map[string]*Post),
-		ByTag:      make(map[string][]*Post),
-		ByYear:     make(map[int][]*Post),
-		PageBySlug: make(map[string]*Post),
+		BySlug:      make(map[string]*Post),
+		DraftBySlug: make(map[string]*Post),
+		ByTag:       make(map[string][]*Post),
+		ByYear:      make(map[int][]*Post),
+		PageBySlug:  make(map[string]*Post),
 	}
 
 	var errCount int
@@ -208,6 +212,11 @@ func (s *Scanner) Scan(contentFS fs.FS, opts ...ScanOption) (*Index, error) {
 		return idx.Posts[i].Date.After(idx.Posts[j].Date)
 	})
 
+	// Sort drafts by date descending
+	sort.SliceStable(idx.Drafts, func(i, j int) bool {
+		return idx.Drafts[i].Date.After(idx.Drafts[j].Date)
+	})
+
 	// Sort pages by weight ascending, then title alphabetically as tiebreaker
 	sort.SliceStable(idx.Pages, func(i, j int) bool {
 		if idx.Pages[i].Weight != idx.Pages[j].Weight {
@@ -231,6 +240,7 @@ func (s *Scanner) Scan(contentFS fs.FS, opts ...ScanOption) (*Index, error) {
 
 	s.logger.Info("content scan completed",
 		"posts", len(idx.Posts),
+		"drafts", len(idx.Drafts),
 		"pages", len(idx.Pages),
 		"errors_skipped", errCount,
 		"collected_errors", len(idx.scanErrors),
@@ -283,12 +293,22 @@ func (s *Scanner) scanDir(contentFS fs.FS, dir string, idx *Index, isPage, bestE
 		if fm == nil {
 			return nil // no front matter, skip
 		}
-		if fm.Draft {
-			return nil // skip drafts
+
+		// Drafts for pages are skipped entirely; draft posts are stored
+		// in the separate Drafts list for preview mode.
+		if fm.Draft && isPage {
+			return nil // skip draft pages
 		}
 
-		if !isPage && fm.Date.IsZero() {
+		if !isPage && !fm.Draft && fm.Date.IsZero() {
 			s.logger.Warn("skipping file: post missing required date",
+				"path", filePath,
+			)
+			skipped++
+			return nil
+		}
+		if !isPage && fm.Draft && fm.Date.IsZero() {
+			s.logger.Warn("skipping draft: post missing required date",
 				"path", filePath,
 			)
 			skipped++
@@ -350,6 +370,18 @@ func (s *Scanner) scanDir(contentFS fs.FS, dir string, idx *Index, isPage, bestE
 			}
 			idx.Pages = append(idx.Pages, post)
 			idx.PageBySlug[slug] = post
+		} else if fm.Draft {
+			if existing, ok := idx.DraftBySlug[slug]; ok {
+				dupeErr := fmt.Errorf("duplicate draft slug %q: %s conflicts with %s", slug, filePath, existing.Path)
+				if bestEffort {
+					idx.scanErrors = append(idx.scanErrors, dupeErr)
+					skipped++
+					return nil
+				}
+				return dupeErr
+			}
+			idx.Drafts = append(idx.Drafts, post)
+			idx.DraftBySlug[slug] = post
 		} else {
 			if existing, ok := idx.BySlug[slug]; ok {
 				dupeErr := fmt.Errorf("duplicate post slug %q: %s conflicts with %s", slug, filePath, existing.Path)

--- a/internal/content/scanner_test.go
+++ b/internal/content/scanner_test.go
@@ -119,7 +119,7 @@ func TestScan_MultiplePosts(t *testing.T) {
 	}
 }
 
-func TestScan_SkipDrafts(t *testing.T) {
+func TestScan_DraftsStoredSeparately(t *testing.T) {
 	fs := fstest.MapFS{
 		"posts/published.md": &fstest.MapFile{
 			Data: []byte(mkPost("Published", "pub", "2025-06-01", nil, false, "Content.\n")),
@@ -134,10 +134,70 @@ func TestScan_SkipDrafts(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(idx.Posts) != 1 {
-		t.Fatalf("expected 1 post (draft skipped), got %d", len(idx.Posts))
+		t.Fatalf("expected 1 published post, got %d", len(idx.Posts))
 	}
 	if idx.Posts[0].Slug != "pub" {
 		t.Errorf("expected published post, got slug %q", idx.Posts[0].Slug)
+	}
+	if len(idx.Drafts) != 1 {
+		t.Fatalf("expected 1 draft, got %d", len(idx.Drafts))
+	}
+	if idx.Drafts[0].Slug != "draft" {
+		t.Errorf("expected draft slug %q, got %q", "draft", idx.Drafts[0].Slug)
+	}
+	if idx.DraftBySlug["draft"] != idx.Drafts[0] {
+		t.Error("DraftBySlug lookup failed for draft")
+	}
+	// Drafts must not appear in the published index
+	if idx.BySlug["draft"] != nil {
+		t.Error("draft should not appear in BySlug (published index)")
+	}
+}
+
+func TestScan_DraftsSortedByDate(t *testing.T) {
+	fs := fstest.MapFS{
+		"posts/old-draft.md": &fstest.MapFile{
+			Data: []byte(mkPost("Old Draft", "old-draft", "2024-01-01", nil, true, "Old.\n")),
+		},
+		"posts/new-draft.md": &fstest.MapFile{
+			Data: []byte(mkPost("New Draft", "new-draft", "2025-06-01", nil, true, "New.\n")),
+		},
+	}
+
+	idx, err := newTestScanner().Scan(fs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(idx.Drafts) != 2 {
+		t.Fatalf("expected 2 drafts, got %d", len(idx.Drafts))
+	}
+	if idx.Drafts[0].Slug != "new-draft" {
+		t.Errorf("drafts[0] = %q, want %q (date descending)", idx.Drafts[0].Slug, "new-draft")
+	}
+	if idx.Drafts[1].Slug != "old-draft" {
+		t.Errorf("drafts[1] = %q, want %q", idx.Drafts[1].Slug, "old-draft")
+	}
+}
+
+func TestScan_DraftPageSkipped(t *testing.T) {
+	fs := fstest.MapFS{
+		"pages/draft-page.md": &fstest.MapFile{
+			Data: []byte(mkPost("Draft Page", "draft-page", "2025-01-01", nil, true, "Draft page.\n")),
+		},
+		"pages/about.md": &fstest.MapFile{
+			Data: []byte(mkPost("About", "about", "2025-01-01", nil, false, "About page.\n")),
+		},
+	}
+
+	idx, err := newTestScanner().Scan(fs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(idx.Pages) != 1 {
+		t.Fatalf("expected 1 page (draft page skipped), got %d", len(idx.Pages))
+	}
+	if len(idx.Drafts) != 0 {
+		t.Errorf("draft pages should not go into Drafts list, got %d", len(idx.Drafts))
 	}
 }
 

--- a/internal/server/handlers/handlers.go
+++ b/internal/server/handlers/handlers.go
@@ -82,6 +82,7 @@ type PageData struct {
 	Tag        string          // current tag filter
 	Title      string          // page title override
 	Pagination *Pagination
+	Preview    bool // true when the request is in preview mode
 }
 
 // Pagination holds paging metadata for list views.
@@ -128,10 +129,11 @@ func HomeHandler(deps *Deps) http.HandlerFunc {
 		}
 
 		data := &PageData{
-			Site:  cfg.Site,
-			Feed:  cfg.Feed,
-			Page:  page,
-			Title: page.Title,
+			Site:    cfg.Site,
+			Feed:    cfg.Feed,
+			Page:    page,
+			Title:   page.Title,
+			Preview: IsPreview(r.Context()),
 		}
 
 		renderTemplate(w, r, deps.Theme, "templates/page.html", data, http.StatusOK)
@@ -182,13 +184,19 @@ func PostsListHandler(deps *Deps) http.HandlerFunc {
 		cfg := deps.LoadConfig()
 		idx := deps.LoadIndex()
 		perPage := cfg.Content.PostsPerPage
+		preview := IsPreview(r.Context())
+
+		posts := idx.Posts
+		if preview {
+			posts = mergedPosts(idx)
+		}
 
 		page := queryInt(r, "page", 1)
 		if page < 1 {
 			page = 1
 		}
 
-		paged, pag := paginate(idx.Posts, page, perPage)
+		paged, pag := paginate(posts, page, perPage)
 		setPageURLs(pag, postsPageURL)
 
 		data := &PageData{
@@ -197,6 +205,7 @@ func PostsListHandler(deps *Deps) http.HandlerFunc {
 			Posts:      paged,
 			Title:      "Posts",
 			Pagination: pag,
+			Preview:    preview,
 		}
 
 		renderTemplate(w, r, deps.Theme, "templates/list.html", data, http.StatusOK)
@@ -210,6 +219,12 @@ func ListHandler(deps *Deps) http.HandlerFunc {
 		cfg := deps.LoadConfig()
 		idx := deps.LoadIndex()
 		perPage := cfg.Content.PostsPerPage
+		preview := IsPreview(r.Context())
+
+		posts := idx.Posts
+		if preview {
+			posts = mergedPosts(idx)
+		}
 
 		page, pathBased := parsePage(r)
 		if page < 0 {
@@ -224,12 +239,12 @@ func ListHandler(deps *Deps) http.HandlerFunc {
 		}
 
 		// For path-based requests, return 404 for out-of-range pages.
-		if pathBased && !validPage(len(idx.Posts), page, perPage) {
+		if pathBased && !validPage(len(posts), page, perPage) {
 			NotFoundHandler(deps)(w, r)
 			return
 		}
 
-		paged, pag := paginate(idx.Posts, page, perPage)
+		paged, pag := paginate(posts, page, perPage)
 		setPageURLs(pag, listPageURL)
 
 		data := &PageData{
@@ -238,6 +253,7 @@ func ListHandler(deps *Deps) http.HandlerFunc {
 			Posts:      paged,
 			Title:      "Posts",
 			Pagination: pag,
+			Preview:    preview,
 		}
 
 		renderTemplate(w, r, deps.Theme, "templates/list.html", data, http.StatusOK)
@@ -249,9 +265,13 @@ func ListHandler(deps *Deps) http.HandlerFunc {
 func PostHandler(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		slug := r.PathValue("slug")
+		preview := IsPreview(r.Context())
 
 		idx := deps.LoadIndex()
 		post, ok := idx.BySlug[slug]
+		if !ok && preview {
+			post, ok = idx.DraftBySlug[slug]
+		}
 		if !ok {
 			NotFoundHandler(deps)(w, r)
 			return
@@ -259,10 +279,11 @@ func PostHandler(deps *Deps) http.HandlerFunc {
 
 		cfg := deps.LoadConfig()
 		data := &PageData{
-			Site:  cfg.Site,
-			Feed:  cfg.Feed,
-			Post:  post,
-			Title: post.Title,
+			Site:    cfg.Site,
+			Feed:    cfg.Feed,
+			Post:    post,
+			Title:   post.Title,
+			Preview: preview,
 		}
 
 		renderTemplate(w, r, deps.Theme, "templates/post.html", data, http.StatusOK)
@@ -299,6 +320,7 @@ func PageHandler(deps *Deps) http.HandlerFunc {
 func TagHandler(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tag := r.PathValue("tag")
+		preview := IsPreview(r.Context())
 
 		idx := deps.LoadIndex()
 		posts, ok := idx.ByTag[tag]
@@ -321,6 +343,7 @@ func TagHandler(deps *Deps) http.HandlerFunc {
 			Tag:        tag,
 			Title:      "Posts tagged \"" + tag + "\"",
 			Pagination: pag,
+			Preview:    preview,
 		}
 
 		renderTemplate(w, r, deps.Theme, "templates/list.html", data, http.StatusOK)
@@ -339,6 +362,28 @@ func NotFoundHandler(deps *Deps) http.HandlerFunc {
 
 		renderTemplate(w, r, deps.Theme, "templates/404.html", data, http.StatusNotFound)
 	}
+}
+
+// mergedPosts returns published + draft posts merged and sorted by date
+// descending. Used in preview mode to include drafts in listings.
+func mergedPosts(idx *content.Index) []*content.Post {
+	if len(idx.Drafts) == 0 {
+		return idx.Posts
+	}
+	merged := make([]*content.Post, 0, len(idx.Posts)+len(idx.Drafts))
+	i, j := 0, 0
+	for i < len(idx.Posts) && j < len(idx.Drafts) {
+		if idx.Posts[i].Date.After(idx.Drafts[j].Date) || idx.Posts[i].Date.Equal(idx.Drafts[j].Date) {
+			merged = append(merged, idx.Posts[i])
+			i++
+		} else {
+			merged = append(merged, idx.Drafts[j])
+			j++
+		}
+	}
+	merged = append(merged, idx.Posts[i:]...)
+	merged = append(merged, idx.Drafts[j:]...)
+	return merged
 }
 
 // paginate returns a page slice and pagination metadata for the given posts.

--- a/internal/server/handlers/handlers.go
+++ b/internal/server/handlers/handlers.go
@@ -305,10 +305,11 @@ func PageHandler(deps *Deps) http.HandlerFunc {
 
 		cfg := deps.LoadConfig()
 		data := &PageData{
-			Site:  cfg.Site,
-			Feed:  cfg.Feed,
-			Page:  page,
-			Title: page.Title,
+			Site:    cfg.Site,
+			Feed:    cfg.Feed,
+			Page:    page,
+			Title:   page.Title,
+			Preview: IsPreview(r.Context()),
 		}
 
 		renderTemplate(w, r, deps.Theme, "templates/page.html", data, http.StatusOK)
@@ -323,8 +324,21 @@ func TagHandler(deps *Deps) http.HandlerFunc {
 		preview := IsPreview(r.Context())
 
 		idx := deps.LoadIndex()
-		posts, ok := idx.ByTag[tag]
-		if !ok || len(posts) == 0 {
+		posts := idx.ByTag[tag]
+
+		// In preview mode, include drafts that carry the requested tag.
+		if preview {
+			for _, d := range idx.Drafts {
+				for _, t := range d.Tags {
+					if t == tag {
+						posts = append(posts, d)
+						break
+					}
+				}
+			}
+		}
+
+		if len(posts) == 0 {
 			NotFoundHandler(deps)(w, r)
 			return
 		}
@@ -355,9 +369,10 @@ func NotFoundHandler(deps *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		cfg := deps.LoadConfig()
 		data := &PageData{
-			Site:  cfg.Site,
-			Feed:  cfg.Feed,
-			Title: "Page Not Found",
+			Site:    cfg.Site,
+			Feed:    cfg.Feed,
+			Title:   "Page Not Found",
+			Preview: IsPreview(r.Context()),
 		}
 
 		renderTemplate(w, r, deps.Theme, "templates/404.html", data, http.StatusNotFound)

--- a/internal/server/handlers/preview.go
+++ b/internal/server/handlers/preview.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"context"
+	"crypto/subtle"
+	"net/http"
+	"strings"
+)
+
+type contextKey string
+
+const previewKey contextKey = "preview"
+
+// IsPreview reports whether the request has preview mode enabled.
+func IsPreview(ctx context.Context) bool {
+	v, _ := ctx.Value(previewKey).(bool)
+	return v
+}
+
+// withPreview returns a new context with the preview flag set.
+func withPreview(ctx context.Context) context.Context {
+	return context.WithValue(ctx, previewKey, true)
+}
+
+// PreviewMiddleware checks for a valid preview token in the request.
+// If the token matches, the request context is annotated with a preview flag
+// that handlers use to include draft posts.
+//
+// Supported token sources (checked in order):
+//  1. Query parameter: ?preview=true&token=<secret>
+//  2. Authorization header: Bearer <secret>
+//
+// When the configured token is empty, preview mode is disabled and the
+// middleware is a no-op passthrough.
+func PreviewMiddleware(deps *Deps) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			cfg := deps.LoadConfig()
+			token := cfg.Site.PreviewToken
+			if token == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if matchesPreviewToken(r, token) {
+				r = r.WithContext(withPreview(r.Context()))
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// matchesPreviewToken checks query params and Authorization header for a
+// valid preview token. Uses constant-time comparison to prevent timing attacks.
+func matchesPreviewToken(r *http.Request, token string) bool {
+	// Check query parameter: ?preview=true&token=<secret>
+	if r.URL.Query().Get("preview") == "true" {
+		candidate := r.URL.Query().Get("token")
+		if candidate != "" && subtle.ConstantTimeCompare([]byte(candidate), []byte(token)) == 1 {
+			return true
+		}
+	}
+
+	// Check Authorization header: Bearer <secret>
+	if auth := r.Header.Get("Authorization"); auth != "" {
+		candidate := strings.TrimPrefix(auth, "Bearer ")
+		if candidate != auth && subtle.ConstantTimeCompare([]byte(candidate), []byte(token)) == 1 {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/server/handlers/preview_test.go
+++ b/internal/server/handlers/preview_test.go
@@ -38,6 +38,14 @@ func previewDeps(t *testing.T, token string) *handlers.Deps {
 		Content: template.HTML("<p>Draft content</p>"), //nolint:gosec
 	}
 
+	aboutPage := &content.Post{
+		FrontMatter: content.FrontMatter{
+			Title: "About",
+		},
+		Slug:    "about",
+		Content: template.HTML("<p>About page</p>"), //nolint:gosec
+	}
+
 	idx := &content.Index{
 		Posts:       []*content.Post{published},
 		Drafts:      []*content.Post{draft},
@@ -45,8 +53,8 @@ func previewDeps(t *testing.T, token string) *handlers.Deps {
 		DraftBySlug: map[string]*content.Post{"my-draft": draft},
 		ByTag:       map[string][]*content.Post{"go": {published}},
 		ByYear:      map[int][]*content.Post{2025: {published}},
-		Pages:       nil,
-		PageBySlug:  make(map[string]*content.Post),
+		Pages:       []*content.Post{aboutPage},
+		PageBySlug:  map[string]*content.Post{"about": aboutPage},
 	}
 
 	tmplFS := fstest.MapFS{
@@ -59,8 +67,11 @@ func previewDeps(t *testing.T, token string) *handlers.Deps {
 		"templates/post.html": &fstest.MapFile{
 			Data: []byte(`{{define "content"}}preview={{.Preview}}|post:{{.Post.Slug}}|draft={{.Post.Draft}}{{end}}`),
 		},
+		"templates/page.html": &fstest.MapFile{
+			Data: []byte(`{{define "content"}}preview={{.Preview}}|page:{{.Page.Slug}}{{end}}`),
+		},
 		"templates/404.html": &fstest.MapFile{
-			Data: []byte(`{{define "content"}}404{{end}}`),
+			Data: []byte(`{{define "content"}}preview={{.Preview}}|404{{end}}`),
 		},
 	}
 	eng, err := theme.NewEngine(tmplFS)
@@ -223,5 +234,76 @@ func TestPreview_PreviewFlagNotSetOnQueryOnly(t *testing.T) {
 	body := rec.Body.String()
 	if !strings.Contains(body, "preview=false") {
 		t.Errorf("expected preview=false without token, got body: %s", body)
+	}
+}
+
+func TestPreview_TagHandler_IncludesDraftsInPreview(t *testing.T) {
+	deps := previewDeps(t, "secret-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/tags/go?preview=true&token=secret-token", nil)
+	req.SetPathValue("tag", "go")
+	rec := httptest.NewRecorder()
+	wrapWithPreview(deps, handlers.TagHandler(deps)).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "my-draft") {
+		t.Errorf("expected draft post in tag listing in preview mode, got body: %s", body)
+	}
+	if !strings.Contains(body, "preview=true") {
+		t.Errorf("expected preview=true, got body: %s", body)
+	}
+}
+
+func TestPreview_TagHandler_ExcludesDraftsWithoutToken(t *testing.T) {
+	deps := previewDeps(t, "secret-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/tags/go", nil)
+	req.SetPathValue("tag", "go")
+	rec := httptest.NewRecorder()
+	wrapWithPreview(deps, handlers.TagHandler(deps)).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "my-draft") {
+		t.Errorf("draft should be hidden in tag listing without token, got body: %s", body)
+	}
+}
+
+func TestPreview_PageHandler_ShowsBanner(t *testing.T) {
+	deps := previewDeps(t, "secret-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/pages/about?preview=true&token=secret-token", nil)
+	req.SetPathValue("slug", "about")
+	rec := httptest.NewRecorder()
+	wrapWithPreview(deps, handlers.PageHandler(deps)).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "preview=true") {
+		t.Errorf("expected preview=true on page handler, got body: %s", body)
+	}
+}
+
+func TestPreview_NotFoundHandler_ShowsBanner(t *testing.T) {
+	deps := previewDeps(t, "secret-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/posts/nonexistent?preview=true&token=secret-token", nil)
+	req.SetPathValue("slug", "nonexistent")
+	rec := httptest.NewRecorder()
+	wrapWithPreview(deps, handlers.PostHandler(deps)).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "preview=true") {
+		t.Errorf("expected preview=true on 404 page, got body: %s", body)
 	}
 }

--- a/internal/server/handlers/preview_test.go
+++ b/internal/server/handlers/preview_test.go
@@ -1,0 +1,227 @@
+package handlers_test
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/khaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/content"
+	"github.com/khaines/blogflow/internal/server/handlers"
+	"github.com/khaines/blogflow/internal/theme"
+)
+
+func previewDeps(t *testing.T, token string) *handlers.Deps {
+	t.Helper()
+
+	published := &content.Post{
+		FrontMatter: content.FrontMatter{
+			Title: "Published Post",
+			Tags:  []string{"go"},
+			Date:  time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		},
+		Slug:    "published",
+		Content: template.HTML("<p>Published content</p>"), //nolint:gosec
+	}
+	draft := &content.Post{
+		FrontMatter: content.FrontMatter{
+			Title: "Draft Post",
+			Draft: true,
+			Tags:  []string{"go"},
+			Date:  time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+		},
+		Slug:    "my-draft",
+		Content: template.HTML("<p>Draft content</p>"), //nolint:gosec
+	}
+
+	idx := &content.Index{
+		Posts:       []*content.Post{published},
+		Drafts:      []*content.Post{draft},
+		BySlug:      map[string]*content.Post{"published": published},
+		DraftBySlug: map[string]*content.Post{"my-draft": draft},
+		ByTag:       map[string][]*content.Post{"go": {published}},
+		ByYear:      map[int][]*content.Post{2025: {published}},
+		Pages:       nil,
+		PageBySlug:  make(map[string]*content.Post),
+	}
+
+	tmplFS := fstest.MapFS{
+		"templates/base.html": &fstest.MapFile{
+			Data: []byte(`{{block "content" .}}{{end}}`),
+		},
+		"templates/list.html": &fstest.MapFile{
+			Data: []byte(`{{define "content"}}preview={{.Preview}}|posts={{len .Posts}}|{{range .Posts}}{{.Slug}}:draft={{.Draft}},{{end}}{{end}}`),
+		},
+		"templates/post.html": &fstest.MapFile{
+			Data: []byte(`{{define "content"}}preview={{.Preview}}|post:{{.Post.Slug}}|draft={{.Post.Draft}}{{end}}`),
+		},
+		"templates/404.html": &fstest.MapFile{
+			Data: []byte(`{{define "content"}}404{{end}}`),
+		},
+	}
+	eng, err := theme.NewEngine(tmplFS)
+	if err != nil {
+		t.Fatalf("creating theme engine: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.Site.PreviewToken = token
+	cfg.Content.PostsPerPage = 10
+
+	return handlers.NewDeps(cfg, idx, eng)
+}
+
+// wrapWithPreview applies the preview middleware to a handler for testing.
+func wrapWithPreview(deps *handlers.Deps, h http.HandlerFunc) http.Handler {
+	return handlers.PreviewMiddleware(deps)(h)
+}
+
+func TestPreview_DraftsHiddenByDefault(t *testing.T) {
+	deps := previewDeps(t, "secret-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	wrapWithPreview(deps, handlers.ListHandler(deps)).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "posts=1") {
+		t.Errorf("expected 1 post without preview, got body: %s", body)
+	}
+	if strings.Contains(body, "my-draft") {
+		t.Errorf("draft should be hidden without token, got body: %s", body)
+	}
+	if !strings.Contains(body, "preview=false") {
+		t.Errorf("expected preview=false, got body: %s", body)
+	}
+}
+
+func TestPreview_DraftsVisibleWithCorrectToken(t *testing.T) {
+	deps := previewDeps(t, "secret-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/?preview=true&token=secret-token", nil)
+	rec := httptest.NewRecorder()
+	wrapWithPreview(deps, handlers.ListHandler(deps)).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "posts=2") {
+		t.Errorf("expected 2 posts (published+draft) in preview, got body: %s", body)
+	}
+	if !strings.Contains(body, "my-draft") {
+		t.Errorf("expected draft post in preview mode, got body: %s", body)
+	}
+	if !strings.Contains(body, "preview=true") {
+		t.Errorf("expected preview=true, got body: %s", body)
+	}
+}
+
+func TestPreview_InvalidTokenHidesDrafts(t *testing.T) {
+	deps := previewDeps(t, "secret-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/?preview=true&token=wrong-token", nil)
+	rec := httptest.NewRecorder()
+	wrapWithPreview(deps, handlers.ListHandler(deps)).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "posts=1") {
+		t.Errorf("expected 1 post with wrong token, got body: %s", body)
+	}
+	if strings.Contains(body, "my-draft") {
+		t.Errorf("draft should be hidden with wrong token, got body: %s", body)
+	}
+}
+
+func TestPreview_BearerToken(t *testing.T) {
+	deps := previewDeps(t, "secret-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer secret-token")
+	rec := httptest.NewRecorder()
+	wrapWithPreview(deps, handlers.ListHandler(deps)).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "posts=2") {
+		t.Errorf("expected 2 posts with Bearer token, got body: %s", body)
+	}
+	if !strings.Contains(body, "preview=true") {
+		t.Errorf("expected preview=true with Bearer token, got body: %s", body)
+	}
+}
+
+func TestPreview_PostHandler_DraftVisible(t *testing.T) {
+	deps := previewDeps(t, "secret-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/posts/my-draft?preview=true&token=secret-token", nil)
+	req.SetPathValue("slug", "my-draft")
+	rec := httptest.NewRecorder()
+	wrapWithPreview(deps, handlers.PostHandler(deps)).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "post:my-draft") {
+		t.Errorf("expected draft post, got body: %s", body)
+	}
+	if !strings.Contains(body, "draft=true") {
+		t.Errorf("expected draft=true, got body: %s", body)
+	}
+}
+
+func TestPreview_PostHandler_DraftHiddenWithoutToken(t *testing.T) {
+	deps := previewDeps(t, "secret-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/posts/my-draft", nil)
+	req.SetPathValue("slug", "my-draft")
+	rec := httptest.NewRecorder()
+	wrapWithPreview(deps, handlers.PostHandler(deps)).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for draft without token, got %d", rec.Code)
+	}
+}
+
+func TestPreview_EmptyTokenDisablesPreview(t *testing.T) {
+	deps := previewDeps(t, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/?preview=true&token=anything", nil)
+	rec := httptest.NewRecorder()
+	wrapWithPreview(deps, handlers.ListHandler(deps)).ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "posts=1") {
+		t.Errorf("expected 1 post when token is empty (preview disabled), got body: %s", body)
+	}
+	if !strings.Contains(body, "preview=false") {
+		t.Errorf("expected preview=false when token is empty, got body: %s", body)
+	}
+}
+
+func TestPreview_PreviewFlagNotSetOnQueryOnly(t *testing.T) {
+	deps := previewDeps(t, "secret-token")
+
+	// preview=true but no token provided
+	req := httptest.NewRequest(http.MethodGet, "/?preview=true", nil)
+	rec := httptest.NewRecorder()
+	wrapWithPreview(deps, handlers.ListHandler(deps)).ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "preview=false") {
+		t.Errorf("expected preview=false without token, got body: %s", body)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -100,6 +100,11 @@ type RouteOptions struct {
 	SitemapHandler   http.HandlerFunc
 	WebhookHandler   http.HandlerFunc
 	StaticFS         fs.FS
+
+	// PreviewMiddleware wraps content handlers to check for a valid preview
+	// token and annotate the request context when present.
+	// If nil, preview mode is disabled.
+	PreviewMiddleware func(http.Handler) http.Handler
 }
 
 // RegisterRoutes sets up all HTTP routes. Call this after content and theme are loaded.
@@ -128,13 +133,19 @@ func (s *Server) RegisterRoutes(opts RouteOptions) {
 		panic("server: RegisterRoutes requires SitemapHandler")
 	}
 
-	// Content routes
-	s.mux.HandleFunc("GET /{$}", opts.HomeHandler)
-	s.mux.HandleFunc("GET /posts", opts.PostsListHandler)
-	s.mux.HandleFunc("GET /page/{page}", opts.ListHandler)
-	s.mux.HandleFunc("GET /posts/{slug}", opts.PostHandler)
-	s.mux.HandleFunc("GET /pages/{slug}", opts.PageHandler)
-	s.mux.HandleFunc("GET /tags/{tag}", opts.TagHandler)
+	// Content routes — wrapped with preview middleware when configured.
+	wrap := func(h http.HandlerFunc) http.Handler {
+		if opts.PreviewMiddleware != nil {
+			return opts.PreviewMiddleware(h)
+		}
+		return h
+	}
+	s.mux.Handle("GET /{$}", wrap(opts.HomeHandler))
+	s.mux.Handle("GET /posts", wrap(opts.PostsListHandler))
+	s.mux.Handle("GET /page/{page}", wrap(opts.ListHandler))
+	s.mux.Handle("GET /posts/{slug}", wrap(opts.PostHandler))
+	s.mux.Handle("GET /pages/{slug}", wrap(opts.PageHandler))
+	s.mux.Handle("GET /tags/{tag}", wrap(opts.TagHandler))
 
 	// Feed
 	if s.config.Feed.Enabled {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -295,7 +295,7 @@ func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
 		next.ServeHTTP(wrapped, r)
 		s.logger.Info("request",
 			"method", r.Method,
-			"path", r.URL.RequestURI(),
+			"path", redactRequestURI(r),
 			"status", wrapped.statusCode,
 			"duration", time.Since(start),
 			"remote", r.RemoteAddr,
@@ -303,6 +303,16 @@ func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
 			"request_id", RequestIDFromContext(r.Context()),
 		)
 	})
+}
+
+// redactRequestURI returns the request URI with sensitive query parameters masked.
+func redactRequestURI(r *http.Request) string {
+	q := r.URL.Query()
+	if q.Get("token") == "" {
+		return r.URL.RequestURI()
+	}
+	q.Set("token", "[REDACTED]")
+	return r.URL.Path + "?" + q.Encode()
 }
 
 func (s *Server) securityHeadersMiddleware(next http.Handler) http.Handler {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -566,6 +566,27 @@ func TestLoggingMiddleware_RequestURI(t *testing.T) {
 	}
 }
 
+func TestLoggingMiddleware_RedactsToken(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	cfg := defaultTestConfig()
+	s := New(cfg, logger)
+	s.RegisterRoutes(testRouteOptions())
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz?preview=true&token=super-secret", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+
+	logged := buf.String()
+	if strings.Contains(logged, "super-secret") {
+		t.Errorf("log must not contain raw token, got: %s", logged)
+	}
+	if !strings.Contains(logged, "REDACTED") {
+		t.Errorf("log should contain REDACTED for token, got: %s", logged)
+	}
+}
+
 func TestHealthEndpoint_CacheControl(t *testing.T) {
 	s := newTestServer(t)
 


### PR DESCRIPTION
## Summary

Posts with `draft: true` in front matter are now stored in a separate `Index.Drafts` list instead of being discarded during scanning. Normal handlers continue to skip drafts, but when a valid preview token is provided, drafts become visible.

### Changes

**Config** (`internal/config/config.go`, `loader.go`):
- Added `SiteConfig.PreviewToken` (env-only: `BLOGFLOW_PREVIEW_TOKEN`)
- Marked as secret (redacted in logs)

**Scanner** (`internal/content/scanner.go`):
- Draft posts stored in `Index.Drafts` and `Index.DraftBySlug`
- Draft pages still skipped (pages don't have preview semantics)
- Drafts sorted by date descending, same as published posts

**Preview middleware** (`internal/server/handlers/preview.go`):
- Checks `?preview=true&token=<secret>` query params
- Also supports `Authorization: Bearer <secret>` header
- Uses constant-time comparison to prevent timing attacks
- Stores preview flag in request context
- No-op when `PreviewToken` is empty (disabled by default)

**Handlers** (`internal/server/handlers/handlers.go`):
- `ListHandler` / `PostsListHandler`: merge drafts into listing in preview mode
- `PostHandler`: fall back to `DraftBySlug` in preview mode
- `PageData.Preview` flag passed to all templates
- `mergedPosts()` helper does a merge-sort of published + drafts

**Templates & CSS**:
- Preview banner partial with sticky yellow warning bar
- `[DRAFT]` badge on list items and post headers
- Dark mode support for banner/badge

### Testing
- 8 new preview handler tests covering: default hidden, valid token, invalid token, Bearer auth, single draft post, empty token disables, no token provided
- 3 new scanner tests: drafts stored separately, draft sorting, draft pages skipped
- All existing tests pass (`go test -race ./...`)

Fixes #131