### PR TITLE
deps: upgrade go-git to v5.19.0 and go-billy to v5.9.0 (security)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main / unreleased
 
+### Dependencies
+
+* [BUGFIX] Deps: Upgrade `go-git/v5` to v5.19.0 and `go-billy/v5` to v5.9.0 to address CVE-2026-44973 (go-billy path traversal), CVE-2026-45022 (go-git object parsing), and CVE-2026-44740 (go-billy symlink loops).
+
 ## 0.4.0 / 2026-04-26
 
 ### BlogFlow


### PR DESCRIPTION
## Summary

Upgrades go-git and go-billy to address three open code-scanning alerts on the repository.

## Alerts addressed

| Alert | Severity | CVE | Fix |
|---|---|---|---|
| #17 | error | [CVE-2026-44973](https://github.com/khaines/blogflow/security/code-scanning/17) — go-billy path traversal | go-billy v5.8.0 → **v5.9.0** |
| #16 | error | [CVE-2026-45022](https://github.com/khaines/blogflow/security/code-scanning/16) — go-git object parsing inconsistency | go-git v5.18.0 → **v5.19.0** |
| #18 | warning | [CVE-2026-44740](https://github.com/khaines/blogflow/security/code-scanning/18) — go-billy symlink loops | go-billy v5.8.0 → **v5.9.0** |

## Transitive updates

- `github.com/cyphar/filepath-securejoin` v0.4.1 → v0.6.1
- `github.com/pjbgf/sha1cd` v0.3.2 → v0.6.0
- `golang.org/x/net` v0.52.0 → v0.53.0
- `github.com/klauspost/cpuid/v2` added v2.3.0

## Validation

- `go build ./...` ✅
- `go test -count=1 -race -shuffle=on ./...` ✅ (all packages pass)

No source changes required; pure minor-version dependency bumps.