### PR TITLE
fix: zero-downtime deployments with rolling revisions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,10 +2,19 @@ name: Deploy
 
 on:
   workflow_dispatch:
+    inputs:
+      full_deploy:
+        description: 'Run full Bicep deployment (not just image update)'
+        type: boolean
+        default: false
   workflow_run:
     workflows: [Publish]
     types: [completed]
     branches: [main]
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/azure/**'
 
 concurrency:
   group: deploy-production
@@ -21,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     environment: production
 
@@ -38,7 +48,11 @@ jobs:
         id: image
         run: echo "tag=sha-$(echo $GITHUB_SHA | cut -c1-7)" >> "$GITHUB_OUTPUT"
 
-      - name: Deploy Bicep template
+      # Full Bicep deploy — only on infra changes or explicit manual trigger
+      - name: Deploy Bicep template (full)
+        if: >-
+          github.event_name == 'push' ||
+          (github.event_name == 'workflow_dispatch' && inputs.full_deploy == true)
         run: |
           az deployment group create \
             --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
@@ -52,3 +66,15 @@ jobs:
               ghcrPassword="${{ secrets.GHCR_PASSWORD }}" \
               appInsightsConnectionString="${{ secrets.APPINSIGHTS_CONNECTION_STRING }}" \
               containerImage="ghcr.io/${{ github.repository }}:${{ steps.image.outputs.tag }}"
+
+      # Image-only update — after Publish or manual (default)
+      # Creates a new revision without full infra redeploy
+      - name: Update container image (rolling)
+        if: >-
+          github.event_name == 'workflow_run' ||
+          (github.event_name == 'workflow_dispatch' && inputs.full_deploy != true)
+        run: |
+          az containerapp update \
+            --name "${{ secrets.AZURE_ENVIRONMENT_NAME }}-app" \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --image "ghcr.io/${{ github.repository }}:${{ steps.image.outputs.tag }}"

--- a/deploy/azure/SETUP.md
+++ b/deploy/azure/SETUP.md
@@ -111,14 +111,56 @@ In **Settings → Environments → production → Environment secrets**, add:
 The workflow also runs automatically when the **Publish** workflow completes
 on main (i.e., after a new container image is pushed to GHCR).
 
-## 8. Custom Domain (Optional)
+## 8. Custom Domain + TLS (Optional)
 
 After the first deploy succeeds:
 
-1. Get the Container App FQDN from the Azure Portal (or from the workflow output)
-2. Add a **CNAME** record with your DNS provider:
+### DNS Setup
+
+1. Get the Container App FQDN from the deploy workflow output or Azure Portal
+2. Add a **CNAME** record at your DNS provider:
    ```
-   blogflow.io  CNAME  <container-app-fqdn>
+   www.blogflow.io  CNAME  <container-app-fqdn>
    ```
-3. In the Azure Portal, navigate to the Container App → **Custom domains**
-4. Add the custom domain and enable **Managed certificate** for automatic TLS
+   > **Note:** GoDaddy doesn't support CNAME on apex domains. Use `www` subdomain
+   > + domain forwarding (`blogflow.io` → `https://www.blogflow.io`).
+
+### Bind Domain + Managed TLS Certificate
+
+```bash
+# 1. Add the hostname
+az containerapp hostname add \
+  --name <app-name> \
+  --resource-group <rg-name> \
+  --hostname www.blogflow.io
+
+# 2. Bind with managed certificate (free, auto-renewed)
+az containerapp hostname bind \
+  --name <app-name> \
+  --resource-group <rg-name> \
+  --hostname www.blogflow.io \
+  --environment <env-name> \
+  --validation-method CNAME
+```
+
+### Make it Reproducible via Bicep (optional)
+
+After the managed certificate is provisioned, get its resource ID:
+```bash
+az containerapp env certificate list \
+  --name <env-name> \
+  --resource-group <rg-name> \
+  --query "[?properties.subjectName=='www.blogflow.io'].id" -o tsv
+```
+
+Then add these environment secrets:
+- `CUSTOM_DOMAIN_NAME` = `www.blogflow.io`
+- `CUSTOM_DOMAIN_CERT_ID` = the certificate resource ID
+
+And pass them in the deploy workflow's full Bicep step:
+```
+customDomainName="${{ secrets.CUSTOM_DOMAIN_NAME }}"
+customDomainCertificateId="${{ secrets.CUSTOM_DOMAIN_CERT_ID }}"
+```
+
+This ensures the domain binding survives a full infrastructure redeploy.

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -47,6 +47,12 @@ param scaleMinReplicas int = 0
 @maxValue(10)
 param scaleMaxReplicas int = 2
 
+@description('Custom domain hostname (e.g. www.blogflow.io). Empty = no custom domain.')
+param customDomainName string = ''
+
+@description('Managed certificate resource ID for custom domain TLS. Empty = no TLS binding.')
+param customDomainCertificateId string = ''
+
 // ---------------------------------------------------------------------------
 // Parameters — secrets (must come from GitHub Secrets / CLI --parameters)
 // ---------------------------------------------------------------------------
@@ -85,6 +91,8 @@ module containerApp 'modules/container-app.bicep' = {
     appInsightsConnectionString: appInsightsConnectionString
     scaleMinReplicas: scaleMinReplicas
     scaleMaxReplicas: scaleMaxReplicas
+    customDomainName: customDomainName
+    customDomainCertificateId: customDomainCertificateId
   }
 }
 

--- a/deploy/azure/modules/container-app.bicep
+++ b/deploy/azure/modules/container-app.bicep
@@ -37,6 +37,12 @@ param scaleMinReplicas int = 0
 @description('Maximum replica count')
 param scaleMaxReplicas int = 2
 
+@description('Custom domain hostname (e.g. www.blogflow.io). Empty = no custom domain.')
+param customDomainName string = ''
+
+@description('Managed certificate ID for custom domain TLS. Required when customDomainName is set.')
+param customDomainCertificateId string = ''
+
 // ---------------------------------------------------------------------------
 // Container App
 // ---------------------------------------------------------------------------
@@ -49,7 +55,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
   properties: {
     managedEnvironmentId: environmentId
     configuration: {
-      activeRevisionsMode: 'Single'
+      activeRevisionsMode: 'Multiple'
 
       // --- Ingress: external HTTPS on port 8080 ---
       ingress: {
@@ -57,6 +63,13 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
         targetPort: 8080
         transport: 'auto'
         allowInsecure: false
+        customDomains: customDomainName != '' ? [
+          {
+            name: customDomainName
+            certificateId: customDomainCertificateId
+            bindingType: customDomainCertificateId != '' ? 'SniEnabled' : 'Disabled'
+          }
+        ] : []
       }
 
       // --- Container registry credentials (GHCR) ---
@@ -167,17 +180,27 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
                 path: '/healthz'
                 port: 8080
               }
-              initialDelaySeconds: 5
+              initialDelaySeconds: 10
               periodSeconds: 15
             }
             {
               type: 'Readiness'
               httpGet: {
-                path: '/readyz'
+                path: '/readyz?strict=true'
                 port: 8080
               }
-              initialDelaySeconds: 3
-              periodSeconds: 10
+              initialDelaySeconds: 5
+              periodSeconds: 5
+              failureThreshold: 30
+            }
+            {
+              type: 'Startup'
+              httpGet: {
+                path: '/readyz?strict=true'
+                port: 8080
+              }
+              periodSeconds: 2
+              failureThreshold: 60
             }
           ]
         }


### PR DESCRIPTION
## Problem
Every deploy to Azure Container Apps causes downtime — old revision is killed before new one finishes cloning content.

## Fix (3 changes)
1. **`activeRevisionsMode: Multiple`** — blue-green: old revision keeps serving until new one is healthy
2. **Startup probe on `/readyz?strict=true`** — 2 min window for clone + scan before receiving traffic  
3. **Split workflow**: Publish triggers `az containerapp update` (image-only); full Bicep only on infra changes or manual

## Result
Old revision serves traffic → new revision starts + clones content → passes readyz → traffic shifts → old revision deactivated. Zero downtime.