### PR TITLE
refactor(deploy): Azure Monitor metrics via self-managed OTel Collector sidecar (#183)

### DIFF
--- a/deploy/azure/SETUP.md
+++ b/deploy/azure/SETUP.md
@@ -176,7 +176,7 @@ az monitor app-insights query \
 ```
 
 Then query the Azure Monitor workspace using the deployment output
-`prometheusQueryEndpoint`. Example with the Azure CLI REST command:
+`prometheusQueryEndpoint`. Query a concrete BlogFlow series (after hitting the app so the counter exists):
 
 ```bash
 PROM_ENDPOINT="$(az deployment group show \
@@ -185,15 +185,13 @@ PROM_ENDPOINT="$(az deployment group show \
   --query properties.outputs.prometheusQueryEndpoint.value -o tsv)"
 
 az rest --method get \
-  --url "${PROM_ENDPOINT}/api/v1/query?query=up"
+  --url "${PROM_ENDPOINT}/api/v1/query?query=blogflow_http_requests_total"
 ```
 
-For a BlogFlow-specific check, replace `up` with a known BlogFlow Prometheus
-series visible from `/metrics`, for example a `blogflow_*` metric name if one is
-present. A successful PromQL response with data confirms the app → collector →
-DCE/DCR → Azure Monitor workspace path is working. If the query is empty, first
-verify the app has received traffic and then check the `otel-collector` container
-logs for auth or export errors.
+A successful PromQL response containing `blogflow_http_requests_total` confirms
+the app → collector → DCE/DCR → Azure Monitor workspace path is working. If the
+query is empty, first verify the app has received traffic and then check the
+`otel-collector` container logs for auth or export errors.
 
 ## 9. Phase 2: Metrics Export via Self-Managed OTel Collector Sidecar
 
@@ -207,13 +205,15 @@ The deployed flow is:
 
 1. **BlogFlow app container** — exports traces and metrics over OTLP/HTTP to
    `http://localhost:4318` inside the Container App replica.
-2. **OTel Collector sidecar** — image `otel/opentelemetry-collector-contrib:0.148.0`
-   receives OTLP on localhost ports 4317/4318.
+2. **OTel Collector sidecar** — image
+   `otel/opentelemetry-collector-contrib:0.148.0@sha256:8164eab2e6bca9c9b0837a8d2f118a6618489008a839db7f9d6510e66be3923c`
+   receives OTLP on localhost ports 4317/4318 and exposes a health endpoint on
+   port 13133 for the ACA liveness probe.
 3. **Traces** — exported to Application Insights using the collector's
    `azuremonitor` exporter and the `APPLICATIONINSIGHTS_CONNECTION_STRING`
    secret.
 4. **Metrics** — exported with `otlphttp` to the DCE metrics-ingestion endpoint:
-   `.../datacollectionRules/<dcr-immutable-id>/streams/Custom-Metrics-Otel/otlp/v1/metrics`.
+   `.../datacollectionRules/<dcr-immutable-id>/streams/Microsoft-PrometheusMetrics/otlp/v1/metrics`.
 5. **Authentication** — the collector uses the contrib `azure_auth` extension,
    a user-assigned managed identity attached to the Container App, and the token
    scope `https://monitor.azure.com/.default`.
@@ -238,22 +238,24 @@ custom image with the YAML baked in.
 
 ### DCR stream name
 
-The DCR uses the Azure Monitor OTLP metrics stream `Custom-Metrics-Otel`. This
-matches the Azure Monitor OTLP ingestion URL pattern documented by Microsoft:
+The DCR uses the Managed Prometheus stream `Microsoft-PrometheusMetrics` for the
+Azure Monitor workspace (`monitoringAccounts`) destination. The collector uses
+the Azure Monitor OTLP `metrics_endpoint` form documented by Microsoft, with the
+DCE metrics endpoint, DCR immutable ID, and the same case-sensitive stream name:
 
 ```text
-https://<metrics-dce-domain>/datacollectionRules/<dcr-immutable-id>/streams/Custom-Metrics-Otel/otlp/v1/metrics
+https://<metrics-dce-domain>/datacollectionRules/<dcr-immutable-id>/streams/Microsoft-PrometheusMetrics/otlp/v1/metrics
 ```
 
-The stream name is case-sensitive and must exactly match the DCR `dataFlows`
-stream. A mismatch can result in dropped metrics.
+The stream name must exactly match the DCR `dataFlows` stream. A mismatch can
+result in silently dropped metrics.
 
 ### Temporality
 
-The app sets `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta`, matching
-Azure Monitor's OTLP guidance for metrics. The collector metrics pipeline also
-includes the `cumulativetodelta` processor as a defensive conversion if any SDK
-or bridge emits cumulative metrics.
+Managed Prometheus expects cumulative metrics, so the app sets
+`OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative`. The collector does
+not use `cumulativetodelta`; its metrics pipeline starts with `memory_limiter`,
+then `batch`, preserving cumulative temporality.
 
 ### Rollout ordering and RBAC propagation
 
@@ -263,7 +265,9 @@ resource explicitly depends on that role assignment before creating the app
 revision. The app module consumes DCR and Container Apps Environment outputs, so
 Bicep orders those modules first. Microsoft Entra RBAC propagation can still lag
 after role assignment creation, so initial collector samples may receive 401/403
-and be dropped during the first few minutes.
+during the first few minutes. The collector `otlphttp` exporter has
+`retry_on_failure` enabled with bounded backoff to reduce early metric loss while
+RBAC propagates.
 
 See [Azure Monitor OTLP ingestion docs](https://learn.microsoft.com/en-us/azure/azure-monitor/containers/opentelemetry-protocol-ingestion)
 for the DCE/DCR ingestion model and the Entra-authenticated collector pattern.
@@ -350,6 +354,9 @@ Container Apps runtime ──console logs──▶ Log Analytics workspace (defa
 - Metrics do NOT go to App Insights or Log Analytics (fixes the cost issue)
 - Traces go to App Insights → Log Analytics `AppTraces` table (acceptable cost)
 - Metrics go to Azure Monitor workspace through DCE/DCR OTLP ingestion
+- The app sets `OTEL_SERVICE_NAME=blogflow` so ingested series are attributable
+- The collector exposes `health_check` on port 13133 for liveness probing and
+  starts telemetry pipelines with `memory_limiter` to reduce OOM risk
 - The collector uses the Container App's user-assigned managed identity and the
   Azure auth extension to acquire Entra tokens for Azure Monitor
 - The DCR authorizes that identity with Monitoring Metrics Publisher at DCR

--- a/deploy/azure/SETUP.md
+++ b/deploy/azure/SETUP.md
@@ -213,7 +213,7 @@ The deployed flow is:
    `azuremonitor` exporter and the `APPLICATIONINSIGHTS_CONNECTION_STRING`
    secret.
 4. **Metrics** — exported with `otlphttp` to the DCE metrics-ingestion endpoint:
-   `.../datacollectionRules/<dcr-immutable-id>/streams/Microsoft-PrometheusMetrics/otlp/v1/metrics`.
+   `.../datacollectionRules/<dcr-immutable-id>/streams/Custom-Metrics-Otel/otlp/v1/metrics`.
 5. **Authentication** — the collector uses the contrib `azure_auth` extension,
    a user-assigned managed identity attached to the Container App, and the token
    scope `https://monitor.azure.com/.default`.
@@ -238,13 +238,13 @@ custom image with the YAML baked in.
 
 ### DCR stream name
 
-The DCR uses the Managed Prometheus stream `Microsoft-PrometheusMetrics` for the
+The DCR uses the native OTLP custom metrics stream `Custom-Metrics-Otel` for the
 Azure Monitor workspace (`monitoringAccounts`) destination. The collector uses
 the Azure Monitor OTLP `metrics_endpoint` form documented by Microsoft, with the
 DCE metrics endpoint, DCR immutable ID, and the same case-sensitive stream name:
 
 ```text
-https://<metrics-dce-domain>/datacollectionRules/<dcr-immutable-id>/streams/Microsoft-PrometheusMetrics/otlp/v1/metrics
+https://<metrics-dce-domain>/datacollectionRules/<dcr-immutable-id>/streams/Custom-Metrics-Otel/otlp/v1/metrics
 ```
 
 The stream name must exactly match the DCR `dataFlows` stream. A mismatch can
@@ -252,7 +252,7 @@ result in silently dropped metrics.
 
 ### Temporality
 
-Managed Prometheus expects cumulative metrics, so the app sets
+Azure Monitor workspace / Prometheus metrics are cumulative, so the app sets
 `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative`. The collector does
 not use `cumulativetodelta`; its metrics pipeline starts with `memory_limiter`,
 then `batch`, preserving cumulative temporality.

--- a/deploy/azure/SETUP.md
+++ b/deploy/azure/SETUP.md
@@ -70,10 +70,9 @@ az monitor app-insights component create \
 > **⚠️ Warning:** The connection string contains an instrumentation key.
 > Treat it as a secret — do not commit it to source control.
 
-> **ℹ️ Note:** Application Insights is now used for **traces only**. Metrics
-> are NOT exported through the managed OTel agent (Phase 2 will route them to
-> Azure Monitor for Prometheus). This stops the expensive Log Analytics
-> ingestion for metrics that was running up charges.
+> **ℹ️ Note:** Application Insights is used for **traces only**. Metrics are
+> exported through the ACA managed OTel agent to Azure Monitor for Prometheus
+> via DCE/DCR, avoiding the expensive Log Analytics metrics ingestion path.
 
 ## 6. Create GitHub Environment and Secrets
 
@@ -118,10 +117,11 @@ In **Settings → Environments → production → Environment secrets**, add:
 
 The deployment creates:
 - **Log Analytics workspace** — container diagnostics (default 30-day retention)
-- **Azure Monitor workspace** — Prometheus metrics destination (provisioned for Phase 2)
+- **Azure Monitor workspace** — Prometheus metrics destination
+- **Data Collection Endpoint + Rule** — OTLP metrics ingestion pipeline
 - **Container Apps Environment** — with managed OTel agent routing:
   - Traces → Application Insights
-  - Metrics → not exported yet (Phase 2: DCE/DCR pipeline)
+  - Metrics → DCE/DCR → Azure Monitor workspace
 - **Container App** — BlogFlow (single container, no sidecar)
 
 The workflow also runs automatically when the **Publish** workflow completes
@@ -142,38 +142,48 @@ on main (i.e., after a new container image is pushed to GHCR).
 >   -o table
 > ```
 
-## 8. Verify Metrics Are NOT Going to Log Analytics (Post-Deploy)
+## 8. Verify Metrics Are Routed to Azure Monitor (Post-Deploy)
 
-After the first deploy, confirm metrics are **not** going to Log Analytics:
+After the first deploy, confirm metrics are **not** going to Log Analytics and
+then verify that the Azure Monitor workspace receives Prometheus metrics.
 
 ```bash
-# Check that AppMetrics table is NOT receiving new data
+# Check that AppMetrics table is NOT receiving new data in Application Insights / Log Analytics
 az monitor app-insights query \
   --app <APP_INSIGHTS_NAME> \
   --resource-group <RG> \
   --analytics-query "AppMetrics | where TimeGenerated > ago(1h) | count"
 ```
 
-> **ℹ️ Note:** Metrics are not currently exported via the OTel agent (Phase 2).
-> BlogFlow still exposes a `/metrics` endpoint on port 8080 for manual
-> inspection or future Prometheus scraping.
+Use the `prometheusQueryEndpoint` deployment output with Azure Managed Grafana
+or another PromQL client to confirm BlogFlow metrics appear in the Azure Monitor
+workspace after the app has emitted metrics for a few minutes.
 
-## 9. Phase 2: Enable Metrics Export (Future)
+## 9. Phase 2: Metrics Export via DCE/DCR
 
-To route metrics to Azure Monitor for Prometheus, you need:
+Metrics export is enabled through Azure Monitor native OTLP ingestion:
 
-1. **Data Collection Endpoint (DCE)** — OTLP ingestion endpoint for metrics
-2. **Data Collection Rule (DCR)** — routes metrics to the Azure Monitor workspace
-3. **Entra ID authentication** — grant "Monitoring Metrics Publisher" role to the
-   environment's managed identity on the DCR
-4. **ACA OTLP configuration** — add the DCE endpoint as an `otlpConfiguration`
-   in the environment's `openTelemetryConfiguration.destinationsConfiguration.otlpConfigurations`
-   array, and reference it by name in `metricsConfiguration.destinations`
-5. **Re-enable metrics in BlogFlow** — set `OTEL_METRICS_EXPORTER=otlp` on the container app
-   (currently unset to skip metrics initialization entirely)
+1. **Data Collection Endpoint (DCE)** — exposes the OTLP metrics ingestion URL
+2. **Data Collection Rule (DCR)** — routes the `Custom-Metrics-Otel` stream to
+   the Azure Monitor workspace created by `monitor-workspace.bicep`
+3. **Managed identity authentication** — the Container Apps Environment has a
+   system-assigned managed identity, and Bicep grants it the
+   **Monitoring Metrics Publisher** role on the DCR
+4. **ACA OTLP configuration** — `container-app-env.bicep` adds an
+   `azureMonitorMetrics` OTLP destination under
+   `openTelemetryConfiguration.destinationsConfiguration.otlpConfigurations`
+   and references it from `metricsConfiguration.destinations`
+5. **BlogFlow metrics exporter** — `container-app.bicep` sets
+   `OTEL_METRICS_EXPORTER=otlp`, so the app exports metrics to the ACA managed
+   OTel agent instead of leaving metrics disabled
+
+No static API keys are configured. The deployment assumes the ACA managed OTel
+agent can use the environment's managed identity when sending to the DCE/DCR
+endpoint. The managed OTel agent and its `2024-10-02-preview` API remain preview
+features; validate ingestion in Azure after deployment.
 
 See [Azure Monitor OTLP ingestion docs](https://learn.microsoft.com/en-us/azure/azure-monitor/containers/opentelemetry-protocol-ingestion)
-for the full DCE/DCR setup procedure.
+for the DCE/DCR ingestion model.
 
 ## Rollback: Revert to OTel Collector Sidecar
 
@@ -257,11 +267,8 @@ This ensures the domain binding survives a full infrastructure redeploy.
 
 ```
 BlogFlow app ──OTLP──▶ ACA managed OTel agent ──── traces ──▶ App Insights ──▶ LA workspace
-                                                                                (AppTraces only)
-
-BlogFlow app ──── /metrics (port 8080) ──── available for future Prometheus scraping
-
-Azure Monitor workspace ──── provisioned, awaiting Phase 2 DCE/DCR setup
+                                      │                                         (AppTraces only)
+                                      └──── metrics ──▶ DCE ──▶ DCR ──▶ Azure Monitor workspace
 
 Container Apps runtime ──console logs──▶ Log Analytics workspace (default 30-day retention)
 ```
@@ -269,6 +276,6 @@ Container Apps runtime ──console logs──▶ Log Analytics workspace (defa
 **Key design decisions:**
 - Metrics do NOT go to App Insights or Log Analytics (fixes the cost issue)
 - Traces go to App Insights → Log Analytics `AppTraces` table (acceptable cost)
-- Azure Monitor workspace is provisioned for future Prometheus metrics storage
-- Phase 2 will add DCE/DCR infrastructure for OTLP metrics ingestion with
-  Entra ID authentication
+- Metrics go to Azure Monitor workspace through DCE/DCR OTLP ingestion
+- The DCR authorizes the Container Apps Environment managed identity with the
+  Monitoring Metrics Publisher role; no static OTLP API keys are stored

--- a/deploy/azure/SETUP.md
+++ b/deploy/azure/SETUP.md
@@ -35,12 +35,24 @@ az ad app federated-credential create --id <APP_ID> --parameters '{
 > If you rename the repo or deploy from a different branch, update this credential
 > or the OIDC exchange will fail silently.
 
-## 4. Grant Contributor Role to the Service Principal
+## 4. Grant Deployment Roles to the Service Principal
+
+The deployment principal creates Azure resources **and** a DCR-scoped role
+assignment for the Container App managed identity. `Contributor` alone cannot
+create role assignments because it lacks `Microsoft.Authorization/roleAssignments/write`.
+Grant `Contributor` plus either `Role Based Access Control Administrator`
+(preferred least-privilege role for RBAC management) or `User Access Administrator`
+at the target resource group scope.
 
 ```bash
 az role assignment create \
   --assignee <SP_OBJECT_ID> \
   --role Contributor \
+  --scope /subscriptions/<SUB_ID>/resourceGroups/<RG_NAME>
+
+az role assignment create \
+  --assignee <SP_OBJECT_ID> \
+  --role "Role Based Access Control Administrator" \
   --scope /subscriptions/<SUB_ID>/resourceGroups/<RG_NAME>
 ```
 
@@ -71,8 +83,9 @@ az monitor app-insights component create \
 > Treat it as a secret — do not commit it to source control.
 
 > **ℹ️ Note:** Application Insights is used for **traces only**. Metrics are
-> exported through the ACA managed OTel agent to Azure Monitor for Prometheus
-> via DCE/DCR, avoiding the expensive Log Analytics metrics ingestion path.
+> exported through the self-managed OTel Collector sidecar to Azure Monitor for
+> Prometheus via DCE/DCR, avoiding the expensive Log Analytics metrics ingestion
+> path.
 
 ## 6. Create GitHub Environment and Secrets
 
@@ -119,10 +132,12 @@ The deployment creates:
 - **Log Analytics workspace** — container diagnostics (default 30-day retention)
 - **Azure Monitor workspace** — Prometheus metrics destination
 - **Data Collection Endpoint + Rule** — OTLP metrics ingestion pipeline
-- **Container Apps Environment** — with managed OTel agent routing:
-  - Traces → Application Insights
-  - Metrics → DCE/DCR → Azure Monitor workspace
-- **Container App** — BlogFlow (single container, no sidecar)
+- **Container Apps Environment** — runtime host and container diagnostics only
+- **User-assigned managed identity** — attached to the Container App for OTel
+  Collector authentication
+- **DCR-scoped role assignment** — grants that identity
+  **Monitoring Metrics Publisher** on the Data Collection Rule
+- **Container App** — BlogFlow plus an OTel Collector sidecar
 
 The workflow also runs automatically when the **Publish** workflow completes
 on main (i.e., after a new container image is pushed to GHCR).
@@ -144,68 +159,126 @@ on main (i.e., after a new container image is pushed to GHCR).
 
 ## 8. Verify Metrics Are Routed to Azure Monitor (Post-Deploy)
 
-After the first deploy, confirm metrics are **not** going to Log Analytics and
-then verify that the Azure Monitor workspace receives Prometheus metrics.
+After the first deploy, generate a little traffic so BlogFlow emits metrics:
 
 ```bash
-# Check that AppMetrics table is NOT receiving new data in Application Insights / Log Analytics
+curl -fsS https://<container-app-fqdn>/healthz
+curl -fsS https://<container-app-fqdn>/readyz
+```
+
+Confirm metrics are **not** going to Log Analytics / Application Insights:
+
+```bash
 az monitor app-insights query \
   --app <APP_INSIGHTS_NAME> \
   --resource-group <RG> \
   --analytics-query "AppMetrics | where TimeGenerated > ago(1h) | count"
 ```
 
-Use the `prometheusQueryEndpoint` deployment output with Azure Managed Grafana
-or another PromQL client to confirm BlogFlow metrics appear in the Azure Monitor
-workspace after the app has emitted metrics for a few minutes.
+Then query the Azure Monitor workspace using the deployment output
+`prometheusQueryEndpoint`. Example with the Azure CLI REST command:
 
-## 9. Phase 2: Metrics Export via DCE/DCR
+```bash
+PROM_ENDPOINT="$(az deployment group show \
+  --resource-group <RG> \
+  --name <DEPLOYMENT_NAME> \
+  --query properties.outputs.prometheusQueryEndpoint.value -o tsv)"
 
-Metrics export is enabled through Azure Monitor native OTLP ingestion:
+az rest --method get \
+  --url "${PROM_ENDPOINT}/api/v1/query?query=up"
+```
 
-1. **Data Collection Endpoint (DCE)** — exposes the OTLP metrics ingestion URL
-2. **Data Collection Rule (DCR)** — routes the `Custom-Metrics-Otel` stream to
-   the Azure Monitor workspace created by `monitor-workspace.bicep`
-3. **Managed identity authentication** — the Container Apps Environment has a
-   system-assigned managed identity, and Bicep grants it the
-   **Monitoring Metrics Publisher** role on the DCR
-4. **ACA OTLP configuration** — `container-app-env.bicep` adds an
-   `azureMonitorMetrics` OTLP destination under
-   `openTelemetryConfiguration.destinationsConfiguration.otlpConfigurations`
-   and references it from `metricsConfiguration.destinations`
-5. **BlogFlow metrics exporter** — `container-app.bicep` sets
-   `OTEL_METRICS_EXPORTER=otlp`, so the app exports metrics to the ACA managed
-   OTel agent instead of leaving metrics disabled
+For a BlogFlow-specific check, replace `up` with a known BlogFlow Prometheus
+series visible from `/metrics`, for example a `blogflow_*` metric name if one is
+present. A successful PromQL response with data confirms the app → collector →
+DCE/DCR → Azure Monitor workspace path is working. If the query is empty, first
+verify the app has received traffic and then check the `otel-collector` container
+logs for auth or export errors.
 
-No static API keys are configured. The deployment assumes the ACA managed OTel
-agent can use the environment's managed identity when sending to the DCE/DCR
-endpoint. The managed OTel agent and its `2024-10-02-preview` API remain preview
-features; validate ingestion in Azure after deployment.
+## 9. Phase 2: Metrics Export via Self-Managed OTel Collector Sidecar
+
+Metrics export is enabled through Azure Monitor native OTLP ingestion, but **not**
+through the ACA managed OpenTelemetry agent. The managed agent's OTLP destination
+configuration supports static headers/API keys and does not acquire the Microsoft
+Entra bearer token required by the DCE. Managed-identity authentication therefore
+requires a self-managed OpenTelemetry Collector sidecar.
+
+The deployed flow is:
+
+1. **BlogFlow app container** — exports traces and metrics over OTLP/HTTP to
+   `http://localhost:4318` inside the Container App replica.
+2. **OTel Collector sidecar** — image `otel/opentelemetry-collector-contrib:0.148.0`
+   receives OTLP on localhost ports 4317/4318.
+3. **Traces** — exported to Application Insights using the collector's
+   `azuremonitor` exporter and the `APPLICATIONINSIGHTS_CONNECTION_STRING`
+   secret.
+4. **Metrics** — exported with `otlphttp` to the DCE metrics-ingestion endpoint:
+   `.../datacollectionRules/<dcr-immutable-id>/streams/Custom-Metrics-Otel/otlp/v1/metrics`.
+5. **Authentication** — the collector uses the contrib `azure_auth` extension,
+   a user-assigned managed identity attached to the Container App, and the token
+   scope `https://monitor.azure.com/.default`.
+6. **Authorization** — Bicep grants **Monitoring Metrics Publisher** to that
+   managed identity at the DCR scope only, using a deterministic `guid()` role
+   assignment and `principalType: 'ServicePrincipal'`.
+
+### Collector config delivery
+
+Azure Container Apps does not provide a simple config-file mount for this sidecar,
+so Bicep passes the collector YAML in the `OTELCOL_CONFIG` environment variable
+and starts the collector with:
+
+```bash
+otelcol-contrib --config=env:OTELCOL_CONFIG
+```
+
+This keeps the deployment self-contained and avoids building a custom collector
+image. The assumption is that the collector config remains small enough for ACA
+environment-variable limits; if the config grows substantially, switch to a small
+custom image with the YAML baked in.
+
+### DCR stream name
+
+The DCR uses the Azure Monitor OTLP metrics stream `Custom-Metrics-Otel`. This
+matches the Azure Monitor OTLP ingestion URL pattern documented by Microsoft:
+
+```text
+https://<metrics-dce-domain>/datacollectionRules/<dcr-immutable-id>/streams/Custom-Metrics-Otel/otlp/v1/metrics
+```
+
+The stream name is case-sensitive and must exactly match the DCR `dataFlows`
+stream. A mismatch can result in dropped metrics.
+
+### Temporality
+
+The app sets `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta`, matching
+Azure Monitor's OTLP guidance for metrics. The collector metrics pipeline also
+includes the `cumulativetodelta` processor as a defensive conversion if any SDK
+or bridge emits cumulative metrics.
+
+### Rollout ordering and RBAC propagation
+
+The Container App module creates the user-assigned managed identity, creates the
+DCR-scoped `Monitoring Metrics Publisher` role assignment, and the Container App
+resource explicitly depends on that role assignment before creating the app
+revision. The app module consumes DCR and Container Apps Environment outputs, so
+Bicep orders those modules first. Microsoft Entra RBAC propagation can still lag
+after role assignment creation, so initial collector samples may receive 401/403
+and be dropped during the first few minutes.
 
 See [Azure Monitor OTLP ingestion docs](https://learn.microsoft.com/en-us/azure/azure-monitor/containers/opentelemetry-protocol-ingestion)
-for the DCE/DCR ingestion model.
+for the DCE/DCR ingestion model and the Entra-authenticated collector pattern.
 
-## Rollback: Revert to OTel Collector Sidecar
+## Rollback: Disable DCE Metrics Export
 
-If the ACA managed OTel agent fails to deliver traces (preview API instability,
-misconfiguration, or Azure outage), follow these steps to revert:
+If the collector-sidecar metrics path fails (preview API instability, collector
+image regression, RBAC propagation issue, or Azure ingestion outage), temporarily
+redeploy with `OTEL_METRICS_EXPORTER` unset in `container-app.bicep` to stop
+metrics export while keeping BlogFlow serving traffic and traces flowing to
+Application Insights. Re-enable metrics after fixing the collector/DCR issue.
 
-1. In `container-app-env.bicep`: revert API to `2024-03-01`, remove
-   `appInsightsConfiguration` and `openTelemetryConfiguration`
-2. In `container-app.bicep`: re-add the OTel Collector sidecar container
-   definition (see `otel/collector-config.yaml` for the original config),
-   restore the `appinsights-cs` secret, and add back `OTEL_SERVICE_NAME`,
-   `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_METRICS_EXPORTER=otlp`, and
-   `BLOGFLOW_METRICS_PORT=9090` env vars
-3. Restore `otel/collector-config.yaml` to its active (uncommented) state
-4. Redeploy with `full_deploy=true`
-
-> **⚠️ Warning:** Rolling back re-enables metrics export to App Insights →
-> Log Analytics, which will resume the PerGB2018 ingestion costs this change
-> was designed to eliminate. Use as a temporary measure only.
-
-> **Note**: The original sidecar config is preserved (commented out) in
-> `otel/collector-config.yaml` for reference.
+> **⚠️ Warning:** Do not roll back to exporting metrics with the collector's
+> `azuremonitor` exporter unless you intentionally accept App Insights → Log
+> Analytics `AppMetrics` ingestion costs.
 
 ## 10. Custom Domain + TLS (Optional)
 
@@ -265,10 +338,10 @@ This ensures the domain binding survives a full infrastructure redeploy.
 
 ## Architecture: Telemetry Flow
 
-```
-BlogFlow app ──OTLP──▶ ACA managed OTel agent ──── traces ──▶ App Insights ──▶ LA workspace
-                                      │                                         (AppTraces only)
-                                      └──── metrics ──▶ DCE ──▶ DCR ──▶ Azure Monitor workspace
+```text
+BlogFlow app ──OTLP localhost:4318──▶ OTel Collector sidecar ── traces ──▶ App Insights ──▶ LA workspace
+                                                   │                         (AppTraces only)
+                                                   └─ metrics + Entra token ─▶ DCE ─▶ DCR ─▶ Azure Monitor workspace
 
 Container Apps runtime ──console logs──▶ Log Analytics workspace (default 30-day retention)
 ```
@@ -277,5 +350,7 @@ Container Apps runtime ──console logs──▶ Log Analytics workspace (defa
 - Metrics do NOT go to App Insights or Log Analytics (fixes the cost issue)
 - Traces go to App Insights → Log Analytics `AppTraces` table (acceptable cost)
 - Metrics go to Azure Monitor workspace through DCE/DCR OTLP ingestion
-- The DCR authorizes the Container Apps Environment managed identity with the
-  Monitoring Metrics Publisher role; no static OTLP API keys are stored
+- The collector uses the Container App's user-assigned managed identity and the
+  Azure auth extension to acquire Entra tokens for Azure Monitor
+- The DCR authorizes that identity with Monitoring Metrics Publisher at DCR
+  scope only; no static OTLP API keys are stored

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -41,6 +41,9 @@ param containerImage string = 'ghcr.io/khaines/blogflow:main'
 @description('GitHub username for GHCR image pulls')
 param ghcrUsername string = 'khaines'
 
+@description('Pinned OpenTelemetry Collector Contrib image reference')
+param otelCollectorImage string = 'otel/opentelemetry-collector-contrib:0.148.0@sha256:8164eab2e6bca9c9b0837a8d2f118a6618489008a839db7f9d6510e66be3923c'
+
 @description('Minimum replica count (0 = scale to zero)')
 @minValue(0)
 @maxValue(10)
@@ -121,6 +124,7 @@ module containerApp 'modules/container-app.bicep' = {
     containerImage: containerImage
     ghcrUsername: ghcrUsername
     ghcrPassword: ghcrPassword
+    otelCollectorImage: otelCollectorImage
     appInsightsConnectionString: appInsightsConnectionString
     dataCollectionRuleName: dataCollection.outputs.dataCollectionRuleName
     dataCollectionRuleImmutableId: dataCollection.outputs.dataCollectionRuleImmutableId

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -4,10 +4,11 @@
 // Deploys BlogFlow to Azure Container Apps with:
 //   - Serverless Container Apps Environment (Consumption plan)
 //   - Log Analytics workspace for container diagnostics
-//   - Azure Monitor workspace for Prometheus metrics (Phase 2)
+//   - Azure Monitor workspace for Prometheus metrics
+//   - DCE/DCR pipeline for OTLP metrics ingestion
 //   - ACA managed OpenTelemetry agent:
 //       • Traces → Application Insights
-//       • Metrics → NOT exported yet (see Phase 2 in SETUP.md)
+//       • Metrics → DCE/DCR → Azure Monitor workspace
 //   - Container App with system-assigned managed identity
 //
 // All account-specific values (subscription, resource group, connection
@@ -85,6 +86,18 @@ module monitorWorkspace 'modules/monitor-workspace.bicep' = {
 }
 
 // ---------------------------------------------------------------------------
+// Module: Data Collection Endpoint + Rule (OTLP metrics ingestion)
+// ---------------------------------------------------------------------------
+module dataCollection 'modules/data-collection.bicep' = {
+  name: 'data-collection'
+  params: {
+    location: location
+    environmentName: environmentName
+    monitorWorkspaceId: monitorWorkspace.outputs.workspaceId
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Module: Container Apps Environment + Log Analytics + OTel routing
 // ---------------------------------------------------------------------------
 module environment 'modules/container-app-env.bicep' = {
@@ -94,6 +107,8 @@ module environment 'modules/container-app-env.bicep' = {
     environmentName: environmentName
     appInsightsConnectionString: appInsightsConnectionString
     logRetentionDays: logRetentionDays
+    otlpMetricsEndpoint: dataCollection.outputs.otlpMetricsEndpoint
+    dataCollectionRuleName: dataCollection.outputs.dataCollectionRuleName
   }
 }
 
@@ -134,3 +149,12 @@ output monitorWorkspaceId string = monitorWorkspace.outputs.workspaceId
 
 @description('Prometheus query endpoint (for Grafana / PromQL dashboards)')
 output prometheusQueryEndpoint string = monitorWorkspace.outputs.prometheusQueryEndpoint
+
+@description('Data Collection Rule resource ID for OTLP metrics ingestion')
+output dataCollectionRuleId string = dataCollection.outputs.dataCollectionRuleId
+
+@description('Data Collection Rule immutable ID for OTLP metrics ingestion')
+output dataCollectionRuleImmutableId string = dataCollection.outputs.dataCollectionRuleImmutableId
+
+@description('DCE metrics ingestion endpoint')
+output metricsIngestionEndpoint string = dataCollection.outputs.metricsIngestionEndpoint

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -6,10 +6,10 @@
 //   - Log Analytics workspace for container diagnostics
 //   - Azure Monitor workspace for Prometheus metrics
 //   - DCE/DCR pipeline for OTLP metrics ingestion
-//   - ACA managed OpenTelemetry agent:
+//   - Self-managed OpenTelemetry Collector sidecar:
 //       • Traces → Application Insights
-//       • Metrics → DCE/DCR → Azure Monitor workspace
-//   - Container App with system-assigned managed identity
+//       • Metrics → DCE/DCR → Azure Monitor workspace with Entra auth
+//   - Container App with user-assigned managed identity for the collector
 //
 // All account-specific values (subscription, resource group, connection
 // strings, credentials) are passed as parameters — never hardcoded.
@@ -98,22 +98,19 @@ module dataCollection 'modules/data-collection.bicep' = {
 }
 
 // ---------------------------------------------------------------------------
-// Module: Container Apps Environment + Log Analytics + OTel routing
+// Module: Container Apps Environment + Log Analytics
 // ---------------------------------------------------------------------------
 module environment 'modules/container-app-env.bicep' = {
   name: 'container-app-env'
   params: {
     location: location
     environmentName: environmentName
-    appInsightsConnectionString: appInsightsConnectionString
     logRetentionDays: logRetentionDays
-    otlpMetricsEndpoint: dataCollection.outputs.otlpMetricsEndpoint
-    dataCollectionRuleName: dataCollection.outputs.dataCollectionRuleName
   }
 }
 
 // ---------------------------------------------------------------------------
-// Module: Container App (BlogFlow — no sidecar)
+// Module: Container App (BlogFlow + OTel Collector sidecar)
 // ---------------------------------------------------------------------------
 module containerApp 'modules/container-app.bicep' = {
   name: 'container-app'
@@ -124,6 +121,11 @@ module containerApp 'modules/container-app.bicep' = {
     containerImage: containerImage
     ghcrUsername: ghcrUsername
     ghcrPassword: ghcrPassword
+    appInsightsConnectionString: appInsightsConnectionString
+    dataCollectionRuleName: dataCollection.outputs.dataCollectionRuleName
+    dataCollectionRuleImmutableId: dataCollection.outputs.dataCollectionRuleImmutableId
+    metricsIngestionEndpoint: dataCollection.outputs.metricsIngestionEndpoint
+    otelMetricsStreamName: dataCollection.outputs.otelMetricsStreamName
     scaleMinReplicas: scaleMinReplicas
     scaleMaxReplicas: scaleMaxReplicas
     customDomainName: customDomainName
@@ -158,3 +160,9 @@ output dataCollectionRuleImmutableId string = dataCollection.outputs.dataCollect
 
 @description('DCE metrics ingestion endpoint')
 output metricsIngestionEndpoint string = dataCollection.outputs.metricsIngestionEndpoint
+
+@description('Container App managed identity principal ID used by the OTel Collector')
+output containerAppManagedIdentityPrincipalId string = containerApp.outputs.principalId
+
+@description('Container App managed identity client ID used by the OTel Collector')
+output containerAppManagedIdentityClientId string = containerApp.outputs.clientId

--- a/deploy/azure/modules/container-app-env.bicep
+++ b/deploy/azure/modules/container-app-env.bicep
@@ -1,16 +1,11 @@
 // ============================================================================
-// Container Apps Environment — Consumption plan + Log Analytics + OTel routing
+// Container Apps Environment — Consumption plan + Log Analytics
 // ============================================================================
-// Creates a serverless Container Apps Environment backed by:
-//   - Log Analytics workspace for container diagnostics and log streaming
-//   - Managed OpenTelemetry agent that routes:
-//       • Traces → Application Insights
-//       • Metrics → DCE/DCR → Azure Monitor workspace
-//       • Logs → NOT exported via OTel (container logs go directly to LA)
-//
-// Uses 2024-10-02-preview API for openTelemetryConfiguration support.
-// Metrics use the environment's system-assigned managed identity; this module
-// grants it Monitoring Metrics Publisher on the DCR.
+// Creates a serverless Container Apps Environment backed by a Log Analytics
+// workspace for container diagnostics and log streaming. Application telemetry
+// is emitted to the self-managed OpenTelemetry Collector sidecar in the
+// Container App; the ACA managed OpenTelemetry agent is intentionally not used
+// because its OTLP destinations support only static headers/API keys.
 // ============================================================================
 
 @description('Azure region')
@@ -19,22 +14,10 @@ param location string
 @description('Base name prefix for resources')
 param environmentName string
 
-@description('Application Insights connection string for trace export')
-@secure()
-param appInsightsConnectionString string
-
 @description('Log Analytics workspace retention in days (7–730). Lower values reduce storage costs.')
 @minValue(7)
 @maxValue(730)
 param logRetentionDays int = 30
-
-@description('Full OTLP metrics endpoint exposed by the Data Collection Endpoint and Rule')
-param otlpMetricsEndpoint string
-
-@description('Data Collection Rule resource name for OTLP metrics ingestion')
-param dataCollectionRuleName string
-
-var monitoringMetricsPublisherRoleDefinitionId = '3913510d-42f4-4e42-8a64-420c390055eb'
 
 // ---------------------------------------------------------------------------
 // Log Analytics Workspace
@@ -51,18 +34,11 @@ resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
 }
 
 // ---------------------------------------------------------------------------
-// Container Apps Environment (Consumption tier) with managed OTel agent
+// Container Apps Environment (Consumption tier)
 // ---------------------------------------------------------------------------
-resource metricsDataCollectionRule 'Microsoft.Insights/dataCollectionRules@2024-03-11' existing = {
-  name: dataCollectionRuleName
-}
-
-resource environment 'Microsoft.App/managedEnvironments@2024-10-02-preview' = {
+resource environment 'Microsoft.App/managedEnvironments@2024-03-01' = {
   name: '${environmentName}-env'
   location: location
-  identity: {
-    type: 'SystemAssigned'
-  }
   properties: {
     appLogsConfiguration: {
       destination: 'log-analytics'
@@ -71,44 +47,6 @@ resource environment 'Microsoft.App/managedEnvironments@2024-10-02-preview' = {
         sharedKey: logAnalytics.listKeys().primarySharedKey
       }
     }
-
-    // --- Application Insights for traces ---
-    appInsightsConfiguration: {
-      connectionString: appInsightsConnectionString
-    }
-
-    // --- Managed OpenTelemetry agent configuration ---
-    // Traces → App Insights. Metrics → Azure Monitor workspace via OTLP DCE/DCR.
-    openTelemetryConfiguration: {
-      destinationsConfiguration: {
-        otlpConfigurations: [
-          {
-            name: 'azureMonitorMetrics'
-            endpoint: otlpMetricsEndpoint
-            insecure: false
-          }
-        ]
-      }
-      tracesConfiguration: {
-        destinations: ['appInsights']
-      }
-      metricsConfiguration: {
-        destinations: ['azureMonitorMetrics']
-      }
-      logsConfiguration: {
-        destinations: []
-      }
-    }
-  }
-}
-
-resource metricsPublisherRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(metricsDataCollectionRule.id, environment.name, monitoringMetricsPublisherRoleDefinitionId)
-  scope: metricsDataCollectionRule
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', monitoringMetricsPublisherRoleDefinitionId)
-    principalId: environment.identity.principalId
-    principalType: 'ServicePrincipal'
   }
 }
 
@@ -121,6 +59,3 @@ output environmentId string = environment.id
 
 @description('Log Analytics workspace resource ID')
 output logAnalyticsWorkspaceId string = logAnalytics.id
-
-@description('System-assigned managed identity principal ID for the Container Apps Environment')
-output environmentPrincipalId string = environment.identity.principalId

--- a/deploy/azure/modules/container-app-env.bicep
+++ b/deploy/azure/modules/container-app-env.bicep
@@ -5,16 +5,12 @@
 //   - Log Analytics workspace for container diagnostics and log streaming
 //   - Managed OpenTelemetry agent that routes:
 //       • Traces → Application Insights
-//       • Metrics → NOT exported (Phase 2: DCE/DCR → Azure Monitor workspace)
+//       • Metrics → DCE/DCR → Azure Monitor workspace
 //       • Logs → NOT exported via OTel (container logs go directly to LA)
 //
 // Uses 2024-10-02-preview API for openTelemetryConfiguration support.
-//
-// Why metrics are not exported yet:
-//   ACA managed OTel agent only supports static-header OTLP auth, but Azure
-//   Monitor OTLP ingestion requires Entra ID bearer tokens. Proper metrics
-//   export needs DCE + DCR infrastructure (Phase 2). Meanwhile, the app still
-//   exposes /metrics on port 8080 for manual or future Prometheus scraping.
+// Metrics use the environment's system-assigned managed identity; this module
+// grants it Monitoring Metrics Publisher on the DCR.
 // ============================================================================
 
 @description('Azure region')
@@ -31,6 +27,14 @@ param appInsightsConnectionString string
 @minValue(7)
 @maxValue(730)
 param logRetentionDays int = 30
+
+@description('Full OTLP metrics endpoint exposed by the Data Collection Endpoint and Rule')
+param otlpMetricsEndpoint string
+
+@description('Data Collection Rule resource name for OTLP metrics ingestion')
+param dataCollectionRuleName string
+
+var monitoringMetricsPublisherRoleDefinitionId = '3913510d-42f4-4e42-8a64-420c390055eb'
 
 // ---------------------------------------------------------------------------
 // Log Analytics Workspace
@@ -49,9 +53,16 @@ resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
 // ---------------------------------------------------------------------------
 // Container Apps Environment (Consumption tier) with managed OTel agent
 // ---------------------------------------------------------------------------
+resource metricsDataCollectionRule 'Microsoft.Insights/dataCollectionRules@2024-03-11' existing = {
+  name: dataCollectionRuleName
+}
+
 resource environment 'Microsoft.App/managedEnvironments@2024-10-02-preview' = {
   name: '${environmentName}-env'
   location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
   properties: {
     appLogsConfiguration: {
       destination: 'log-analytics'
@@ -67,22 +78,37 @@ resource environment 'Microsoft.App/managedEnvironments@2024-10-02-preview' = {
     }
 
     // --- Managed OpenTelemetry agent configuration ---
-    // Traces → App Insights. Metrics are NOT routed through the managed agent.
-    // App Insights does NOT accept metrics via the managed OTel agent (by design).
-    // OTLP metrics export to Azure Monitor workspace requires DCE/DCR with
-    // Entra ID auth, which is not yet supported by ACA's static-header OTLP
-    // configuration. See Phase 2 in SETUP.md.
+    // Traces → App Insights. Metrics → Azure Monitor workspace via OTLP DCE/DCR.
     openTelemetryConfiguration: {
+      destinationsConfiguration: {
+        otlpConfigurations: [
+          {
+            name: 'azureMonitorMetrics'
+            endpoint: otlpMetricsEndpoint
+            insecure: false
+          }
+        ]
+      }
       tracesConfiguration: {
         destinations: ['appInsights']
       }
       metricsConfiguration: {
-        destinations: []
+        destinations: ['azureMonitorMetrics']
       }
       logsConfiguration: {
         destinations: []
       }
     }
+  }
+}
+
+resource metricsPublisherRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(metricsDataCollectionRule.id, environment.name, monitoringMetricsPublisherRoleDefinitionId)
+  scope: metricsDataCollectionRule
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', monitoringMetricsPublisherRoleDefinitionId)
+    principalId: environment.identity.principalId
+    principalType: 'ServicePrincipal'
   }
 }
 
@@ -95,3 +121,6 @@ output environmentId string = environment.id
 
 @description('Log Analytics workspace resource ID')
 output logAnalyticsWorkspaceId string = logAnalytics.id
+
+@description('System-assigned managed identity principal ID for the Container Apps Environment')
+output environmentPrincipalId string = environment.identity.principalId

--- a/deploy/azure/modules/container-app.bicep
+++ b/deploy/azure/modules/container-app.bicep
@@ -47,6 +47,9 @@ param metricsIngestionEndpoint string
 @description('DCR stream name for Azure Monitor OTLP metrics ingestion')
 param otelMetricsStreamName string
 
+@description('Pinned OpenTelemetry Collector Contrib image reference')
+param otelCollectorImage string = 'otel/opentelemetry-collector-contrib:0.148.0@sha256:8164eab2e6bca9c9b0837a8d2f118a6618489008a839db7f9d6510e66be3923c'
+
 @description('Minimum replica count')
 param scaleMinReplicas int = 0
 
@@ -60,7 +63,6 @@ param customDomainName string = ''
 param customDomainCertificateId string = ''
 
 var monitoringMetricsPublisherRoleDefinitionId = '3913510d-42f4-4e42-8a64-420c390055eb'
-var otelCollectorImage = 'otel/opentelemetry-collector-contrib:0.148.0'
 var otlpMetricsEndpoint = '${metricsIngestionEndpoint}/datacollectionRules/${dataCollectionRuleImmutableId}/streams/${otelMetricsStreamName}/otlp/v1/metrics'
 var otelCollectorConfig = join([
   'receivers:'
@@ -72,12 +74,17 @@ var otelCollectorConfig = join([
   '        endpoint: localhost:4318'
   ''
   'processors:'
-  '  cumulativetodelta:'
+  '  memory_limiter:'
+  '    check_interval: 1s'
+  '    limit_mib: 384'
+  '    spike_limit_mib: 96'
   '  batch:'
   '    timeout: 10s'
   '    send_batch_size: 256'
   ''
   'extensions:'
+  '  health_check:'
+  '    endpoint: 0.0.0.0:13133'
   '  azure_auth:'
   '    managed_identity:'
   '      client_id: ${containerAppIdentity.properties.clientId}'
@@ -90,17 +97,22 @@ var otelCollectorConfig = join([
   '    metrics_endpoint: "${otlpMetricsEndpoint}"'
   '    auth:'
   '      authenticator: azure_auth'
+  '    retry_on_failure:'
+  '      enabled: true'
+  '      initial_interval: 5s'
+  '      max_interval: 30s'
+  '      max_elapsed_time: 10m'
   ''
   'service:'
-  '  extensions: [azure_auth]'
+  '  extensions: [health_check, azure_auth]'
   '  pipelines:'
   '    traces:'
   '      receivers: [otlp]'
-  '      processors: [batch]'
+  '      processors: [memory_limiter, batch]'
   '      exporters: [azuremonitor/traces]'
   '    metrics:'
   '      receivers: [otlp]'
-  '      processors: [cumulativetodelta, batch]'
+  '      processors: [memory_limiter, batch]'
   '      exporters: [otlphttp/azuremonitor_metrics]'
 ], '\n')
 
@@ -207,6 +219,10 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
           }
           env: [
             {
+              name: 'OTEL_SERVICE_NAME'
+              value: 'blogflow'
+            }
+            {
               name: 'OTEL_TRACES_EXPORTER'
               value: 'otlp'
             }
@@ -224,7 +240,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
             }
             {
               name: 'OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE'
-              value: 'delta'
+              value: 'cumulative'
             }
             {
               name: 'BLOGFLOW_SYNC_STRATEGY'
@@ -309,6 +325,17 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
             {
               name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
               secretRef: 'appinsights-cs'
+            }
+          ]
+          probes: [
+            {
+              type: 'Liveness'
+              httpGet: {
+                path: '/'
+                port: 13133
+              }
+              initialDelaySeconds: 10
+              periodSeconds: 15
             }
           ]
         }

--- a/deploy/azure/modules/container-app.bicep
+++ b/deploy/azure/modules/container-app.bicep
@@ -4,7 +4,7 @@
 // Runs the BlogFlow container. Telemetry is handled by the ACA managed
 // OpenTelemetry agent (configured on the environment):
 //   - Traces → Application Insights
-//   - Metrics → not exported via OTel (app still exposes /metrics on :8080)
+//   - Metrics → Azure Monitor workspace via DCE/DCR
 //
 // The ACA managed OTel agent automatically injects OTEL_EXPORTER_OTLP_ENDPOINT
 // and other standard OTel env vars at runtime. BlogFlow's OTel SDK discovers
@@ -93,6 +93,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
         }
         {
           name: 'appinsights-cs'
+          #disable-next-line use-secure-value-for-secure-inputs
           value: 'deprecated-see-env-level-config'
         }
       ]
@@ -126,13 +127,13 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
           env: [
             // The ACA managed OTel agent auto-injects OTEL_EXPORTER_OTLP_ENDPOINT.
             // BlogFlow hardcodes OTEL_SERVICE_NAME='blogflow' in code (cmd/blogflow/main.go).
-            // We only set the trace exporter type so BlogFlow's OTel SDK initializes tracing.
-            // OTEL_METRICS_EXPORTER is intentionally UNSET (not "none") because BlogFlow's
-            // init code checks `os.Getenv != ""` — any non-empty value enables the metrics
-            // bridge. Leaving it unset skips metrics initialization entirely. See Phase 2
-            // in SETUP.md for future metrics export.
+            // Enable OTLP traces and metrics so the managed agent can route telemetry.
             {
               name: 'OTEL_TRACES_EXPORTER'
+              value: 'otlp'
+            }
+            {
+              name: 'OTEL_METRICS_EXPORTER'
               value: 'otlp'
             }
             {

--- a/deploy/azure/modules/container-app.bicep
+++ b/deploy/azure/modules/container-app.bicep
@@ -1,16 +1,15 @@
 // ============================================================================
-// Container App — BlogFlow (sidecar-free)
+// Container App — BlogFlow + self-managed OpenTelemetry Collector sidecar
 // ============================================================================
-// Runs the BlogFlow container. Telemetry is handled by the ACA managed
-// OpenTelemetry agent (configured on the environment):
-//   - Traces → Application Insights
-//   - Metrics → Azure Monitor workspace via DCE/DCR
+// Runs BlogFlow with an OpenTelemetry Collector sidecar. BlogFlow exports OTLP
+// to localhost; the collector exports:
+//   - Traces → Application Insights via the azuremonitor exporter
+//   - Metrics → DCE/DCR → Azure Monitor workspace via otlphttp + azure_auth
 //
-// The ACA managed OTel agent automatically injects OTEL_EXPORTER_OTLP_ENDPOINT
-// and other standard OTel env vars at runtime. BlogFlow's OTel SDK discovers
-// the agent automatically.
-//
-// Identity: System-assigned managed identity for Azure integration.
+// Identity: a user-assigned managed identity is attached to the Container App
+// and granted Monitoring Metrics Publisher on the DCR before the app revision is
+// created. The collector uses that identity to fetch Entra tokens for
+// https://monitor.azure.com/.default.
 // ============================================================================
 
 @description('Azure region')
@@ -32,6 +31,22 @@ param ghcrUsername string
 @secure()
 param ghcrPassword string
 
+@description('Application Insights connection string for trace export')
+@secure()
+param appInsightsConnectionString string
+
+@description('Data Collection Rule resource name for OTLP metrics ingestion')
+param dataCollectionRuleName string
+
+@description('Data Collection Rule immutable ID used in OTLP metrics ingestion URLs')
+param dataCollectionRuleImmutableId string
+
+@description('DCE metrics ingestion endpoint')
+param metricsIngestionEndpoint string
+
+@description('DCR stream name for Azure Monitor OTLP metrics ingestion')
+param otelMetricsStreamName string
+
 @description('Minimum replica count')
 param scaleMinReplicas int = 0
 
@@ -44,6 +59,73 @@ param customDomainName string = ''
 @description('Managed certificate ID for custom domain TLS. Required when customDomainName is set.')
 param customDomainCertificateId string = ''
 
+var monitoringMetricsPublisherRoleDefinitionId = '3913510d-42f4-4e42-8a64-420c390055eb'
+var otelCollectorImage = 'otel/opentelemetry-collector-contrib:0.148.0'
+var otlpMetricsEndpoint = '${metricsIngestionEndpoint}/datacollectionRules/${dataCollectionRuleImmutableId}/streams/${otelMetricsStreamName}/otlp/v1/metrics'
+var otelCollectorConfig = join([
+  'receivers:'
+  '  otlp:'
+  '    protocols:'
+  '      grpc:'
+  '        endpoint: localhost:4317'
+  '      http:'
+  '        endpoint: localhost:4318'
+  ''
+  'processors:'
+  '  cumulativetodelta:'
+  '  batch:'
+  '    timeout: 10s'
+  '    send_batch_size: 256'
+  ''
+  'extensions:'
+  '  azure_auth:'
+  '    managed_identity:'
+  '      client_id: ${containerAppIdentity.properties.clientId}'
+  '    scopes:'
+  '      - https://monitor.azure.com/.default'
+  ''
+  'exporters:'
+  '  azuremonitor/traces: {}'
+  '  otlphttp/azuremonitor_metrics:'
+  '    metrics_endpoint: "${otlpMetricsEndpoint}"'
+  '    auth:'
+  '      authenticator: azure_auth'
+  ''
+  'service:'
+  '  extensions: [azure_auth]'
+  '  pipelines:'
+  '    traces:'
+  '      receivers: [otlp]'
+  '      processors: [batch]'
+  '      exporters: [azuremonitor/traces]'
+  '    metrics:'
+  '      receivers: [otlp]'
+  '      processors: [cumulativetodelta, batch]'
+  '      exporters: [otlphttp/azuremonitor_metrics]'
+], '\n')
+
+// ---------------------------------------------------------------------------
+// Managed identity and DCR-scoped metrics publishing grant
+// ---------------------------------------------------------------------------
+resource containerAppIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: '${appName}-otel-mi'
+  location: location
+}
+
+resource metricsDataCollectionRule 'Microsoft.Insights/dataCollectionRules@2024-03-11' existing = {
+  name: dataCollectionRuleName
+}
+
+resource metricsPublisherRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(metricsDataCollectionRule.id, containerAppIdentity.id, monitoringMetricsPublisherRoleDefinitionId)
+  scope: metricsDataCollectionRule
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', monitoringMetricsPublisherRoleDefinitionId)
+    principalId: containerAppIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Container App
 // ---------------------------------------------------------------------------
@@ -51,7 +133,10 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
   name: appName
   location: location
   identity: {
-    type: 'SystemAssigned'
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${containerAppIdentity.id}': {}
+    }
   }
   properties: {
     managedEnvironmentId: environmentId
@@ -83,9 +168,6 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
       ]
 
       // --- Secrets ---
-      // NOTE: 'appinsights-cs' is retained as a placeholder during the transition
-      // from sidecar to managed OTel agent. Active revisions still reference it.
-      // Remove after all old revisions using it have been deactivated.
       secrets: [
         {
           name: 'ghcr-password'
@@ -93,8 +175,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
         }
         {
           name: 'appinsights-cs'
-          #disable-next-line use-secure-value-for-secure-inputs
-          value: 'deprecated-see-env-level-config'
+          value: appInsightsConnectionString
         }
       ]
     }
@@ -125,9 +206,6 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
             memory: '0.5Gi'
           }
           env: [
-            // The ACA managed OTel agent auto-injects OTEL_EXPORTER_OTLP_ENDPOINT.
-            // BlogFlow hardcodes OTEL_SERVICE_NAME='blogflow' in code (cmd/blogflow/main.go).
-            // Enable OTLP traces and metrics so the managed agent can route telemetry.
             {
               name: 'OTEL_TRACES_EXPORTER'
               value: 'otlp'
@@ -135,6 +213,18 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
             {
               name: 'OTEL_METRICS_EXPORTER'
               value: 'otlp'
+            }
+            {
+              name: 'OTEL_EXPORTER_OTLP_ENDPOINT'
+              value: 'http://localhost:4318'
+            }
+            {
+              name: 'OTEL_EXPORTER_OTLP_PROTOCOL'
+              value: 'http/protobuf'
+            }
+            {
+              name: 'OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE'
+              value: 'delta'
             }
             {
               name: 'BLOGFLOW_SYNC_STRATEGY'
@@ -200,8 +290,28 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
             }
           ]
         }
-        // OTel Collector sidecar REMOVED — the ACA managed OTel agent
-        // handles trace/metrics routing at the environment level.
+        // --- OpenTelemetry Collector sidecar ---
+        {
+          name: 'otel-collector'
+          image: otelCollectorImage
+          args: [
+            '--config=env:OTELCOL_CONFIG'
+          ]
+          resources: {
+            cpu: json('0.25')
+            memory: '0.5Gi'
+          }
+          env: [
+            {
+              name: 'OTELCOL_CONFIG'
+              value: otelCollectorConfig
+            }
+            {
+              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+              secretRef: 'appinsights-cs'
+            }
+          ]
+        }
       ]
 
       // --- Scaling ---
@@ -211,6 +321,9 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
       }
     }
   }
+  dependsOn: [
+    metricsPublisherRoleAssignment
+  ]
 }
 
 // ---------------------------------------------------------------------------
@@ -223,5 +336,8 @@ output fqdn string = containerApp.properties.configuration.ingress.fqdn
 @description('Container App resource name')
 output name string = containerApp.name
 
-@description('System-assigned managed identity principal ID')
-output principalId string = containerApp.identity.principalId
+@description('User-assigned managed identity principal ID used by the OTel Collector')
+output principalId string = containerAppIdentity.properties.principalId
+
+@description('User-assigned managed identity client ID used by the OTel Collector')
+output clientId string = containerAppIdentity.properties.clientId

--- a/deploy/azure/modules/data-collection.bicep
+++ b/deploy/azure/modules/data-collection.bicep
@@ -1,0 +1,102 @@
+// ============================================================================
+// Data Collection — OTLP metrics ingestion for Azure Monitor workspace
+// ============================================================================
+// Creates the Azure Monitor Data Collection Endpoint (DCE) and Data Collection
+// Rule (DCR) used by the ACA managed OpenTelemetry agent to send OTLP metrics
+// to the Azure Monitor workspace. Authentication is handled by Entra ID via
+// role assignment in main.bicep; no static API keys are configured here.
+// ============================================================================
+
+@description('Azure region')
+param location string
+
+@description('Base name prefix for resources')
+param environmentName string
+
+@description('Azure Monitor workspace resource ID for Prometheus metrics')
+param monitorWorkspaceId string
+
+var otelMetricsStreamName = 'Custom-Metrics-Otel'
+var monitorWorkspaceDestinationName = 'azureMonitorWorkspace'
+
+// ---------------------------------------------------------------------------
+// Data Collection Endpoint (OTLP ingestion)
+// ---------------------------------------------------------------------------
+resource dataCollectionEndpoint 'Microsoft.Insights/dataCollectionEndpoints@2024-03-11' = {
+  name: '${environmentName}-metrics-dce'
+  location: location
+  properties: {
+    description: 'OTLP metrics ingestion endpoint for BlogFlow'
+    networkAcls: {
+      publicNetworkAccess: 'Enabled'
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Data Collection Rule (route OTLP metrics to Azure Monitor workspace)
+// ---------------------------------------------------------------------------
+resource dataCollectionRule 'Microsoft.Insights/dataCollectionRules@2024-03-11' = {
+  name: '${environmentName}-metrics-dcr'
+  location: location
+  properties: {
+    description: 'Routes BlogFlow OTLP metrics to the Azure Monitor workspace'
+    dataCollectionEndpointId: dataCollectionEndpoint.id
+    directDataSources: {
+      otelMetrics: [
+        {
+          name: 'blogflowOtelMetrics'
+          streams: [
+            otelMetricsStreamName
+          ]
+          enrichWithResourceAttributes: [
+            '*'
+          ]
+        }
+      ]
+    }
+    destinations: {
+      monitoringAccounts: [
+        {
+          name: monitorWorkspaceDestinationName
+          accountResourceId: monitorWorkspaceId
+        }
+      ]
+    }
+    dataFlows: [
+      {
+        streams: [
+          otelMetricsStreamName
+        ]
+        destinations: [
+          monitorWorkspaceDestinationName
+        ]
+      }
+    ]
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Outputs
+// ---------------------------------------------------------------------------
+
+@description('Data Collection Endpoint resource ID')
+output dataCollectionEndpointId string = dataCollectionEndpoint.id
+
+@description('Data Collection Rule resource name')
+output dataCollectionRuleName string = dataCollectionRule.name
+
+@description('Data Collection Rule resource ID')
+output dataCollectionRuleId string = dataCollectionRule.id
+
+@description('Data Collection Rule immutable ID used in OTLP ingestion URLs')
+output dataCollectionRuleImmutableId string = dataCollectionRule.properties.immutableId
+
+@description('DCE logs ingestion endpoint')
+output logsIngestionEndpoint string = dataCollectionEndpoint.properties.logsIngestion.endpoint
+
+@description('DCE metrics ingestion endpoint')
+output metricsIngestionEndpoint string = dataCollectionEndpoint.properties.metricsIngestion.endpoint
+
+@description('Full OTLP metrics endpoint for the ACA managed OpenTelemetry agent')
+output otlpMetricsEndpoint string = '${dataCollectionEndpoint.properties.metricsIngestion.endpoint}/dataCollectionRules/${dataCollectionRule.properties.immutableId}/streams/${otelMetricsStreamName}/otlp/v1/metrics'

--- a/deploy/azure/modules/data-collection.bicep
+++ b/deploy/azure/modules/data-collection.bicep
@@ -2,9 +2,10 @@
 // Data Collection — OTLP metrics ingestion for Azure Monitor workspace
 // ============================================================================
 // Creates the Azure Monitor Data Collection Endpoint (DCE) and Data Collection
-// Rule (DCR) used by the ACA managed OpenTelemetry agent to send OTLP metrics
-// to the Azure Monitor workspace. Authentication is handled by Entra ID via
-// role assignment in main.bicep; no static API keys are configured here.
+// Rule (DCR) used by the self-managed OpenTelemetry Collector sidecar to send
+// OTLP metrics to the Azure Monitor workspace. Authentication is handled by
+// Microsoft Entra ID through the collector's Azure auth extension; no static API
+// keys are configured here.
 // ============================================================================
 
 @description('Azure region')
@@ -92,11 +93,14 @@ output dataCollectionRuleId string = dataCollectionRule.id
 @description('Data Collection Rule immutable ID used in OTLP ingestion URLs')
 output dataCollectionRuleImmutableId string = dataCollectionRule.properties.immutableId
 
+@description('DCR stream name for Azure Monitor OTLP metrics ingestion')
+output otelMetricsStreamName string = otelMetricsStreamName
+
 @description('DCE logs ingestion endpoint')
 output logsIngestionEndpoint string = dataCollectionEndpoint.properties.logsIngestion.endpoint
 
 @description('DCE metrics ingestion endpoint')
 output metricsIngestionEndpoint string = dataCollectionEndpoint.properties.metricsIngestion.endpoint
 
-@description('Full OTLP metrics endpoint for the ACA managed OpenTelemetry agent')
-output otlpMetricsEndpoint string = '${dataCollectionEndpoint.properties.metricsIngestion.endpoint}/dataCollectionRules/${dataCollectionRule.properties.immutableId}/streams/${otelMetricsStreamName}/otlp/v1/metrics'
+@description('Full OTLP metrics endpoint for the self-managed OpenTelemetry Collector')
+output otlpMetricsEndpoint string = '${dataCollectionEndpoint.properties.metricsIngestion.endpoint}/datacollectionRules/${dataCollectionRule.properties.immutableId}/streams/${otelMetricsStreamName}/otlp/v1/metrics'

--- a/deploy/azure/modules/data-collection.bicep
+++ b/deploy/azure/modules/data-collection.bicep
@@ -17,7 +17,7 @@ param environmentName string
 @description('Azure Monitor workspace resource ID for Prometheus metrics')
 param monitorWorkspaceId string
 
-var otelMetricsStreamName = 'Microsoft-PrometheusMetrics'
+var otelMetricsStreamName = 'Custom-Metrics-Otel'
 var monitorWorkspaceDestinationName = 'azureMonitorWorkspace'
 
 // ---------------------------------------------------------------------------

--- a/deploy/azure/modules/data-collection.bicep
+++ b/deploy/azure/modules/data-collection.bicep
@@ -17,7 +17,7 @@ param environmentName string
 @description('Azure Monitor workspace resource ID for Prometheus metrics')
 param monitorWorkspaceId string
 
-var otelMetricsStreamName = 'Custom-Metrics-Otel'
+var otelMetricsStreamName = 'Microsoft-PrometheusMetrics'
 var monitorWorkspaceDestinationName = 'azureMonitorWorkspace'
 
 // ---------------------------------------------------------------------------

--- a/deploy/azure/modules/monitor-workspace.bicep
+++ b/deploy/azure/modules/monitor-workspace.bicep
@@ -5,14 +5,9 @@
 // Prometheus metrics. This workspace stores time-series data with a cost
 // model appropriate for metrics (unlike Log Analytics PerGB2018).
 //
-// Phase 1 (current): The workspace is provisioned but metrics are NOT yet
-//   routed here. The managed OTel agent only exports traces → App Insights.
-//   Metrics export requires DCE/DCR infrastructure and Entra ID auth, which
-//   is a Phase 2 follow-up.
-//
-// Phase 2 (future): Set up Data Collection Endpoint + Data Collection Rule
-//   for OTLP metrics ingestion, then configure the ACA managed OTel agent
-//   to export metrics to the DCE endpoint with proper authentication.
+// Metrics are routed here through the DCE/DCR resources and a self-managed
+// OpenTelemetry Collector sidecar. The collector authenticates to Azure Monitor
+// with the Container App's managed identity through the Azure auth extension.
 // ============================================================================
 
 @description('Azure region')

--- a/deploy/azure/otel/collector-config.yaml
+++ b/deploy/azure/otel/collector-config.yaml
@@ -43,7 +43,7 @@ extensions:
 exporters:
   azuremonitor/traces: {}
   otlphttp/azuremonitor_metrics:
-    metrics_endpoint: "https://<metrics-dce-domain>/datacollectionRules/<dcr-immutable-id>/streams/Microsoft-PrometheusMetrics/otlp/v1/metrics"
+    metrics_endpoint: "https://<metrics-dce-domain>/datacollectionRules/<dcr-immutable-id>/streams/Custom-Metrics-Otel/otlp/v1/metrics"
     auth:
       authenticator: azure_auth
     retry_on_failure:

--- a/deploy/azure/otel/collector-config.yaml
+++ b/deploy/azure/otel/collector-config.yaml
@@ -1,50 +1,55 @@
-# OTel Collector configuration — RETIRED
+# OTel Collector configuration — reference only
 #
-# This file was previously used by the OTel Collector sidecar to receive traces
-# and metrics from BlogFlow and export them to Azure Monitor (Application Insights).
+# The active Azure Container Apps deployment passes an equivalent collector YAML
+# through the OTELCOL_CONFIG environment variable and starts the sidecar with:
 #
-# PROBLEM: The azuremonitor exporter sent BOTH traces and metrics to App Insights,
-# which stored metrics in the AppMetrics table of the backing Log Analytics workspace
-# at expensive PerGB2018 rates. Metrics should never go to Log Analytics.
+#   otelcol-contrib --config=env:OTELCOL_CONFIG
 #
-# REPLACED BY: ACA managed OpenTelemetry agent (configured in container-app-env.bicep)
-#   - Traces → Application Insights (correct)
-#   - Metrics → NOT exported (Phase 2 will route to Azure Monitor for Prometheus via DCE/DCR)
+# ACA does not provide a simple config-file mount for this sidecar. Keeping the
+# config inline in Bicep avoids a custom collector image while the configuration
+# remains small. If it grows substantially, bake this YAML into a tiny custom
+# collector image and change container-app.bicep accordingly.
 #
-# The OTel Collector sidecar has been removed from container-app.bicep.
-# This file is kept for reference only.
-#
-# --- Original configuration ---
-#
-# receivers:
-#   otlp:
-#     protocols:
-#       http:
-#         endpoint: 0.0.0.0:4318
-#   prometheus:
-#     config:
-#       scrape_configs:
-#         - job_name: blogflow
-#           scrape_interval: 30s
-#           static_configs:
-#             - targets: ["localhost:9090"]
-#
-# processors:
-#   batch:
-#     timeout: 10s
-#     send_batch_size: 256
-#
-# exporters:
-#   azuremonitor:
-#     connection_string: ${env:APPLICATIONINSIGHTS_CONNECTION_STRING}
-#
-# service:
-#   pipelines:
-#     traces:
-#       receivers: [otlp]
-#       processors: [batch]
-#       exporters: [azuremonitor]
-#     metrics:                          # <-- THIS caused metrics in Log Analytics
-#       receivers: [otlp, prometheus]   # <-- DUPLICATE: both push and scrape
-#       processors: [batch]
-#       exporters: [azuremonitor]       # <-- Wrong destination for metrics
+# See deploy/azure/modules/container-app.bicep for the rendered configuration,
+# which injects the managed identity client ID, DCR immutable ID, and DCE metrics
+# endpoint at deploy time.
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+      http:
+        endpoint: localhost:4318
+
+processors:
+  cumulativetodelta:
+  batch:
+    timeout: 10s
+    send_batch_size: 256
+
+extensions:
+  azure_auth:
+    managed_identity:
+      client_id: <container-app-user-assigned-managed-identity-client-id>
+    scopes:
+      - https://monitor.azure.com/.default
+
+exporters:
+  azuremonitor/traces: {}
+  otlphttp/azuremonitor_metrics:
+    metrics_endpoint: "https://<metrics-dce-domain>/datacollectionRules/<dcr-immutable-id>/streams/Custom-Metrics-Otel/otlp/v1/metrics"
+    auth:
+      authenticator: azure_auth
+
+service:
+  extensions: [azure_auth]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [azuremonitor/traces]
+    metrics:
+      receivers: [otlp]
+      processors: [cumulativetodelta, batch]
+      exporters: [otlphttp/azuremonitor_metrics]

--- a/deploy/azure/otel/collector-config.yaml
+++ b/deploy/azure/otel/collector-config.yaml
@@ -23,12 +23,17 @@ receivers:
         endpoint: localhost:4318
 
 processors:
-  cumulativetodelta:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 384
+    spike_limit_mib: 96
   batch:
     timeout: 10s
     send_batch_size: 256
 
 extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
   azure_auth:
     managed_identity:
       client_id: <container-app-user-assigned-managed-identity-client-id>
@@ -38,18 +43,23 @@ extensions:
 exporters:
   azuremonitor/traces: {}
   otlphttp/azuremonitor_metrics:
-    metrics_endpoint: "https://<metrics-dce-domain>/datacollectionRules/<dcr-immutable-id>/streams/Custom-Metrics-Otel/otlp/v1/metrics"
+    metrics_endpoint: "https://<metrics-dce-domain>/datacollectionRules/<dcr-immutable-id>/streams/Microsoft-PrometheusMetrics/otlp/v1/metrics"
     auth:
       authenticator: azure_auth
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 10m
 
 service:
-  extensions: [azure_auth]
+  extensions: [health_check, azure_auth]
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
+      processors: [memory_limiter, batch]
       exporters: [azuremonitor/traces]
     metrics:
       receivers: [otlp]
-      processors: [cumulativetodelta, batch]
+      processors: [memory_limiter, batch]
       exporters: [otlphttp/azuremonitor_metrics]


### PR DESCRIPTION
## Summary
Route BlogFlow metrics to Azure Monitor (Managed Prometheus workspace) via native OTLP ingestion.

## Architecture (revised after review)
BlogFlow app → OTLP `localhost:4318` → **self-managed OpenTelemetry Collector sidecar** (`otel/opentelemetry-collector-contrib`, digest-pinned) → `otlphttp` to the **DCE/DCR** native OTLP metrics endpoint (`.../datacollectionRules/<immutable-id>/streams/Custom-Metrics-Otel/otlp/v1/metrics`), authenticated by the Container App's **user-assigned managed identity** via the collector's `azure_auth` extension (Entra token, scope `https://monitor.azure.com/.default`). **No static keys.**

> Why a sidecar (not the ACA managed OTel agent): the ACA managed agent only supports static-header OTLP auth — it can't attach a managed-identity Entra token, which Azure Monitor OTLP ingestion requires. Verified against Azure docs during review.

## Details
- **DCE + DCR** routing OTLP metrics to the Azure Monitor workspace (`monitoringAccounts`), stream `Custom-Metrics-Otel` (native OTLP path; `Custom-Metrics-*` per Azure docs).
- **RBAC**: `Monitoring Metrics Publisher` scoped to the **DCR only**, granted to the app's user-assigned MI (deterministic `guid()`, `ServicePrincipal`).
- **Temporality**: cumulative (Managed Prometheus native).
- **Reliability**: `retry_on_failure` (survives initial RBAC-propagation 403s), `memory_limiter`, `health_check` (:13133) + sidecar liveness probe.
- **Ops**: `OTEL_SERVICE_NAME=blogflow`; SETUP.md documents the deploy-principal RBAC prerequisite (RBAC Administrator/User Access Administrator), propagation delay, and a PromQL ingestion-verification query.

Infrastructure-only (no CHANGELOG per convention).

Fixes #183