### PR TITLE
fix(deploy): retain appinsights-cs secret during revision transition

### DIFF
--- a/deploy/azure/modules/container-app.bicep
+++ b/deploy/azure/modules/container-app.bicep
@@ -83,10 +83,17 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
       ]
 
       // --- Secrets ---
+      // NOTE: 'appinsights-cs' is retained as a placeholder during the transition
+      // from sidecar to managed OTel agent. Active revisions still reference it.
+      // Remove after all old revisions using it have been deactivated.
       secrets: [
         {
           name: 'ghcr-password'
           value: ghcrPassword
+        }
+        {
+          name: 'appinsights-cs'
+          value: 'deprecated-see-env-level-config'
         }
       ]
     }


### PR DESCRIPTION
## Problem

The deploy from PR #184 failed because active revision `prod-app--0000009` still references the `appinsights-cs` secret that was removed. ACA refuses to delete secrets referenced by active revisions.

```
ContainerAppSecretInUse: Container App has active revisions referencing 
secret you are trying to delete.
```

## Fix

Add a placeholder `appinsights-cs` secret with a dummy value. The new revision created by this deploy won't reference it (no env var uses `secretRef: appinsights-cs`), and once the old revision is deactivated, the placeholder can be removed in a follow-up PR.

Revisions `0000007` and `0000008` (zero traffic) have already been deactivated via CLI.

## Follow-up

After this deploys and `0000009` is no longer active, remove the placeholder secret.