### PR TITLE
fix(overlayfs): negative-cache hardening — invalidation-generation guard + contention fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### BlogFlow
 
+* [BUGFIX] overlayfs: guard negative-cache stores with an invalidation generation so concurrent layer invalidations cannot resurrect stale upper-layer misses. #272
+* [ENHANCEMENT] overlayfs: shard the negative-cache LRU to reduce hot-path contention under parallel cache hits. #271
 * [CHANGE] overlayfs: negative cache now uses true LRU eviction of the least-recently-used entry at capacity (previously admission-capped — stopped caching new misses once full). #245
 * [BUGFIX] overlayfs: reject files exceeding the 64 MiB read limit before fully reading them (the `fs.ReadFileFS` fast-path previously read the whole file before the size check — latent OOM on the content trust boundary); covers template loading. #234
 

--- a/internal/overlayfs/metrics.go
+++ b/internal/overlayfs/metrics.go
@@ -13,11 +13,11 @@ type overlayMetrics struct {
 	layerHitTotal   *prometheus.CounterVec
 	missTotal       prometheus.Counter
 	negCacheHit     prometheus.Counter
-	negCacheSize    prometheus.Gauge
+	negCacheSize    prometheus.GaugeFunc
 	pathRejected    *prometheus.CounterVec
 }
 
