### PR TITLE
docs: relocate test-gap-analysis out of design/ and fix stale citations

### DIFF
--- a/docs/engineering/notes/README.md
+++ b/docs/engineering/notes/README.md
@@ -1,0 +1,3 @@
+# Engineering Notes
+
+This directory holds non-spec engineering notes, trackers, and operational checklists. Permanent component specifications and ADR-style design documents belong in [`../design/`](../design/) and must follow that directory's design document template.

--- a/docs/engineering/notes/test-gap-analysis.md
+++ b/docs/engineering/notes/test-gap-analysis.md
@@ -29,6 +29,7 @@
 ### 3\. Webhook IP allowlist enforcement gap ✅ [✓] Closed
 
 **Resolved**: `internal/config/config.go:103` adds `AllowedIPs []string yaml:"allowed_ips"` to WebhookConfig. Implementation in `internal/gitops/webhook.go:111-112` filters source IPs against `AllowedIPs` (returns HTTP 403 for non-listed IPs). Tests in `internal/gitops/webhook_ip_allowlist_test.go` cover allowed, blocked, and empty-allowlist defaults. Design doc updated in `docs/engineering/design/configuration-system.md` §2.4 (ARC2 fix).
+
 ### 4\. Config file size >1 MB rejection not proven ✅ [✓] Closed
 
 **Resolved**: `internal/config/loader.go:26` defines `const maxConfigFileSize = 1 << 20` (1 MB). `internal/config/loader.go:135-140` rejects files exceeding this limit with a 1 MB error. Direct test at `internal/config/config_test.go:263-281` (`TestLoad_FileSizeLimit`) creates a 2 MB file and asserts the 1 MB error message.
@@ -78,7 +79,7 @@ No direct test validates that sync triggers (webhook/git-sync/hot-watch) invalid
 
 **Resolved**: `internal/overlayfs/symlink_escape_test.go` covers symlink escape checks against actual symlinks pointing outside configured layer boundaries, addressing the security implications previously flagged.
 
-### 15\. Overlay FS max read size limit enforcement
+### 15\. Overlay FS max read size limit enforcement ✅ [✓] Closed
 
 The overlay filesystem has a distinct 64 MiB per-file read bound via `internal/overlayfs/overlayfs.go:671` (`maxReadSize`). This applies to files read through overlayfs, including templates and static assets, and is separate from the configuration loader's 1 MB `internal/config/loader.go:26` `maxConfigFileSize` limit for `site.yaml`. `internal/overlayfs/max_read_size_test.go` (`TestLargeFileRejection`) covers rejection for files larger than `maxReadSize`.
 
@@ -112,7 +113,7 @@ Each accepted issue must satisfy:
 
 ## Notes & References
 
-1. Design source: `docs/engineering/design/configuration-system.md` (§3.1-§7, §8 acceptance criteria mapping table lines 264+)
+1. Design source: `docs/engineering/design/configuration-system.md` (§3.1-§7, §3.4 acceptance criteria mapping table around line 613)
 2. Coverage checklist generated from scan of existing `*_test.go` files using file counts and coverage maps across subsystems  
    - See CI workflow `.github/workflows/ci.yml` smoke tests for baseline HTTP endpoint checks. CSP header coverage for 404 and `/metrics` is now resolved by `internal/server/csp_coverage_test.go`; rate-limit edge-path coverage remains separate from those closed CSP checks.
 3. Theme dev guide `docs/theme-development.md` covers static asset serving rules (§7-8 sections). CSS injection prevention and partial include error-path tests remain useful follow-ups; CSP header presence on non-page responses is resolved by `internal/server/csp_coverage_test.go`.
