### PR TITLE
ci(deploy): deactivate superseded Container App revisions after deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,3 +88,74 @@ jobs:
             --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
             --container-name blogflow \
             --image "ghcr.io/${{ github.repository }}:${{ steps.image.outputs.tag }}"
+
+      # Cleanup — deactivate the previously deployed revision(s).
+      # The container app runs in 'Multiple' active-revisions mode, so both the
+      # rolling image update and the full Bicep deploy create a NEW revision but
+      # leave prior revisions Active (provisioned + billable). Left unchecked,
+      # these accumulate on every push to main. This step waits for the newest
+      # revision to report Healthy, then deactivates every older revision that is
+      # no longer serving traffic — leaving only the current deployment running.
+      - name: Deactivate superseded revisions
+        env:
+          APP_NAME: ${{ secrets.AZURE_ENVIRONMENT_NAME }}-app
+          RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+        run: |
+          set -euo pipefail
+
+          # The revision produced by the deploy step above.
+          latest="$(az containerapp show \
+            --name "$APP_NAME" \
+            --resource-group "$RESOURCE_GROUP" \
+            --query "properties.latestRevisionName" -o tsv)"
+          echo "Newest revision: $latest"
+
+          # Wait (bounded) for the new revision to become Healthy. We only reap
+          # old revisions once the new one is confirmed good, so a failed rollout
+          # keeps the prior revision(s) active as a fallback.
+          deadline=$(( SECONDS + 300 ))
+          while :; do
+            read -r health running provisioning <<< "$(az containerapp revision show \
+              --name "$APP_NAME" \
+              --resource-group "$RESOURCE_GROUP" \
+              --revision "$latest" \
+              --query "[properties.healthState, properties.runningState, properties.provisioningState]" \
+              -o tsv)"
+            echo "  health=$health running=$running provisioning=$provisioning"
+            if [ "$health" = "Healthy" ]; then
+              break
+            fi
+            if [ "$provisioning" = "Failed" ] || [ "$running" = "Failed" ]; then
+              echo "::error::New revision $latest failed to start (running=$running provisioning=$provisioning); leaving prior revisions active as a fallback."
+              exit 1
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "::error::Timed out waiting for $latest to become Healthy; leaving prior revisions active as a fallback."
+              exit 1
+            fi
+            sleep 10
+          done
+          echo "New revision $latest is Healthy."
+
+          # A revision cannot be deactivated while it is receiving traffic, so we
+          # only target Active, non-latest revisions with zero traffic weight
+          # (traffic auto-shifts to the latest revision via latestRevision=true).
+          query="[?properties.active && name!='$latest' && properties.trafficWeight==\`0\`].name"
+          mapfile -t stale < <(az containerapp revision list \
+            --name "$APP_NAME" \
+            --resource-group "$RESOURCE_GROUP" \
+            --query "$query" -o tsv)
+
+          if [ "${#stale[@]}" -eq 0 ]; then
+            echo "No superseded revisions to deactivate."
+            exit 0
+          fi
+
+          for rev in "${stale[@]}"; do
+            echo "Deactivating superseded revision: $rev"
+            az containerapp revision deactivate \
+              --name "$APP_NAME" \
+              --resource-group "$RESOURCE_GROUP" \
+              --revision "$rev"
+          done
+          echo "Deactivated ${#stale[@]} superseded revision(s)."

--- a/deploy/azure/SETUP.md
+++ b/deploy/azure/SETUP.md
@@ -127,6 +127,21 @@ The deployment creates:
 The workflow also runs automatically when the **Publish** workflow completes
 on main (i.e., after a new container image is pushed to GHCR).
 
+> **ℹ️ Note: Revision cleanup.** The container app runs in `Multiple`
+> active-revisions mode, so each deploy creates a new revision. After a
+> successful deploy, the workflow's `Deactivate superseded revisions` step waits
+> for the newest revision to report `Healthy`, then deactivates every older
+> zero-traffic revision so only the current deployment stays provisioned. A
+> failed/unhealthy rollout leaves the prior revisions Active as a fallback (and
+> fails the deploy job). To inspect revisions manually:
+>
+> ```bash
+> az containerapp revision list \
+>   --name <app-name> --resource-group <rg-name> \
+>   --query "[].{name:name, active:properties.active, traffic:properties.trafficWeight, health:properties.healthState}" \
+>   -o table
+> ```
+
 ## 8. Verify Metrics Are NOT Going to Log Analytics (Post-Deploy)
 
 After the first deploy, confirm metrics are **not** going to Log Analytics:


### PR DESCRIPTION
## Problem

Every deploy from `main` runs `az containerapp update`, which creates a **new Container App revision**. The app runs in `activeRevisionsMode: 'Multiple'` (`deploy/azure/modules/container-app.bicep`), so ACA leaves prior revisions **Active** (provisioned + billable). Nothing ever deactivated them, so old revisions accumulated on every push.

## Fix

Add a `Deactivate superseded revisions` step to `.github/workflows/deploy.yml` that runs after the deploy (both the rolling image update and the full Bicep path):

1. Resolves the newest revision via `properties.latestRevisionName`.
2. **Polls until it reports `Healthy`** (5-minute bound) — cleanup only happens once the new revision is confirmed good.
3. Deactivates every older **zero-traffic, non-latest** revision. Traffic auto-shifts to the latest revision via `latestRevision=true`, and ACA forbids deactivating a revision that is still receiving traffic — so the `trafficWeight==0` filter keeps this safe.
4. **Fail-safe:** if the new revision fails to provision or never becomes `Healthy`, the step exits non-zero and leaves prior revisions Active as a fallback (surfaces the bad deploy instead of reaping the last-good revision).

Also documents the behavior and a manual revision-inspection command in `deploy/azure/SETUP.md`.

## Validation

No Azure access in the authoring environment, so the step logic was validated with `bash -n` plus a mock-`az` harness covering:

- happy path (multiple stale revisions reaped),
- no-superseded-revisions (exit 0, no-op),
- failed rollout (fast-fail, exit 1, prior revisions untouched).

Confirmed the JMESPath `trafficWeight==\`0\`` filter reaches `az` with **literal backticks** (no shell command-substitution).

## Notes

- This keeps `Multiple` revision mode and cleans up in the pipeline. An alternative is switching the app to `Single` revision mode (ACA auto-deactivates the old revision on health), but that is a larger infra/behavior change and is intentionally out of scope here.
- No `CHANGELOG.md` entry: this is an operational/CI-only change, not a code change.