-func newOverlayMetrics(reg prometheus.Registerer) (*overlayMetrics, error) {
+func newOverlayMetrics(reg prometheus.Registerer, negCacheSize func() float64) (*overlayMetrics, error) {
 	m := &overlayMetrics{
 		resolveDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -46,11 +46,12 @@ func newOverlayMetrics(reg prometheus.Registerer) (*overlayMetrics, error) {
 				Help: "Negative cache hits (avoided layer checks).",
 			},
 		),
-		negCacheSize: prometheus.NewGauge(
+		negCacheSize: prometheus.NewGaugeFunc(
 			prometheus.GaugeOpts{
 				Name: "blogflow_overlay_negcache_size",
 				Help: "Current number of entries in the negative cache.",
 			},
+			negCacheSize,
 		),
 		pathRejected: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -88,7 +89,9 @@ type Option func(*OverlayFS) error
 // Returns an error if metric registration fails (e.g., duplicate registration).
 func WithMetrics(reg prometheus.Registerer) Option {
 	return func(o *OverlayFS) error {
-		m, err := newOverlayMetrics(reg)
+		m, err := newOverlayMetrics(reg, func() float64 {
+			return float64(o.negCacheSize.Load())
+		})
 		if err != nil {
 			return err
 		}

--- a/internal/overlayfs/negcache_lru_test.go
+++ b/internal/overlayfs/negcache_lru_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 	"testing/fstest"
+	"time"
 )
 
 // TestNegativeCachePopulates verifies negCache entries are created when a file
@@ -263,8 +264,6 @@ func TestNegativeCacheConcurrentReadFileInvalidateLayer(t *testing.T) {
 }
 
 func TestNegativeCacheInvalidationGenerationPreventsStaleStore(t *testing.T) {
-	t.Parallel()
-
 	const name = "posts/race.md"
 	upper := fstest.MapFS{}
 	lower := &blockingOpenFS{
@@ -306,6 +305,112 @@ func TestNegativeCacheInvalidationGenerationPreventsStaleStore(t *testing.T) {
 	if string(data) != "upper" {
 		t.Fatalf("ReadFile(%q) after invalidation = %q, want upper", name, data)
 	}
+}
+
+func TestNegativeCacheReplaceLayerGenerationSnapshotPreventsStaleStore(t *testing.T) {
+	const name = "posts/replace-race.md"
+	snapshot := make(chan struct{})
+	proceed := make(chan struct{})
+	var once sync.Once
+	setNegCacheAfterLayerSnapshotHook(t, func() {
+		once.Do(func() {
+			close(snapshot)
+			<-proceed
+		})
+	})
+
+	ofs := NewOverlayFS(
+		fstest.MapFS{},
+		fstest.MapFS{name: {Data: []byte("lower")}},
+	).WithLayerNames([]string{"theme", "defaults"})
+
+	errCh := make(chan error, 1)
+	go func() {
+		data, err := ofs.ReadFile(name)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		if string(data) != "lower" {
+			errCh <- fmt.Errorf("in-flight ReadFile(%q) = %q, want lower", name, data)
+			return
+		}
+		errCh <- nil
+	}()
+
+	<-snapshot
+	if err := ofs.ReplaceLayer(0, fstest.MapFS{name: {Data: []byte("upper")}}); err != nil {
+		t.Fatalf("ReplaceLayer(0) failed: %v", err)
+	}
+	close(proceed)
+
+	if err := <-errCh; err != nil {
+		t.Fatal(err)
+	}
+
+	assertNegCacheContains(t, ofs, name, false)
+	data, err := ofs.ReadFile(name)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) after ReplaceLayer failed: %v", name, err)
+	}
+	if string(data) != "upper" {
+		t.Fatalf("ReadFile(%q) after ReplaceLayer = %q, want upper", name, data)
+	}
+}
+
+func TestNegativeCacheInvalidateLayerLocksAllShardsBeforePruning(t *testing.T) {
+	const name = "posts/partial-invalidation.md"
+	upper := fstest.MapFS{}
+	lower := fstest.MapFS{name: {Data: []byte("lower")}}
+	ofs := NewOverlayFS(upper, lower).WithLayerNames([]string{"theme", "defaults"})
+
+	if data, err := ofs.ReadFile(name); err != nil {
+		t.Fatalf("warm ReadFile(%q) failed: %v", name, err)
+	} else if string(data) != "lower" {
+		t.Fatalf("warm ReadFile(%q) = %q, want lower", name, data)
+	}
+	assertNegCacheContains(t, ofs, name, true)
+
+	upper[name] = &fstest.MapFile{Data: []byte("upper")}
+	invalidating := make(chan struct{})
+	releaseInvalidation := make(chan struct{})
+	var once sync.Once
+	setNegCacheInvalidationLockedHook(t, func() {
+		once.Do(func() {
+			close(invalidating)
+			<-releaseInvalidation
+		})
+	})
+
+	invalidationDone := make(chan struct{})
+	go func() {
+		ofs.InvalidateLayer(0)
+		close(invalidationDone)
+	}()
+
+	<-invalidating
+	readDone := make(chan readResult, 1)
+	go func() {
+		data, err := ofs.ReadFile(name)
+		readDone <- readResult{data: string(data), err: err}
+	}()
+
+	select {
+	case result := <-readDone:
+		t.Fatalf("ReadFile completed while invalidation held all shard locks: data=%q err=%v", result.data, result.err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseInvalidation)
+	<-invalidationDone
+	result := <-readDone
+	if result.err != nil {
+		t.Fatalf("ReadFile(%q) during invalidation failed: %v", name, result.err)
+	}
+	if result.data != "upper" {
+		t.Fatalf("ReadFile(%q) during invalidation = %q, want upper", name, result.data)
+	}
+	assertNegCacheContains(t, ofs, name, false)
 }
 
 func assertNegCacheContains(t *testing.T, ofs *OverlayFS, name string, want bool) {
@@ -372,4 +477,29 @@ func (b *blockingOpenFS) Open(name string) (fs.File, error) {
 		<-b.release
 	}
 	return b.base.Open(name)
+}
+
+type readResult struct {
+	data string
+	err  error
+}
+
+func setNegCacheAfterLayerSnapshotHook(t *testing.T, hook func()) {
+	t.Helper()
+
+	testHook := negCacheTestHook(hook)
+	negCacheAfterLayerSnapshotHook.Store(&testHook)
+	t.Cleanup(func() {
+		negCacheAfterLayerSnapshotHook.Store(nil)
+	})
+}
+
+func setNegCacheInvalidationLockedHook(t *testing.T, hook func()) {
+	t.Helper()
+
+	testHook := negCacheTestHook(hook)
+	negCacheInvalidationLockedHook.Store(&testHook)
+	t.Cleanup(func() {
+		negCacheInvalidationLockedHook.Store(nil)
+	})
 }

--- a/internal/overlayfs/negcache_lru_test.go
+++ b/internal/overlayfs/negcache_lru_test.go
@@ -2,6 +2,7 @@ package overlayfs
 
 import (
 	"fmt"
+	"io/fs"
 	"sync"
 	"testing"
 	"testing/fstest"
@@ -69,7 +70,7 @@ func TestNegativeCachePopulates(t *testing.T) {
 
 	// Verify negCache populated: we expect at least 2 entries for fallthrough paths,
 	// possibly more if layer 0 had paths that don't exist anywhere.
-	count := ofs.negCacheCount.Load()
+	count := ofs.negCacheLen()
 	if count < 2 {
 		t.Errorf("negCacheEntry count = %d, want >= 2 (paths absent from layer 0 must populate negCache)", count)
 	}
@@ -80,14 +81,14 @@ func TestNegativeCachePopulates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile(config.yaml) unexpectedly failed: %v", err)
 	}
-	gotBefore := ofs.negCacheCount.Load()
+	gotBefore := ofs.negCacheLen()
 
 	// Reading the same path again should not increase count (already cached).
 	_, err = ofs.ReadFile("config.yaml")
 	if err != nil {
 		t.Fatalf("ReadFile(config.yaml) 2nd try unexpectedly failed: %v", err)
 	}
-	gotAfter := ofs.negCacheCount.Load()
+	gotAfter := ofs.negCacheLen()
 
 	if gotBefore != gotAfter {
 		t.Errorf("double-read of layer-0 path changed negCache count from %d to %d; expected no change", gotBefore, gotAfter)
@@ -103,16 +104,16 @@ func TestNegativeCacheLRUEvictsLeastRecentlyUsed(t *testing.T) {
 
 	emptyLayer := fstest.MapFS{}
 	lowerLayer := fstest.MapFS{}
-	for i := 1; i <= 4; i++ {
-		key := fmt.Sprintf("file%02d", i)
+	names := sameNegCacheShardNames(t, testLimit+1)
+	for i, key := range names {
 		lowerLayer[key] = &fstest.MapFile{Data: []byte(fmt.Sprintf("data-%d", i))}
 	}
 
 	ofs := NewOverlayFS(emptyLayer, lowerLayer).WithLayerNames([]string{"theme", "defaults"})
-	ofs.maxNegCacheEntries = testLimit
+	ofs.maxNegCacheEntries = negCacheShardCount * testLimit
 
 	for i := 1; i <= testLimit; i++ {
-		name := fmt.Sprintf("file%02d", i)
+		name := names[i-1]
 		data, err := ofs.ReadFile(name)
 		if err != nil {
 			t.Fatalf("ReadFile(%q) unexpectedly failed: %v", name, err)
@@ -122,27 +123,27 @@ func TestNegativeCacheLRUEvictsLeastRecentlyUsed(t *testing.T) {
 		}
 	}
 
-	if count := ofs.negCacheCount.Load(); count != int64(testLimit) {
+	if count := ofs.negCacheLen(); count != int64(testLimit) {
 		t.Fatalf("negCacheEntry count after warmup = %d, want %d", count, testLimit)
 	}
 
-	// Refresh file01 through Stat, which performs lookup-only recency refresh.
-	// A true LRU cache should now evict file02, not file01.
-	if _, err := ofs.Stat("file01"); err != nil {
-		t.Fatalf("Stat(file01) refresh unexpectedly failed: %v", err)
+	// Refresh the first file through Stat, which performs lookup-only recency refresh.
+	// A true per-shard LRU cache should now evict the second file, not the first.
+	if _, err := ofs.Stat(names[0]); err != nil {
+		t.Fatalf("Stat(%s) refresh unexpectedly failed: %v", names[0], err)
 	}
-	if _, err := ofs.ReadFile("file04"); err != nil {
-		t.Fatalf("ReadFile(file04) insertion unexpectedly failed: %v", err)
+	if _, err := ofs.ReadFile(names[3]); err != nil {
+		t.Fatalf("ReadFile(%s) insertion unexpectedly failed: %v", names[3], err)
 	}
 
-	if count := ofs.negCacheCount.Load(); count != int64(testLimit) {
+	if count := ofs.negCacheLen(); count != int64(testLimit) {
 		t.Fatalf("negCacheEntry count after eviction = %d, want %d", count, testLimit)
 	}
 
-	assertNegCacheContains(t, ofs, "file01", true)
-	assertNegCacheContains(t, ofs, "file02", false)
-	assertNegCacheContains(t, ofs, "file03", true)
-	assertNegCacheContains(t, ofs, "file04", true)
+	assertNegCacheContains(t, ofs, names[0], true)
+	assertNegCacheContains(t, ofs, names[1], false)
+	assertNegCacheContains(t, ofs, names[2], true)
+	assertNegCacheContains(t, ofs, names[3], true)
 }
 
 func TestNegativeCacheStoreUpdatesExistingEntry(t *testing.T) {
@@ -160,7 +161,7 @@ func TestNegativeCacheStoreUpdatesExistingEntry(t *testing.T) {
 	if entry.firstCandidateLayer != 2 {
 		t.Fatalf("firstCandidateLayer = %d, want 2", entry.firstCandidateLayer)
 	}
-	if count := ofs.negCacheCount.Load(); count != 1 {
+	if count := ofs.negCacheLen(); count != 1 {
 		t.Fatalf("negCacheEntry count = %d, want 1", count)
 	}
 	assertNegCacheListSync(t, ofs)
@@ -261,12 +262,59 @@ func TestNegativeCacheConcurrentReadFileInvalidateLayer(t *testing.T) {
 	assertNegCacheListSync(t, ofs)
 }
 
+func TestNegativeCacheInvalidationGenerationPreventsStaleStore(t *testing.T) {
+	t.Parallel()
+
+	const name = "posts/race.md"
+	upper := fstest.MapFS{}
+	lower := &blockingOpenFS{
+		base:      fstest.MapFS{name: {Data: []byte("lower")}},
+		blockName: name,
+		opened:    make(chan struct{}),
+		release:   make(chan struct{}),
+	}
+	ofs := NewOverlayFS(upper, lower).WithLayerNames([]string{"theme", "defaults"})
+
+	errCh := make(chan error, 1)
+	go func() {
+		data, err := ofs.ReadFile(name)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		if string(data) != "lower" {
+			errCh <- fmt.Errorf("in-flight ReadFile(%q) = %q, want lower", name, data)
+			return
+		}
+		errCh <- nil
+	}()
+
+	<-lower.opened
+	upper[name] = &fstest.MapFile{Data: []byte("upper")}
+	ofs.InvalidateLayer(0)
+	close(lower.release)
+
+	if err := <-errCh; err != nil {
+		t.Fatal(err)
+	}
+
+	assertNegCacheContains(t, ofs, name, false)
+	data, err := ofs.ReadFile(name)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) after invalidation failed: %v", name, err)
+	}
+	if string(data) != "upper" {
+		t.Fatalf("ReadFile(%q) after invalidation = %q, want upper", name, data)
+	}
+}
+
 func assertNegCacheContains(t *testing.T, ofs *OverlayFS, name string, want bool) {
 	t.Helper()
 
-	ofs.negCacheMu.Lock()
-	_, got := ofs.negCache[name]
-	ofs.negCacheMu.Unlock()
+	shard := ofs.negCacheShard(name)
+	shard.mu.Lock()
+	_, got := shard.m[name]
+	shard.mu.Unlock()
 	if got != want {
 		t.Fatalf("negCache contains %q = %v, want %v", name, got, want)
 	}
@@ -275,15 +323,53 @@ func assertNegCacheContains(t *testing.T, ofs *OverlayFS, name string, want bool
 func assertNegCacheListSync(t *testing.T, ofs *OverlayFS) {
 	t.Helper()
 
-	ofs.negCacheMu.Lock()
-	mapLen := len(ofs.negCache)
-	listLen := 0
-	if ofs.negCacheLRU != nil {
-		listLen = ofs.negCacheLRU.Len()
-	}
-	ofs.negCacheMu.Unlock()
+	for i := range ofs.negCacheShards {
+		shard := &ofs.negCacheShards[i]
+		shard.mu.Lock()
+		mapLen := 0
+		if shard.m != nil {
+			mapLen = len(shard.m)
+		}
+		listLen := 0
+		if shard.lru != nil {
+			listLen = shard.lru.Len()
+		}
+		shard.mu.Unlock()
 
-	if listLen != mapLen {
-		t.Fatalf("negCacheLRU.Len() = %d, want len(negCache) %d", listLen, mapLen)
+		if listLen != mapLen {
+			t.Fatalf("negCache shard %d lru.Len() = %d, want len(map) %d", i, listLen, mapLen)
+		}
 	}
+}
+
+func sameNegCacheShardNames(t *testing.T, count int) []string {
+	t.Helper()
+
+	byShard := make(map[uint32][]string)
+	for i := 0; i < 10_000; i++ {
+		name := fmt.Sprintf("file%05d", i)
+		shard := negCacheShardIndex(name)
+		byShard[shard] = append(byShard[shard], name)
+		if len(byShard[shard]) == count {
+			return byShard[shard]
+		}
+	}
+	t.Fatalf("could not find %d names in one negative-cache shard", count)
+	return nil
+}
+
+type blockingOpenFS struct {
+	base      fs.FS
+	blockName string
+	opened    chan struct{}
+	release   chan struct{}
+	once      sync.Once
+}
+
+func (b *blockingOpenFS) Open(name string) (fs.File, error) {
+	if name == b.blockName {
+		b.once.Do(func() { close(b.opened) })
+		<-b.release
+	}
+	return b.base.Open(name)
 }

--- a/internal/overlayfs/overlayfs.go
+++ b/internal/overlayfs/overlayfs.go
@@ -30,6 +30,8 @@ import (
 	"time"
 )
 
+const negCacheShardCount = 16
+
 // layerMeta stores resolved root paths for disk-backed layers.
 // Used for symlink escape detection on non-Linux platforms.
 type layerMeta struct {
@@ -48,10 +50,8 @@ type OverlayFS struct {
 	mu sync.RWMutex // protects layers slice during hot-reload
 
 	// Negative cache: tracks paths confirmed absent from upper layers.
-	negCacheMu    sync.Mutex
-	negCache      map[string]*list.Element // map path to *negCacheListEntry in negCacheLRU
-	negCacheLRU   *list.List
-	negCacheCount atomic.Int64
+	negCacheShards [negCacheShardCount]negCacheShard
+	negCacheGen    atomic.Uint64
 
 	// maxNegCacheEntries bounds the negative cache size. At capacity,
 	// inserting a new entry evicts the least-recently-used entry.
@@ -59,6 +59,12 @@ type OverlayFS struct {
 
 	// metrics is nil when WithMetrics is not used (zero overhead).
 	metrics *overlayMetrics
+}
+
+type negCacheShard struct {
+	mu  sync.Mutex
+	m   map[string]*list.Element // map path to *negCacheListEntry in lru
+	lru *list.List
 }
 
 type negCacheEntry struct {
@@ -106,8 +112,6 @@ func NewOverlayFS(layers ...fs.FS) *OverlayFS {
 		layers:             filtered,
 		layerNames:         filteredNames,
 		layerMeta:          make([]layerMeta, len(filtered)),
-		negCache:           make(map[string]*list.Element),
-		negCacheLRU:        list.New(),
 		maxNegCacheEntries: 100_000,
 	}
 }
@@ -227,6 +231,7 @@ func (o *OverlayFS) Open(name string) (fs.File, error) {
 	startLayer := 0
 	negCacheHit := false
 	cachedFirstCandidateLayer := -1
+	negCacheGen := o.negCacheGen.Load()
 	if entry, ok := o.negCacheLookup(name); ok {
 		negCacheHit = true
 		cachedFirstCandidateLayer = entry.firstCandidateLayer
@@ -250,7 +255,7 @@ func (o *OverlayFS) Open(name string) (fs.File, error) {
 			}
 			// Cache: record that layers [0, i) don't have this path
 			if i > 0 && (!negCacheHit || i != cachedFirstCandidateLayer) {
-				o.negCacheStore(name, negCacheEntry{firstCandidateLayer: i})
+				o.negCacheStoreWithGeneration(name, negCacheEntry{firstCandidateLayer: i}, negCacheGen)
 			}
 			if o.metrics != nil {
 				o.metrics.resolveDuration.WithLabelValues("open").Observe(time.Since(start).Seconds())
@@ -293,6 +298,7 @@ func (o *OverlayFS) ReadFile(name string) ([]byte, error) {
 	startLayer := 0
 	negCacheHit := false
 	cachedFirstCandidateLayer := -1
+	negCacheGen := o.negCacheGen.Load()
 	if entry, ok := o.negCacheLookup(name); ok {
 		negCacheHit = true
 		cachedFirstCandidateLayer = entry.firstCandidateLayer
@@ -321,7 +327,7 @@ func (o *OverlayFS) ReadFile(name string) ([]byte, error) {
 			if readErr != nil {
 				return nil, readErr
 			}
-			o.recordReadFileHit(name, i, negCacheHit, cachedFirstCandidateLayer, start)
+			o.recordReadFileHit(name, i, negCacheHit, cachedFirstCandidateLayer, negCacheGen, start)
 			return data, nil
 		}
 		if !isNotExist(err) {
@@ -336,9 +342,9 @@ func (o *OverlayFS) ReadFile(name string) ([]byte, error) {
 	return nil, &fs.PathError{Op: "readfile", Path: name, Err: fs.ErrNotExist}
 }
 
-func (o *OverlayFS) recordReadFileHit(name string, layer int, negCacheHit bool, cachedFirstCandidateLayer int, start time.Time) {
+func (o *OverlayFS) recordReadFileHit(name string, layer int, negCacheHit bool, cachedFirstCandidateLayer int, negCacheGen uint64, start time.Time) {
 	if layer > 0 && (!negCacheHit || layer != cachedFirstCandidateLayer) {
-		o.negCacheStore(name, negCacheEntry{firstCandidateLayer: layer})
+		o.negCacheStoreWithGeneration(name, negCacheEntry{firstCandidateLayer: layer}, negCacheGen)
 	}
 	if o.metrics != nil {
 		o.metrics.resolveDuration.WithLabelValues("readfile").Observe(time.Since(start).Seconds())
@@ -427,7 +433,12 @@ func (o *OverlayFS) Stat(name string) (fs.FileInfo, error) {
 	o.mu.RUnlock()
 
 	startLayer := 0
+	negCacheHit := false
+	cachedFirstCandidateLayer := -1
+	negCacheGen := o.negCacheGen.Load()
 	if entry, ok := o.negCacheLookup(name); ok {
+		negCacheHit = true
+		cachedFirstCandidateLayer = entry.firstCandidateLayer
 		if entry.firstCandidateLayer < len(layers) {
 			startLayer = entry.firstCandidateLayer
 			if o.metrics != nil {
@@ -446,6 +457,9 @@ func (o *OverlayFS) Stat(name string) (fs.FileInfo, error) {
 			}
 			info, err := sfs.Stat(name)
 			if err == nil {
+				if i > 0 && (!negCacheHit || i != cachedFirstCandidateLayer) {
+					o.negCacheStoreWithGeneration(name, negCacheEntry{firstCandidateLayer: i}, negCacheGen)
+				}
 				if o.metrics != nil {
 					o.metrics.resolveDuration.WithLabelValues("stat").Observe(time.Since(start).Seconds())
 					o.metrics.layerHitTotal.WithLabelValues(o.layerName(i)).Inc()
@@ -469,6 +483,9 @@ func (o *OverlayFS) Stat(name string) (fs.FileInfo, error) {
 				info, statErr := f.Stat()
 				_ = f.Close()
 				if statErr == nil {
+					if i > 0 && (!negCacheHit || i != cachedFirstCandidateLayer) {
+						o.negCacheStoreWithGeneration(name, negCacheEntry{firstCandidateLayer: i}, negCacheGen)
+					}
 					if o.metrics != nil {
 						o.metrics.resolveDuration.WithLabelValues("stat").Observe(time.Since(start).Seconds())
 						o.metrics.layerHitTotal.WithLabelValues(o.layerName(i)).Inc()
@@ -506,55 +523,72 @@ func (o *OverlayFS) OpenFile(name string) (fs.File, fs.FileInfo, error) {
 	return f, info, nil
 }
 
-// Exact LRU refreshes recency on every hit, so this path intentionally takes
-// the global cache lock. See #271 for sharded/approximate-LRU follow-up.
 func (o *OverlayFS) negCacheLookup(name string) (negCacheEntry, bool) {
-	o.negCacheMu.Lock()
-	defer o.negCacheMu.Unlock()
+	shard := o.negCacheShard(name)
+	shard.mu.Lock()
+	defer shard.mu.Unlock()
 
-	elem, ok := o.negCache[name]
+	if shard.m == nil {
+		return negCacheEntry{}, false
+	}
+	elem, ok := shard.m[name]
 	if !ok {
 		return negCacheEntry{}, false
 	}
-	o.negCacheLRU.MoveToFront(elem)
+	shard.lru.MoveToFront(elem)
 	return elem.Value.(negCacheListEntry).value, true
 }
 
 func (o *OverlayFS) negCacheStore(name string, entry negCacheEntry) {
+	o.negCacheStoreWithGeneration(name, entry, o.negCacheGen.Load())
+}
+
+func (o *OverlayFS) negCacheStoreWithGeneration(name string, entry negCacheEntry, gen uint64) {
 	if o.maxNegCacheEntries <= 0 {
 		return
 	}
-
-	o.negCacheMu.Lock()
-	if elem, ok := o.negCache[name]; ok {
-		elem.Value = negCacheListEntry{key: name, value: entry}
-		o.negCacheLRU.MoveToFront(elem)
-		size := int64(len(o.negCache))
-		o.negCacheMu.Unlock()
-		o.updateNegCacheSizeMetric(size)
+	if o.negCacheGen.Load() != gen {
 		return
 	}
 
-	if len(o.negCache) >= o.maxNegCacheEntries {
-		oldest := o.negCacheLRU.Back()
+	shard := o.negCacheShard(name)
+	shard.mu.Lock()
+
+	if o.negCacheGen.Load() != gen {
+		shard.mu.Unlock()
+		return
+	}
+	o.ensureNegCacheShardLocked(shard)
+
+	if elem, ok := shard.m[name]; ok {
+		elem.Value = negCacheListEntry{key: name, value: entry}
+		shard.lru.MoveToFront(elem)
+		shard.mu.Unlock()
+		if o.metrics != nil {
+			o.updateNegCacheSizeMetric(o.negCacheLen())
+		}
+		return
+	}
+
+	if shard.lru.Len() >= o.negCacheShardCapacity() {
+		oldest := shard.lru.Back()
 		if oldest != nil {
 			oldestEntry := oldest.Value.(negCacheListEntry)
-			o.removeNegCacheElement(oldestEntry.key, oldest)
+			removeNegCacheElement(shard, oldestEntry.key, oldest)
 		}
 	}
 
-	elem := o.negCacheLRU.PushFront(negCacheListEntry{key: name, value: entry})
-	o.negCache[name] = elem
-	size := int64(len(o.negCache))
-	o.negCacheCount.Store(size)
-	o.negCacheMu.Unlock()
-	o.updateNegCacheSizeMetric(size)
+	elem := shard.lru.PushFront(negCacheListEntry{key: name, value: entry})
+	shard.m[name] = elem
+	shard.mu.Unlock()
+	if o.metrics != nil {
+		o.updateNegCacheSizeMetric(o.negCacheLen())
+	}
 }
 
-func (o *OverlayFS) removeNegCacheElement(key string, elem *list.Element) {
-	delete(o.negCache, key)
-	o.negCacheLRU.Remove(elem)
-	o.negCacheCount.Store(int64(len(o.negCache)))
+func removeNegCacheElement(shard *negCacheShard, key string, elem *list.Element) {
+	delete(shard.m, key)
+	shard.lru.Remove(elem)
 }
 
 func (o *OverlayFS) updateNegCacheSizeMetric(size int64) {
@@ -563,33 +597,91 @@ func (o *OverlayFS) updateNegCacheSizeMetric(size int64) {
 	}
 }
 
+func (o *OverlayFS) negCacheShard(name string) *negCacheShard {
+	return &o.negCacheShards[negCacheShardIndex(name)]
+}
+
+func (o *OverlayFS) ensureNegCacheShardLocked(shard *negCacheShard) {
+	if shard.m == nil {
+		shard.m = make(map[string]*list.Element)
+	}
+	if shard.lru == nil {
+		shard.lru = list.New()
+	}
+}
+
+func (o *OverlayFS) negCacheShardCapacity() int {
+	capacity := o.maxNegCacheEntries / negCacheShardCount
+	if o.maxNegCacheEntries%negCacheShardCount != 0 {
+		capacity++
+	}
+	if capacity < 1 {
+		capacity = 1
+	}
+	return capacity
+}
+
+func (o *OverlayFS) negCacheLen() int64 {
+	var total int64
+	for i := range o.negCacheShards {
+		shard := &o.negCacheShards[i]
+		shard.mu.Lock()
+		if shard.m != nil {
+			total += int64(len(shard.m))
+		}
+		shard.mu.Unlock()
+	}
+	return total
+}
+
+func negCacheShardIndex(name string) uint32 {
+	var h uint32 = 2166136261
+	for i := 0; i < len(name); i++ {
+		h ^= uint32(name[i])
+		h *= 16777619
+	}
+	return h % negCacheShardCount
+}
+
 // InvalidateLayer clears negative cache entries for a specific layer.
 // Called when files within a layer change (e.g., file edit, new file).
 func (o *OverlayFS) InvalidateLayer(layerIndex int) {
-	o.negCacheMu.Lock()
-	for key, elem := range o.negCache {
-		entry := elem.Value.(negCacheListEntry)
-		if entry.value.firstCandidateLayer >= layerIndex {
-			o.removeNegCacheElement(key, elem)
+	o.negCacheGen.Add(1)
+	for i := range o.negCacheShards {
+		shard := &o.negCacheShards[i]
+		shard.mu.Lock()
+		if shard.m != nil {
+			for key, elem := range shard.m {
+				entry := elem.Value.(negCacheListEntry)
+				if entry.value.firstCandidateLayer >= layerIndex {
+					removeNegCacheElement(shard, key, elem)
+				}
+			}
 		}
+		shard.mu.Unlock()
 	}
-	size := int64(len(o.negCache))
-	o.negCacheMu.Unlock()
-	o.updateNegCacheSizeMetric(size)
+	if o.metrics != nil {
+		o.updateNegCacheSizeMetric(o.negCacheLen())
+	}
 }
 
 // InvalidateAll clears the entire negative cache.
 func (o *OverlayFS) InvalidateAll() {
-	o.negCacheMu.Lock()
-	o.negCache = make(map[string]*list.Element)
-	if o.negCacheLRU == nil {
-		o.negCacheLRU = list.New()
-	} else {
-		o.negCacheLRU.Init()
+	o.negCacheGen.Add(1)
+	for i := range o.negCacheShards {
+		shard := &o.negCacheShards[i]
+		shard.mu.Lock()
+		shard.m = make(map[string]*list.Element)
+		if shard.lru == nil {
+			shard.lru = list.New()
+		} else {
+			shard.lru.Init()
+		}
+		shard.mu.Unlock()
 	}
-	o.negCacheCount.Store(0)
-	o.negCacheMu.Unlock()
-	o.updateNegCacheSizeMetric(0)
+	if o.metrics != nil {
+		o.updateNegCacheSizeMetric(0)
+	}
 }
 
 // ReplaceLayer atomically replaces a layer's backing fs.FS and clears
@@ -602,18 +694,25 @@ func (o *OverlayFS) ReplaceLayer(layerIndex int, newFS fs.FS) error {
 	if layerIndex < 0 || layerIndex >= len(o.layers) {
 		return fmt.Errorf("overlayfs: layer index %d out of range [0, %d)", layerIndex, len(o.layers))
 	}
+	o.negCacheGen.Add(1)
 	o.layers[layerIndex] = newFS
 	// Clear neg-cache entries that reference this or higher layers
-	o.negCacheMu.Lock()
-	for key, elem := range o.negCache {
-		entry := elem.Value.(negCacheListEntry)
-		if entry.value.firstCandidateLayer >= layerIndex {
-			o.removeNegCacheElement(key, elem)
+	for i := range o.negCacheShards {
+		shard := &o.negCacheShards[i]
+		shard.mu.Lock()
+		if shard.m != nil {
+			for key, elem := range shard.m {
+				entry := elem.Value.(negCacheListEntry)
+				if entry.value.firstCandidateLayer >= layerIndex {
+					removeNegCacheElement(shard, key, elem)
+				}
+			}
 		}
+		shard.mu.Unlock()
 	}
-	size := int64(len(o.negCache))
-	o.negCacheMu.Unlock()
-	o.updateNegCacheSizeMetric(size)
+	if o.metrics != nil {
+		o.updateNegCacheSizeMetric(o.negCacheLen())
+	}
 	return nil
 }
 

--- a/internal/overlayfs/overlayfs.go
+++ b/internal/overlayfs/overlayfs.go
@@ -605,23 +605,14 @@ func (o *OverlayFS) negCacheStoreWithGeneration(name string, entry negCacheEntry
 
 	elem := shard.lru.PushFront(negCacheListEntry{key: name, value: entry})
 	shard.m[name] = elem
-	size := o.negCacheSize.Add(1)
+	o.negCacheSize.Add(1)
 	shard.mu.Unlock()
-	if o.metrics != nil {
-		o.updateNegCacheSizeMetric(size)
-	}
 }
 
-func (o *OverlayFS) removeNegCacheElementLocked(shard *negCacheShard, key string, elem *list.Element) int64 {
+func (o *OverlayFS) removeNegCacheElementLocked(shard *negCacheShard, key string, elem *list.Element) {
 	delete(shard.m, key)
 	shard.lru.Remove(elem)
-	return o.negCacheSize.Add(-1)
-}
-
-func (o *OverlayFS) updateNegCacheSizeMetric(size int64) {
-	if o.metrics != nil {
-		o.metrics.negCacheSize.Set(float64(size))
-	}
+	o.negCacheSize.Add(-1)
 }
 
 func (o *OverlayFS) negCacheShard(name string) *negCacheShard {
@@ -705,22 +696,18 @@ func (o *OverlayFS) InvalidateLayer(layerIndex int) {
 	defer o.unlockAllNegCacheShards()
 	runNegCacheInvalidationLockedHook()
 
-	size := o.negCacheSize.Load()
 	for i := range o.negCacheShards {
 		shard := &o.negCacheShards[i]
 		if shard.m != nil {
 			for key, elem := range shard.m {
 				entry := elem.Value.(negCacheListEntry)
 				if entry.value.firstCandidateLayer >= layerIndex {
-					size = o.removeNegCacheElementLocked(shard, key, elem)
+					o.removeNegCacheElementLocked(shard, key, elem)
 				}
 			}
 		}
 	}
 	o.negCacheGen.Add(1)
-	if o.metrics != nil {
-		o.updateNegCacheSizeMetric(size)
-	}
 }
 
 // InvalidateAll clears the entire negative cache.
@@ -740,9 +727,6 @@ func (o *OverlayFS) InvalidateAll() {
 	}
 	o.negCacheSize.Store(0)
 	o.negCacheGen.Add(1)
-	if o.metrics != nil {
-		o.updateNegCacheSizeMetric(0)
-	}
 }
 
 // ReplaceLayer atomically replaces a layer's backing fs.FS and clears
@@ -761,7 +745,6 @@ func (o *OverlayFS) ReplaceLayer(layerIndex int, newFS fs.FS) error {
 	defer o.unlockAllNegCacheShards()
 	runNegCacheInvalidationLockedHook()
 
-	size := o.negCacheSize.Load()
 	// Clear neg-cache entries that reference this or higher layers
 	for i := range o.negCacheShards {
 		shard := &o.negCacheShards[i]
@@ -769,15 +752,12 @@ func (o *OverlayFS) ReplaceLayer(layerIndex int, newFS fs.FS) error {
 			for key, elem := range shard.m {
 				entry := elem.Value.(negCacheListEntry)
 				if entry.value.firstCandidateLayer >= layerIndex {
-					size = o.removeNegCacheElementLocked(shard, key, elem)
+					o.removeNegCacheElementLocked(shard, key, elem)
 				}
 			}
 		}
 	}
 	o.negCacheGen.Add(1)
-	if o.metrics != nil {
-		o.updateNegCacheSizeMetric(size)
-	}
 	return nil
 }
 

--- a/internal/overlayfs/overlayfs.go
+++ b/internal/overlayfs/overlayfs.go
@@ -30,7 +30,17 @@ import (
 	"time"
 )
 
+// negCacheShardCount spreads exact-LRU bookkeeping across independent locks.
+// Sixteen shards keeps hot-path contention low without making invalidation,
+// which is infrequent and locks all shards, unnecessarily expensive.
 const negCacheShardCount = 16
+
+type negCacheTestHook func()
+
+var (
+	negCacheAfterLayerSnapshotHook atomic.Pointer[negCacheTestHook]
+	negCacheInvalidationLockedHook atomic.Pointer[negCacheTestHook]
+)
 
 // layerMeta stores resolved root paths for disk-backed layers.
 // Used for symlink escape detection on non-Linux platforms.
@@ -51,10 +61,15 @@ type OverlayFS struct {
 
 	// Negative cache: tracks paths confirmed absent from upper layers.
 	negCacheShards [negCacheShardCount]negCacheShard
-	negCacheGen    atomic.Uint64
+	// negCacheGen is bumped on every invalidation. Stores captured under an
+	// older generation are dropped so stale misses cannot be resurrected after
+	// a layer changes.
+	negCacheGen  atomic.Uint64
+	negCacheSize atomic.Int64
 
 	// maxNegCacheEntries bounds the negative cache size. At capacity,
-	// inserting a new entry evicts the least-recently-used entry.
+	// inserting a new entry evicts the least-recently-used entry in that
+	// entry's shard. This is an approximate, not global, LRU under key skew.
 	maxNegCacheEntries int
 
 	// metrics is nil when WithMetrics is not used (zero overhead).
@@ -226,12 +241,13 @@ func (o *OverlayFS) Open(name string) (fs.File, error) {
 	o.mu.RLock()
 	layers := make([]fs.FS, len(o.layers))
 	copy(layers, o.layers)
+	negCacheGen := o.negCacheGen.Load()
 	o.mu.RUnlock()
+	runNegCacheAfterLayerSnapshotHook()
 
 	startLayer := 0
 	negCacheHit := false
 	cachedFirstCandidateLayer := -1
-	negCacheGen := o.negCacheGen.Load()
 	if entry, ok := o.negCacheLookup(name); ok {
 		negCacheHit = true
 		cachedFirstCandidateLayer = entry.firstCandidateLayer
@@ -293,12 +309,13 @@ func (o *OverlayFS) ReadFile(name string) ([]byte, error) {
 	o.mu.RLock()
 	layers := make([]fs.FS, len(o.layers))
 	copy(layers, o.layers)
+	negCacheGen := o.negCacheGen.Load()
 	o.mu.RUnlock()
+	runNegCacheAfterLayerSnapshotHook()
 
 	startLayer := 0
 	negCacheHit := false
 	cachedFirstCandidateLayer := -1
-	negCacheGen := o.negCacheGen.Load()
 	if entry, ok := o.negCacheLookup(name); ok {
 		negCacheHit = true
 		cachedFirstCandidateLayer = entry.firstCandidateLayer
@@ -430,12 +447,13 @@ func (o *OverlayFS) Stat(name string) (fs.FileInfo, error) {
 	o.mu.RLock()
 	layers := make([]fs.FS, len(o.layers))
 	copy(layers, o.layers)
+	negCacheGen := o.negCacheGen.Load()
 	o.mu.RUnlock()
+	runNegCacheAfterLayerSnapshotHook()
 
 	startLayer := 0
 	negCacheHit := false
 	cachedFirstCandidateLayer := -1
-	negCacheGen := o.negCacheGen.Load()
 	if entry, ok := o.negCacheLookup(name); ok {
 		negCacheHit = true
 		cachedFirstCandidateLayer = entry.firstCandidateLayer
@@ -547,6 +565,8 @@ func (o *OverlayFS) negCacheStoreWithGeneration(name string, entry negCacheEntry
 	if o.maxNegCacheEntries <= 0 {
 		return
 	}
+	// Fast fail before taking the shard lock. This drops stores from resolves
+	// that began before an invalidation changed the cache generation.
 	if o.negCacheGen.Load() != gen {
 		return
 	}
@@ -554,6 +574,8 @@ func (o *OverlayFS) negCacheStoreWithGeneration(name string, entry negCacheEntry
 	shard := o.negCacheShard(name)
 	shard.mu.Lock()
 
+	// Re-check under the shard lock so an invalidation that waited on this
+	// shard cannot be followed by a stale store from the old generation.
 	if o.negCacheGen.Load() != gen {
 		shard.mu.Unlock()
 		return
@@ -565,7 +587,7 @@ func (o *OverlayFS) negCacheStoreWithGeneration(name string, entry negCacheEntry
 		shard.lru.MoveToFront(elem)
 		shard.mu.Unlock()
 		if o.metrics != nil {
-			o.updateNegCacheSizeMetric(o.negCacheLen())
+			o.updateNegCacheSizeMetric(o.negCacheSize.Load())
 		}
 		return
 	}
@@ -574,21 +596,23 @@ func (o *OverlayFS) negCacheStoreWithGeneration(name string, entry negCacheEntry
 		oldest := shard.lru.Back()
 		if oldest != nil {
 			oldestEntry := oldest.Value.(negCacheListEntry)
-			removeNegCacheElement(shard, oldestEntry.key, oldest)
+			o.removeNegCacheElementLocked(shard, oldestEntry.key, oldest)
 		}
 	}
 
 	elem := shard.lru.PushFront(negCacheListEntry{key: name, value: entry})
 	shard.m[name] = elem
+	o.negCacheSize.Add(1)
 	shard.mu.Unlock()
 	if o.metrics != nil {
-		o.updateNegCacheSizeMetric(o.negCacheLen())
+		o.updateNegCacheSizeMetric(o.negCacheSize.Load())
 	}
 }
 
-func removeNegCacheElement(shard *negCacheShard, key string, elem *list.Element) {
+func (o *OverlayFS) removeNegCacheElementLocked(shard *negCacheShard, key string, elem *list.Element) {
 	delete(shard.m, key)
 	shard.lru.Remove(elem)
+	o.negCacheSize.Add(-1)
 }
 
 func (o *OverlayFS) updateNegCacheSizeMetric(size int64) {
@@ -634,6 +658,18 @@ func (o *OverlayFS) negCacheLen() int64 {
 	return total
 }
 
+func (o *OverlayFS) lockAllNegCacheShards() {
+	for i := range o.negCacheShards {
+		o.negCacheShards[i].mu.Lock()
+	}
+}
+
+func (o *OverlayFS) unlockAllNegCacheShards() {
+	for i := len(o.negCacheShards) - 1; i >= 0; i-- {
+		o.negCacheShards[i].mu.Unlock()
+	}
+}
+
 func negCacheShardIndex(name string) uint32 {
 	var h uint32 = 2166136261
 	for i := 0; i < len(name); i++ {
@@ -643,42 +679,59 @@ func negCacheShardIndex(name string) uint32 {
 	return h % negCacheShardCount
 }
 
+func runNegCacheAfterLayerSnapshotHook() {
+	if hook := negCacheAfterLayerSnapshotHook.Load(); hook != nil {
+		(*hook)()
+	}
+}
+
+func runNegCacheInvalidationLockedHook() {
+	if hook := negCacheInvalidationLockedHook.Load(); hook != nil {
+		(*hook)()
+	}
+}
+
 // InvalidateLayer clears negative cache entries for a specific layer.
 // Called when files within a layer change (e.g., file edit, new file).
 func (o *OverlayFS) InvalidateLayer(layerIndex int) {
-	o.negCacheGen.Add(1)
+	o.lockAllNegCacheShards()
+	defer o.unlockAllNegCacheShards()
+	runNegCacheInvalidationLockedHook()
+
 	for i := range o.negCacheShards {
 		shard := &o.negCacheShards[i]
-		shard.mu.Lock()
 		if shard.m != nil {
 			for key, elem := range shard.m {
 				entry := elem.Value.(negCacheListEntry)
 				if entry.value.firstCandidateLayer >= layerIndex {
-					removeNegCacheElement(shard, key, elem)
+					o.removeNegCacheElementLocked(shard, key, elem)
 				}
 			}
 		}
-		shard.mu.Unlock()
 	}
+	o.negCacheGen.Add(1)
 	if o.metrics != nil {
-		o.updateNegCacheSizeMetric(o.negCacheLen())
+		o.updateNegCacheSizeMetric(o.negCacheSize.Load())
 	}
 }
 
 // InvalidateAll clears the entire negative cache.
 func (o *OverlayFS) InvalidateAll() {
-	o.negCacheGen.Add(1)
+	o.lockAllNegCacheShards()
+	defer o.unlockAllNegCacheShards()
+	runNegCacheInvalidationLockedHook()
+
 	for i := range o.negCacheShards {
 		shard := &o.negCacheShards[i]
-		shard.mu.Lock()
 		shard.m = make(map[string]*list.Element)
 		if shard.lru == nil {
 			shard.lru = list.New()
 		} else {
 			shard.lru.Init()
 		}
-		shard.mu.Unlock()
 	}
+	o.negCacheSize.Store(0)
+	o.negCacheGen.Add(1)
 	if o.metrics != nil {
 		o.updateNegCacheSizeMetric(0)
 	}
@@ -694,24 +747,27 @@ func (o *OverlayFS) ReplaceLayer(layerIndex int, newFS fs.FS) error {
 	if layerIndex < 0 || layerIndex >= len(o.layers) {
 		return fmt.Errorf("overlayfs: layer index %d out of range [0, %d)", layerIndex, len(o.layers))
 	}
-	o.negCacheGen.Add(1)
 	o.layers[layerIndex] = newFS
+
+	o.lockAllNegCacheShards()
+	defer o.unlockAllNegCacheShards()
+	runNegCacheInvalidationLockedHook()
+
 	// Clear neg-cache entries that reference this or higher layers
 	for i := range o.negCacheShards {
 		shard := &o.negCacheShards[i]
-		shard.mu.Lock()
 		if shard.m != nil {
 			for key, elem := range shard.m {
 				entry := elem.Value.(negCacheListEntry)
 				if entry.value.firstCandidateLayer >= layerIndex {
-					removeNegCacheElement(shard, key, elem)
+					o.removeNegCacheElementLocked(shard, key, elem)
 				}
 			}
 		}
-		shard.mu.Unlock()
 	}
+	o.negCacheGen.Add(1)
 	if o.metrics != nil {
-		o.updateNegCacheSizeMetric(o.negCacheLen())
+		o.updateNegCacheSizeMetric(o.negCacheSize.Load())
 	}
 	return nil
 }

--- a/internal/overlayfs/overlayfs.go
+++ b/internal/overlayfs/overlayfs.go
@@ -38,7 +38,13 @@ const negCacheShardCount = 16
 type negCacheTestHook func()
 
 var (
+	// negCacheAfterLayerSnapshotHook is a deterministic test synchronization
+	// point. It is nil in production, so the hot path only pays an atomic load
+	// and nil check.
 	negCacheAfterLayerSnapshotHook atomic.Pointer[negCacheTestHook]
+	// negCacheInvalidationLockedHook is a deterministic test synchronization
+	// point after invalidation has acquired all shard locks. It is nil in
+	// production and exists only to make race regressions reproducible.
 	negCacheInvalidationLockedHook atomic.Pointer[negCacheTestHook]
 )
 
@@ -586,9 +592,6 @@ func (o *OverlayFS) negCacheStoreWithGeneration(name string, entry negCacheEntry
 		elem.Value = negCacheListEntry{key: name, value: entry}
 		shard.lru.MoveToFront(elem)
 		shard.mu.Unlock()
-		if o.metrics != nil {
-			o.updateNegCacheSizeMetric(o.negCacheSize.Load())
-		}
 		return
 	}
 
@@ -602,17 +605,17 @@ func (o *OverlayFS) negCacheStoreWithGeneration(name string, entry negCacheEntry
 
 	elem := shard.lru.PushFront(negCacheListEntry{key: name, value: entry})
 	shard.m[name] = elem
-	o.negCacheSize.Add(1)
+	size := o.negCacheSize.Add(1)
 	shard.mu.Unlock()
 	if o.metrics != nil {
-		o.updateNegCacheSizeMetric(o.negCacheSize.Load())
+		o.updateNegCacheSizeMetric(size)
 	}
 }
 
-func (o *OverlayFS) removeNegCacheElementLocked(shard *negCacheShard, key string, elem *list.Element) {
+func (o *OverlayFS) removeNegCacheElementLocked(shard *negCacheShard, key string, elem *list.Element) int64 {
 	delete(shard.m, key)
 	shard.lru.Remove(elem)
-	o.negCacheSize.Add(-1)
+	return o.negCacheSize.Add(-1)
 }
 
 func (o *OverlayFS) updateNegCacheSizeMetric(size int64) {
@@ -679,12 +682,16 @@ func negCacheShardIndex(name string) uint32 {
 	return h % negCacheShardCount
 }
 
+// runNegCacheAfterLayerSnapshotHook is a no-op-in-production deterministic
+// test sync point used to pause a resolver after it snapshots layers+generation.
 func runNegCacheAfterLayerSnapshotHook() {
 	if hook := negCacheAfterLayerSnapshotHook.Load(); hook != nil {
 		(*hook)()
 	}
 }
 
+// runNegCacheInvalidationLockedHook is a no-op-in-production deterministic
+// test sync point used after an invalidation owns every cache shard lock.
 func runNegCacheInvalidationLockedHook() {
 	if hook := negCacheInvalidationLockedHook.Load(); hook != nil {
 		(*hook)()
@@ -698,20 +705,21 @@ func (o *OverlayFS) InvalidateLayer(layerIndex int) {
 	defer o.unlockAllNegCacheShards()
 	runNegCacheInvalidationLockedHook()
 
+	size := o.negCacheSize.Load()
 	for i := range o.negCacheShards {
 		shard := &o.negCacheShards[i]
 		if shard.m != nil {
 			for key, elem := range shard.m {
 				entry := elem.Value.(negCacheListEntry)
 				if entry.value.firstCandidateLayer >= layerIndex {
-					o.removeNegCacheElementLocked(shard, key, elem)
+					size = o.removeNegCacheElementLocked(shard, key, elem)
 				}
 			}
 		}
 	}
 	o.negCacheGen.Add(1)
 	if o.metrics != nil {
-		o.updateNegCacheSizeMetric(o.negCacheSize.Load())
+		o.updateNegCacheSizeMetric(size)
 	}
 }
 
@@ -753,6 +761,7 @@ func (o *OverlayFS) ReplaceLayer(layerIndex int, newFS fs.FS) error {
 	defer o.unlockAllNegCacheShards()
 	runNegCacheInvalidationLockedHook()
 
+	size := o.negCacheSize.Load()
 	// Clear neg-cache entries that reference this or higher layers
 	for i := range o.negCacheShards {
 		shard := &o.negCacheShards[i]
@@ -760,14 +769,14 @@ func (o *OverlayFS) ReplaceLayer(layerIndex int, newFS fs.FS) error {
 			for key, elem := range shard.m {
 				entry := elem.Value.(negCacheListEntry)
 				if entry.value.firstCandidateLayer >= layerIndex {
-					o.removeNegCacheElementLocked(shard, key, elem)
+					size = o.removeNegCacheElementLocked(shard, key, elem)
 				}
 			}
 		}
 	}
 	o.negCacheGen.Add(1)
 	if o.metrics != nil {
-		o.updateNegCacheSizeMetric(o.negCacheSize.Load())
+		o.updateNegCacheSizeMetric(size)
 	}
 	return nil
 }

--- a/internal/overlayfs/overlayfs_bench_test.go
+++ b/internal/overlayfs/overlayfs_bench_test.go
@@ -167,11 +167,12 @@ func BenchmarkNegCacheHitCrossShard_Parallel(b *testing.B) {
 	}
 
 	b.Run("ReadFile", func(b *testing.B) {
+		offsets := benchWorkerOffsets(len(names))
 		b.SetParallelism(8)
 		b.ReportAllocs()
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
-			i := 0
+			i := <-offsets
 			for pb.Next() {
 				name := names[i%len(names)]
 				i++
@@ -189,11 +190,12 @@ func BenchmarkNegCacheHitCrossShard_Parallel(b *testing.B) {
 	})
 
 	b.Run("Stat", func(b *testing.B) {
+		offsets := benchWorkerOffsets(len(names))
 		b.SetParallelism(8)
 		b.ReportAllocs()
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
-			i := 0
+			i := <-offsets
 			for pb.Next() {
 				name := names[i%len(names)]
 				i++
@@ -250,7 +252,21 @@ func benchCrossShardNames(keysPerShard int) []string {
 		if len(namesByShard[shard]) != keysPerShard {
 			panic("could not generate enough cross-shard benchmark names")
 		}
-		names = append(names, namesByShard[shard]...)
+	}
+	for key := 0; key < keysPerShard; key++ {
+		for shard := range namesByShard {
+			names = append(names, namesByShard[shard][key])
+		}
 	}
 	return names
+}
+
+func benchWorkerOffsets(nameCount int) <-chan int {
+	const maxWorkers = 4096
+
+	offsets := make(chan int, maxWorkers)
+	for i := 0; i < maxWorkers; i++ {
+		offsets <- i % nameCount
+	}
+	return offsets
 }

--- a/internal/overlayfs/overlayfs_bench_test.go
+++ b/internal/overlayfs/overlayfs_bench_test.go
@@ -149,6 +149,63 @@ func BenchmarkNegCacheHit_Parallel(b *testing.B) {
 	})
 }
 
+func BenchmarkNegCacheHitCrossShard_Parallel(b *testing.B) {
+	const keysPerShard = 16
+
+	names := benchCrossShardNames(keysPerShard)
+	upper := fstest.MapFS{}
+	lower := make(fstest.MapFS, len(names))
+	for _, name := range names {
+		lower[name] = &fstest.MapFile{Data: []byte("data")}
+	}
+	ofs := NewOverlayFS(upper, lower).WithLayerNames([]string{"theme", "defaults"})
+
+	for _, name := range names {
+		if _, err := ofs.ReadFile(name); err != nil {
+			b.Fatalf("warm ReadFile(%q): %v", name, err)
+		}
+	}
+
+	b.Run("ReadFile", func(b *testing.B) {
+		b.SetParallelism(8)
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			i := 0
+			for pb.Next() {
+				name := names[i%len(names)]
+				i++
+				data, err := ofs.ReadFile(name)
+				if err != nil {
+					b.Error(err)
+					return
+				}
+				if len(data) == 0 {
+					b.Error("ReadFile returned empty data")
+					return
+				}
+			}
+		})
+	})
+
+	b.Run("Stat", func(b *testing.B) {
+		b.SetParallelism(8)
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			i := 0
+			for pb.Next() {
+				name := names[i%len(names)]
+				i++
+				if _, err := ofs.Stat(name); err != nil {
+					b.Error(err)
+					return
+				}
+			}
+		})
+	})
+}
+
 func BenchmarkReadDir_Union(b *testing.B) {
 	ofs := benchReadDirOverlay(25)
 	b.ReportAllocs()
@@ -176,4 +233,24 @@ func BenchmarkOpen_Parallel(b *testing.B) {
 			_ = f.Close()
 		}
 	})
+}
+
+func benchCrossShardNames(keysPerShard int) []string {
+	namesByShard := make([][]string, negCacheShardCount)
+	for i := 0; i < 100_000; i++ {
+		name := fmt.Sprintf("cross-shard/file%05d.txt", i)
+		shard := negCacheShardIndex(name)
+		if len(namesByShard[shard]) < keysPerShard {
+			namesByShard[shard] = append(namesByShard[shard], name)
+		}
+	}
+
+	names := make([]string, 0, negCacheShardCount*keysPerShard)
+	for shard := range namesByShard {
+		if len(namesByShard[shard]) != keysPerShard {
+			panic("could not generate enough cross-shard benchmark names")
+		}
+		names = append(names, namesByShard[shard]...)
+	}
+	return names
 }


### PR DESCRIPTION
Fixes #272
Fixes #271

## Summary
- Adds a global negative-cache invalidation generation. Open, ReadFile, and Stat snapshot the generation inside the layer read lock, atomically with copying the layer slice, then skip stale stores if any invalidation or ReplaceLayer changes the generation before store.
- Replaces the single negative-cache mutex/map/LRU with 16 path-hash shards, each with its own mutex and approximate per-shard LRU capacity.
- Makes invalidation atomic from readers' perspective by locking all shards in fixed order, pruning/clearing, bumping the generation, then releasing.
- Replaces the write-only production negCacheCount field with an atomic size counter for metrics and keeps locked negCacheLen() for tests.
- Adds focused doc comments and cross-shard parallel benchmarks.

## Regression coverage
- TestNegativeCacheInvalidationGenerationPreventsStaleStore covers InvalidateLayer during an in-flight read.
- TestNegativeCacheReplaceLayerGenerationSnapshotPreventsStaleStore covers ReplaceLayer completing after layer snapshot but before the read resolves.
- TestNegativeCacheInvalidateLayerLocksAllShardsBeforePruning covers readers being blocked while invalidation holds all shard locks.
- Verified the ReplaceLayer test fails without the gen snapshot fix: stale entry remains in neg-cache.
- Verified the atomic invalidation test fails without all-shard locking: read completes during partial invalidation with lower-layer data.

## Benchmark evidence
Command: go test -run ^$ -bench NegCacheHit -benchtime=100ms -cpu 1,4,16 ./internal/overlayfs/

Original baseline before sharding:
- BenchmarkNegCacheHit_Parallel/ReadFile: 223.0 ns/op (cpu=1), 177.4 ns/op (cpu=4), 330.8 ns/op (cpu=16)
- BenchmarkNegCacheHit_Parallel/Stat: 143.0 ns/op (cpu=1), 132.8 ns/op (cpu=4), 179.0 ns/op (cpu=16)

Final same-key benchmark:
- BenchmarkNegCacheHit_Parallel/ReadFile: 229.3 ns/op (cpu=1), 167.5 ns/op (cpu=4), 299.1 ns/op (cpu=16)
- BenchmarkNegCacheHit_Parallel/Stat: 157.7 ns/op (cpu=1), 78.43 ns/op (cpu=4), 148.0 ns/op (cpu=16)

Final cross-shard benchmark:
- BenchmarkNegCacheHitCrossShard_Parallel/ReadFile: 329.5 ns/op (cpu=1), 183.1 ns/op (cpu=4), 264.3 ns/op (cpu=16)
- BenchmarkNegCacheHitCrossShard_Parallel/Stat: 240.6 ns/op (cpu=1), 83.65 ns/op (cpu=4), 200.5 ns/op (cpu=16)

Decision: sharded LRU remains implemented. The same-key benchmark intentionally still contends on one shard; the cross-shard benchmark exercises distributed keys and prevents a single global cache lock from becoming the universal bottleneck.

## Validation
- go build ./...
- go vet ./...
- golangci-lint run ./internal/overlayfs/...
- go test -race -count=3 ./internal/overlayfs/...
- go test -race -count=1 ./...
- go test -run ^$ -bench NegCacheHit -benchtime=100ms -cpu 1,4,16 ./internal/overlayfs/