@@ -134,6 +135,6 @@ Historical note: these follow-up issues were subsequently filed, including #216 
 **Status Checklist**: Each item gets: `[ ]` for "not covered", `[ ✓] when test passes, `[ ?] if pending design doc review`. Mark coverage status as we add tests incrementally rather than waiting for full PR cycle first (allows early visibility into missing areas). This helps prioritize security-sensitive gaps before lower-risk enhancements.
 
 **Review Checklist Per Persona**:
-- Security SME: Validate 🔴 items #12, #4 webhook IP allowlist, secret length minimums, symlink escape detection  
-- Systems Engineer: Verify 🟡 race condition concurrency tests (#5), environment variable override validation rules (#17)  
-- Cloud-Native SRE: Confirm low-priority performance regression benchmarks in stress test scenarios from items list above
+- Security SME: Re-check closed security coverage (#1 CSP, #2/#14 symlink escape, #3 webhook IP allowlist, #5 secret length) only if those areas change again.
+- Systems Engineer: Verify remaining open implementation/test gaps for theme/template behavior (#7, #8, #10) and targeted hot-reload invalidation (#12).
+- Cloud-Native SRE: Confirm remaining open cache reload performance regression benchmark coverage (#18).

--- a/docs/engineering/notes/test-gap-analysis.md
+++ b/docs/engineering/notes/test-gap-analysis.md
@@ -24,22 +24,22 @@
 
 ### 2\. Symlink path-traversal bypass from theme overlays accessing outside-layer files ✅ [✓] Closed
 
-**Resolved**: `internal/gitops/symlink_escape_test.go` covers symlink escape detection in overlay FS under path-traversal conditions, confirming tests exist that prevent symlinks from escaping layer boundaries.
+**Resolved**: `internal/overlayfs/symlink_escape_test.go` (`TestCheckSymlinkSafe_RejectsEscapeFromOverlay`, `TestCheckSymlinkSafe_RejectsRootSymlinkEscape`, `TestCheckSymlinkSafe_RejectsNestedChainEscape`, `TestOverlayFS_SymlinkOpen`) covers symlink escape detection in overlay FS under path-traversal conditions, confirming tests exist that prevent symlinks from escaping layer boundaries.
 
 ### 3\. Webhook IP allowlist enforcement gap ✅ [✓] Closed
 
-**Resolved**: `internal/config/config.go:97` adds `AllowedIPs []string yaml:"allowed_ips"` to WebhookConfig. Implementation in `internal/gitops/webhook.go:101-105` filters source IPs against `AllowedIPs` (returns HTTP 403 for non-listed IPs). Tests in `internal/gitops/webhook_ip_allowlist_test.go` cover allowed, blocked, and empty-allowlist defaults. Design doc updated in configuration-system.md §2.4 (ARC2 fix).
+**Resolved**: `internal/config/config.go:103` adds `AllowedIPs []string yaml:"allowed_ips"` to WebhookConfig. Implementation in `internal/gitops/webhook.go:111-112` filters source IPs against `AllowedIPs` (returns HTTP 403 for non-listed IPs). Tests in `internal/gitops/webhook_ip_allowlist_test.go` cover allowed, blocked, and empty-allowlist defaults. Design doc updated in configuration-system.md §2.4 (ARC2 fix).
 ### 4\. Config file size >1 MB rejection not proven ✅ [✓] Closed
 
-**Resolved**: `internal/config/loader.go:25` defines `const maxConfigFileSize = 1 << 20` (1 MB). `internal/config/loader.go:132-133` rejects files exceeding this limit with "config file exceeds 1 MB limit". Direct test at `internal/config/config_test.go:263-281` (`TestLoad_FileSizeLimit`) creates a 2 MB file and asserts the 1 MB error message.
+**Resolved**: `internal/config/loader.go:26` defines `const maxConfigFileSize = 1 << 20` (1 MB). `internal/config/loader.go:135-140` rejects files exceeding this limit with a 1 MB error. Direct test at `internal/config/config_test.go:263-281` (`TestLoad_FileSizeLimit`) creates a 2 MB file and asserts the 1 MB error message.
 
 ### 5\. Webhook secret must be ≥32 bytes enforced at startup ✅ [✓] Closed
 
-**Resolved**: `internal/gitops/webhook.go` enforces minimum secret length (32 bytes) in `NewWebhookStrategy`. `internal/gitops/webhook_secret_length_test.go` (`TestNewWebhookStrategy_SecretBoundary`) tests 31, 32, and 64 byte boundary cases. `internal/gitops/webhook_secret_logging_test.go` verifies secret length requirement.
+**Resolved**: `internal/gitops/webhook.go:55-60` enforces minimum secret length (32 bytes) in `NewWebhookStrategy`. `internal/gitops/sync_test.go` (`TestNewWebhookStrategy_SecretBoundary`) tests 31, 32, and 64 byte boundary cases.
 
 ### 6.`BLOGFLOW_GIT_TOKEN` env var — injection and logging leak prevention ✅ [✓] Closed
 
-**Resolved**: `internal/gitops/auth.go:38` stores `Token string` in `AuthConfig`. `internal/gitops/auth.go:64` redacts the token in `LogValue()` via `slog.String("token", "[REDACTED]")`. Integration test at `internal/gitops/auth_test.go:216-222` (`TestLoadAuthFromEnv_LogValueRedaction`) asserts the raw token value is absent from logged output and `[REDACTED]` is present.
+**Resolved**: `internal/gitops/auth.go:38` stores `Token string` in `AuthConfig`. `internal/gitops/auth.go:64` redacts the token in `LogValue()` via `slog.String("token", "[REDACTED]")`. Integration test at `internal/gitops/auth_test.go:213-222` (`TestAuthConfig_LogValueRedaction`) asserts the raw token value is absent from logged output and `[REDACTED]` is present.
 
 ---
 
@@ -58,8 +58,9 @@ The template engine currently doesn't fail fast if a `{{define "name"}}` block i
 ### 10\. Partial path resolution error message coverage
 When template includes call references a partial that doesn't exist the system should return a clear user-friendly parse-time error pointing to missing file location instead of generic "template not found" from html/template fallback handler on default layer only (which could mask content directory errors).
 
-### 11\. YAML anchor/alias rejection test for DOS prevention
-Config files using `&anchor` or `*` aliases in unquoted scalar value positions should be rejected with explicit error message; tests need to parse raw bytes and show that billion-laughs-style expansion attacks are explicitly blocked before struct fields even start allocating memory (defense-in-depth layer).
+### 11\. YAML anchor/alias rejection test for DOS prevention ✅ [✓] Closed
+
+**Resolved**: `internal/config/config_test.go:220-260` (`TestLoad_AnchorAlias`) verifies bare anchors and aliases are rejected with errors mentioning anchors/aliases, while a quoted glob containing `*` is accepted. This covers the defense-in-depth check before YAML aliases can allocate expanded structures.
 
 ### 12\. Hot-reload path through sync invalidating fewer layers 🔴 Open (no coverage)
 
@@ -69,23 +70,25 @@ No direct test validates that sync triggers (webhook/git-sync/hot-watch) invalid
 
 ## 🟢 Low Priority Nice-to-Have — Future Work for Defensive Coverage
 
-### 13\. Negative cache admission-cap policy verification ✅ [✓] Closed
+### 13\. Negative cache eviction policy verification ✅ [✓] Closed
 
-**Resolved**: `negcache_admission_test.go` covers admission-cap policy (at capacity, new misses skip caching) verifying bounded memory. No eviction of oldest entries — unbounded-growth prevented by load-or-store gate.
+**Resolved**: `internal/overlayfs/negcache_admission_test.go` covers the existing admission-cap policy, verifying bounded memory when the cache reaches capacity. The eviction wording is addressed by #245, which updates the behavior to true LRU eviction of the least-recently-used negative-cache entry.
 
 ### 14\. stat.Symlink path traversal detection tested ✅ [✓] Closed
 
-**Resolved**: `symlink_escape_test.go` covers symlink escape checks against actual symlinks pointing outside configured layer boundaries, addressing the security implications previously flagged.
+**Resolved**: `internal/overlayfs/symlink_escape_test.go` covers symlink escape checks against actual symlinks pointing outside configured layer boundaries, addressing the security implications previously flagged.
 
-### 15\. Max template file size limit enforcement. Templates exceeding ~64 MB threshold not tested for immediate rejection before memory allocation occurs, potentially leading to OOM under attack; verify early failure mode exists now and always runs during compile time even with embedded defaults baked in as fallback source of truth when user uploads oversized file via git pull or content sync strategy deployment pipeline stages allow such files to land on disk temporarily).
+### 15\. Overlay FS max read size limit enforcement
+
+The overlay filesystem has a distinct 64 MiB per-file read bound via `internal/overlayfs/overlayfs.go:669-680` (`maxReadSize`). This applies to files read through overlayfs, including templates and static assets, and is separate from the configuration loader's 1 MB `internal/config/loader.go:26` `maxConfigFileSize` limit for `site.yaml`. `internal/overlayfs/max_read_size_test.go` (`TestLargeFileRejection`) covers rejection for files larger than `maxReadSize`.
 
 ### 16\. Webhook secret logging redaction test ✅ [✓] Closed
 
-**Resolved**: `internal/config/webhook_log_redaction_test.go` (`TestWebhookConfig_LogValueRedaction`) directly exercises `WebhookConfig.LogValue()` — logs a `WebhookConfig` as an slog attribute and asserts `[REDACTED]` is present and the raw secret is absent. Mutation-verifiable: breaking `LogValue()` causes this test to fail. The hollow integration test in `webhook_secret_logging_test.go` was replaced by this direct LogValue exercise. The dead `loader.Load()` call in `webhook_secret_length_test.go` was also removed.
+**Resolved**: `internal/config/webhook_log_redaction_test.go` (`TestWebhookConfig_LogValueRedaction`) directly exercises `WebhookConfig.LogValue()` — logs a `WebhookConfig` as an slog attribute and asserts `[REDACTED]` is present and the raw secret is absent. Mutation-verifiable: breaking `LogValue()` causes this test to fail. Prior indirect coverage was replaced by this direct `LogValue()` exercise.
 
-### 17\. Environment variable override validation completeness 🔴 Open (no coverage)
+### 17\. Environment variable override validation completeness ✅ [✓] Closed
 
-**Status**: Tests for BLOGFLOW_* overrides exist but only validate successful type conversions — not negative cases like providing a non-integer string to a port field that silently falls back to YAML default without logging a warning (user should be alerted about the ignored/bad value before config load completes and returns invalid configuration state).
+**Resolved**: `internal/config/env_override_test.go` covers invalid override values (`TestEnvOverrideInvalidPort`, `TestEnvOverrideInvalidMetricsPort`, `TestEnvOverrideInvalidBool`) and successful server port override (`TestEnvOverrideValidServerPort`). `internal/config/config_test.go:584-595` (`TestLoad_EnvOverrideError`) also verifies invalid `BLOGFLOW_SERVER_PORT` values return an environment override error instead of silently falling back to YAML/default values.
 
 ### 18\. Cache reload performance regression detection 🔴 Open (no coverage)
 

--- a/docs/engineering/notes/test-gap-analysis.md
+++ b/docs/engineering/notes/test-gap-analysis.md
@@ -10,9 +10,9 @@
 
 | Priority | Count | Description |
 |----------|-------|-------------|
-| **Critical (🔴)** | 6 | Security-sensitive issues affecting CSP/headers path traversal rate limits secret handling config file size limit enforcement, webhook IP allowlist missing, git-token logging leak prevention. |
-| High priority 🟡) | 9 | Important gaps: theme partial override behavior validation + error paths for partial include resolution when templates aren't found (vs happy-path), template functions completeness tests like `readingTime` edge cases on zero/nil input sizes etc., symlink escape detection in overlay FS not proven tested under path-traversal conditions, concurrent reload during active request processing race condition verification needed. |
-| Low priority 🟢) | 3 | Nice-to-have defensive coverage: negative cache eviction policy for absent paths over max capacity limits (100K entries threshold), hot-reload performance regression detection when sync invalidates only changed layers not entire stack, file size ≥64MB enforcement in template assets. |
+| **Critical (🔴)** | 6 | Security-sensitive issues tracked for CSP/headers, path traversal, rate limits, secret handling, config file size limit enforcement, webhook IP allowlist, and git-token logging leak prevention. |
+| High priority 🟡) | 9 | Important gaps: theme partial override behavior validation + error paths for partial include resolution when templates aren't found (vs happy-path), template functions completeness tests like `readingTime` edge cases on zero/nil input sizes, and concurrent reload during active request processing race condition verification. |
+| Low priority 🟢) | 3 | Nice-to-have defensive coverage tracked for negative-cache eviction policy, hot-reload performance regression detection when sync invalidates only changed layers, and file-size enforcement in template/static assets. |
 
 ---
 
@@ -28,7 +28,7 @@
 
 ### 3\. Webhook IP allowlist enforcement gap ✅ [✓] Closed
 
-**Resolved**: `internal/config/config.go:103` adds `AllowedIPs []string yaml:"allowed_ips"` to WebhookConfig. Implementation in `internal/gitops/webhook.go:111-112` filters source IPs against `AllowedIPs` (returns HTTP 403 for non-listed IPs). Tests in `internal/gitops/webhook_ip_allowlist_test.go` cover allowed, blocked, and empty-allowlist defaults. Design doc updated in configuration-system.md §2.4 (ARC2 fix).
+**Resolved**: `internal/config/config.go:103` adds `AllowedIPs []string yaml:"allowed_ips"` to WebhookConfig. Implementation in `internal/gitops/webhook.go:111-112` filters source IPs against `AllowedIPs` (returns HTTP 403 for non-listed IPs). Tests in `internal/gitops/webhook_ip_allowlist_test.go` cover allowed, blocked, and empty-allowlist defaults. Design doc updated in `docs/engineering/design/configuration-system.md` §2.4 (ARC2 fix).
 ### 4\. Config file size >1 MB rejection not proven ✅ [✓] Closed
 
 **Resolved**: `internal/config/loader.go:26` defines `const maxConfigFileSize = 1 << 20` (1 MB). `internal/config/loader.go:135-140` rejects files exceeding this limit with a 1 MB error. Direct test at `internal/config/config_test.go:263-281` (`TestLoad_FileSizeLimit`) creates a 2 MB file and asserts the 1 MB error message.
@@ -72,7 +72,7 @@ No direct test validates that sync triggers (webhook/git-sync/hot-watch) invalid
 
 ### 13\. Negative cache eviction policy verification ✅ [✓] Closed
 
-**Resolved**: `internal/overlayfs/negcache_admission_test.go` covers the existing admission-cap policy, verifying bounded memory when the cache reaches capacity. The eviction wording is addressed by #245, which updates the behavior to true LRU eviction of the least-recently-used negative-cache entry.
+**Resolved**: `internal/overlayfs/negcache_admission_test.go` covers the existing admission-cap policy, verifying bounded memory when the cache reaches capacity. The eviction wording is being addressed by #245 (true LRU eviction of the least-recently-used negative-cache entry), with implementation currently open in PR #263.
 
 ### 14\. stat.Symlink path traversal detection tested ✅ [✓] Closed
 
@@ -80,7 +80,7 @@ No direct test validates that sync triggers (webhook/git-sync/hot-watch) invalid
 
 ### 15\. Overlay FS max read size limit enforcement
 
-The overlay filesystem has a distinct 64 MiB per-file read bound via `internal/overlayfs/overlayfs.go:669-680` (`maxReadSize`). This applies to files read through overlayfs, including templates and static assets, and is separate from the configuration loader's 1 MB `internal/config/loader.go:26` `maxConfigFileSize` limit for `site.yaml`. `internal/overlayfs/max_read_size_test.go` (`TestLargeFileRejection`) covers rejection for files larger than `maxReadSize`.
+The overlay filesystem has a distinct 64 MiB per-file read bound via `internal/overlayfs/overlayfs.go:671` (`maxReadSize`). This applies to files read through overlayfs, including templates and static assets, and is separate from the configuration loader's 1 MB `internal/config/loader.go:26` `maxConfigFileSize` limit for `site.yaml`. `internal/overlayfs/max_read_size_test.go` (`TestLargeFileRejection`) covers rejection for files larger than `maxReadSize`.
 
 ### 16\. Webhook secret logging redaction test ✅ [✓] Closed
 
@@ -104,7 +104,7 @@ Each accepted issue must satisfy:
 # Acceptance Checklist (per-issue requirement) ✅
 
 - [ ] **Reproduction Steps**: Clear steps to reproduce behavior deviating from design spec  
-- [ ] **Expected Behavior per Spec Docline #XX** from `docs/engineering/config-system.md` etc. showing required test for scenario described here  
+- [ ] **Expected Behavior per Spec Docline #XX** from `docs/engineering/design/configuration-system.md` etc. showing required test for scenario described here  
 - [ ] **Unit Test Code** added covering edge case + happy path with assertion failures logged as errors or warnings appropriately based on severity level defined by design doc priority classification in each subsystem's testing guidelines (see CI patterns)  
 ```
 
