### PR TITLE
fix: add --container-name to rolling image update

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,4 +84,5 @@ jobs:
           az containerapp update \
             --name "${{ secrets.AZURE_ENVIRONMENT_NAME }}-app" \
             --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --container-name blogflow \
             --image "ghcr.io/${{ github.repository }}:${{ steps.image.outputs.tag }}"


### PR DESCRIPTION
Multi-container apps require `--container-name blogflow` when using `az containerapp update --image`. Without it, Azure doesn't know which container to update.