@@ -114,18 +114,19 @@ Each accepted issue must satisfy:
 
 1. Design source: `docs/engineering/design/configuration-system.md` (§3.1-§7, §8 acceptance criteria mapping table lines 264+)
 2. Coverage checklist generated from scan of existing `*_test.go` files using file counts and coverage maps across subsystems  
-   - See CI workflow `.github/workflows/ci.yml` smoke tests for baseline HTTP endpoint checks currently passing under happy-path scenarios only but not error paths (like CSP header missing on 404 responses) or rate limit enforcement behaviors
-3. Theme dev guide `docs/theme-development.md` covers static asset serving rules (§7-8 sections) without explicit test coverage shown in existing test count  
-   - No unit/integration tests for CSS injection prevention, partial include error paths (when file missing vs present), CSP header presence on non-page responses like `/metrics prometheus scrape endpoint
-4. GitOps webhook security patterns require IP allowlist enforcement and secret validation minimum length checks at startup per config spec requirements but no such test exists  
-5. Overlay FS limits need verification for symlink escapes path traversal not currently covered in context overlayfs_test.go file line counts alone don't specify which assertions actually exist there; must read implementation code to confirm
+   - See CI workflow `.github/workflows/ci.yml` smoke tests for baseline HTTP endpoint checks. CSP header coverage for 404 and `/metrics` is now resolved by `internal/server/csp_coverage_test.go`; rate-limit edge-path coverage remains separate from those closed CSP checks.
+3. Theme dev guide `docs/theme-development.md` covers static asset serving rules (§7-8 sections). CSS injection prevention and partial include error-path tests remain useful follow-ups; CSP header presence on non-page responses is resolved by `internal/server/csp_coverage_test.go`.
+4. GitOps webhook security patterns for IP allowlist enforcement and secret validation minimum length checks are now covered by `internal/gitops/webhook_ip_allowlist_test.go` and `internal/gitops/sync_test.go` (`TestNewWebhookStrategy_SecretBoundary`).
+5. Overlay FS symlink-escape path traversal coverage is now resolved by `internal/overlayfs/symlink_escape_test.go`; `internal/overlayfs/max_read_size_test.go` covers the `maxReadSize` guard.
 
 ---
 
 ## Next Steps — Issue Creation Plan
 
+Historical note: these follow-up issues were subsequently filed, including #216 (CSP), #234 (template size), #235 (hot-reload), and #245 (negative cache); this section is retained for history.
+
 1\. Create all issues above using labels: `test-gap-critical` or priority/flag based severity levels from table (6 critical + 9 high-priority items with clear security implications get flagged for immediate fix by dev team next release); low/nice-to-have as future enhancements  
-2\. Add relevant test stubs per subsystem into existing package code structure matching spec scenarios listed above using coverage-mapped design docs requirements and CI patterns established in `.github/workflows/ci.yml` (lint→build→test steps already exist but not all scenarios within §3-§7 of config-system.md validated yet)  
+2\. Add relevant test stubs per subsystem into existing package code structure matching spec scenarios listed above using coverage-mapped design docs requirements and CI patterns established in `.github/workflows/ci.yml` (lint→build→test steps already exist but not all scenarios within §3-§7 of `docs/engineering/design/configuration-system.md` validated yet)  
 3\. Generate Mermaid diagrams showing content pipeline stages needing additional validation tests before deploying next version to production or staging environments; each diagram should show input validation layers vs unvalidated outputs where gaps remain unprotected
 
 ---


### PR DESCRIPTION
## Summary

Relocates the ephemeral test-gap tracker out of `docs/engineering/design/`, which is reserved for permanent design specs/ADRs that follow `000-template.md` and include an issue header.

## Changes

- Moved `docs/engineering/design/test-gap-analysis.md` to `docs/engineering/notes/test-gap-analysis.md`.
- Added `docs/engineering/notes/README.md` for non-spec engineering notes and trackers.
- Corrected stale citations:
  - Webhook secret boundary test: `internal/gitops/sync_test.go` / `TestNewWebhookStrategy_SecretBoundary`
  - Symlink escape tests: `internal/overlayfs/symlink_escape_test.go`
  - Git token redaction test: `internal/gitops/auth_test.go` / `TestAuthConfig_LogValueRedaction`
  - YAML anchor/alias coverage: `internal/config/config_test.go` / `TestLoad_AnchorAlias`
  - Env override coverage: `internal/config/env_override_test.go` and `TestLoad_EnvOverrideError`
- Clarified the 64 MiB overlayfs `maxReadSize` limit vs. the 1 MB config `maxConfigFileSize` limit.
- Updated negative-cache wording to reference #245 for LRU eviction of the least-recently-used entry.

## Validation

- `go build ./...` passed.
- Confirmed the old design path is gone and the tracker now exists under notes.
- Confirmed markdown links in notes resolve.

Fixes #246