### PR TITLE
fix(deploy): harden Azure OTel collector sidecar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Validate Azure collector image pinning
+        run: python3 deploy/azure/validate-collector-image-pin.py
+
       - uses: actions/setup-go@v6
         with:
           go-version: '1.26'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,12 @@ jobs:
             echo "tag=main" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Validate Azure collector image pinning
+        if: >-
+          github.event_name == 'push' ||
+          (github.event_name == 'workflow_dispatch' && inputs.full_deploy == true)
+        run: python3 deploy/azure/validate-collector-image-pin.py
+
       # Full Bicep deploy — only on infra changes or explicit manual trigger
       - name: Deploy Bicep template (full)
         if: >-

--- a/deploy/azure/SETUP.md
+++ b/deploy/azure/SETUP.md
@@ -243,14 +243,18 @@ The collector image is assembled from two Bicep parameters instead of one free-f
 image string:
 
 - `otelCollectorImageRepository` — repository plus tag, default
-  `otel/opentelemetry-collector-contrib:0.148.0`
-- `otelCollectorImageDigest` — 64-character SHA-256 digest without the
-  `sha256:` prefix
+  `otel/opentelemetry-collector-contrib:0.148.0`; do not include `@` or an
+  embedded digest
+- `otelCollectorImageDigest` — 64-character lowercase-hex SHA-256 digest without
+  the `sha256:` prefix
 
 The deployed image is always rendered as
 `<repository>@sha256:<digest>`, so a tag-only collector override cannot be
-deployed accidentally. Update both parameters together when intentionally moving
-to a newer collector release.
+deployed accidentally. The Bicep template rejects an embedded digest in the repository parameter and
+requires the digest to match `^[0-9a-f]{64}$` before rendering the final image
+reference. `deploy/azure/validate-collector-image-pin.py` also runs in CI/deploy
+validation to catch bad checked-in defaults before deployment. Update both
+parameters together when intentionally moving to a newer collector release.
 
 ### Collector health probes and bind address
 
@@ -258,8 +262,16 @@ The `otel-collector` sidecar has Startup, Readiness, and Liveness probes against
 the collector `health_check` extension on port 13133. Startup gives the collector
 up to two minutes to initialize, Readiness gates the Container App revision until
 the sidecar health endpoint is responding, and Liveness restarts a wedged
-collector. This reduces the cold-start window where BlogFlow could emit metrics
-before the collector pipeline is available.
+collector. The Readiness probe intentionally has no `initialDelaySeconds` because
+the Startup probe gates it.
+
+The health endpoint confirms the collector service and configured extensions are
+running, but it does **not** wait for the `azure_auth` extension to acquire an
+Entra token or prove the DCE export path. Early 401/403s during managed-identity
+RBAC propagation can still occur after Readiness succeeds. That cold-start loss
+window is mitigated by the configured `batch` processor plus `otlphttp`
+`retry_on_failure` backoff (`initial_interval: 5s`, `max_interval: 30s`,
+`max_elapsed_time: 10m`), not by the probe itself.
 
 The collector `health_check` extension intentionally binds `0.0.0.0:13133` rather
 than `localhost:13133`. Azure Container Apps probes originate from the platform
@@ -320,13 +332,18 @@ for the DCE/DCR ingestion model and the Entra-authenticated collector pattern.
 
 Bicep deploys a Prometheus rule group named
 `<environmentName>-metrics-ingestion` by default. The alert
-`BlogFlowMetricsIngestionAbsent` evaluates this PromQL expression every minute:
+`BlogFlowMetricsIngestionAbsent` evaluates this per-environment PromQL expression every minute:
 
 ```promql
-absent_over_time({__name__=~"blogflow_.*"}[30m])
+absent_over_time({__name__=~"blogflow_.*",deployment_environment="<environmentName>"}[30m])
 ```
 
-If the expression remains active for 10 minutes, Azure Monitor raises a severity
+The app container sets `OTEL_RESOURCE_ATTRIBUTES=deployment.environment=<environmentName>`,
+which is translated to the Prometheus label `deployment_environment`. This keeps
+shared Azure Monitor workspaces from masking one environment's broken pipeline
+with another environment's healthy `blogflow_*` series.
+
+If the expression remains active for `PT5M`, Azure Monitor raises a severity
 2 alert indicating no BlogFlow custom metrics have arrived for the previous 30
 minutes. This is intended to catch persistent collector authentication/export
 failures, including 401/403 responses that otherwise appear only in
@@ -334,14 +351,19 @@ failures, including 401/403 responses that otherwise appear only in
 
 Optional parameters:
 
-- `enableMetricsIngestionAbsenceAlert` — default `true`; set `false` if the app
-  intentionally scales to zero for long periods or metrics are not expected.
+- `enableMetricsIngestionAbsenceAlert` — default `true`; the deployed rule is
+  effectively enabled only when `scaleMinReplicas > 0`. Bicep always deploys the
+  rule group and passes the effective boolean to `properties.enabled`, so toggling
+  this parameter to `false` disables an existing alert during incremental deploys
+  instead of leaving a previously-created rule active.
 - `metricsIngestionAbsenceActionGroupId` — Azure Monitor action group resource
   ID for notifications. Leave empty to create the alert rule without notification
   actions, then attach actions later in Azure Monitor.
 
-If `scaleMinReplicas=0`, expect this alert to fire during sustained idle periods
-unless an external synthetic check keeps the app warm or the alert is disabled.
+If `scaleMinReplicas=0`, the rule group is created but disabled by default to
+avoid idle scale-to-zero false positives. To alert for a scale-to-zero app, keep
+`enableMetricsIngestionAbsenceAlert=true`, set `scaleMinReplicas > 0`, or add an
+external synthetic check that keeps metrics flowing before enabling the rule.
 
 ## Rollback: Disable DCE Metrics Export
 
@@ -425,7 +447,9 @@ Container Apps runtime ──console logs──▶ Log Analytics workspace (defa
 - Metrics do NOT go to App Insights or Log Analytics (fixes the cost issue)
 - Traces go to App Insights → Log Analytics `AppTraces` table (acceptable cost)
 - Metrics go to Azure Monitor workspace through DCE/DCR OTLP ingestion
-- The app sets `OTEL_SERVICE_NAME=blogflow` so ingested series are attributable
+- The app sets `OTEL_SERVICE_NAME=blogflow` and
+  `OTEL_RESOURCE_ATTRIBUTES=deployment.environment=<environmentName>` so ingested
+  series are attributable and environment-scoped
 - The collector exposes `health_check` on port 13133 for Startup, Readiness,
   and Liveness probing and starts telemetry pipelines with `memory_limiter` to
   reduce OOM risk
@@ -435,5 +459,6 @@ Container Apps runtime ──console logs──▶ Log Analytics workspace (defa
   scope only; no static OTLP API keys are stored
 - The DCE defaults to public network access for compatibility; use
   `dcePublicNetworkAccess=Disabled` only with a working private ingestion path
-- A Prometheus rule group alerts when `blogflow_*` metrics disappear from the
-  Azure Monitor workspace
+- A Prometheus rule group alerts when environment-scoped `blogflow_*` metrics
+  disappear from the Azure Monitor workspace; it is disabled automatically when
+  `scaleMinReplicas=0` to avoid idle false positives

--- a/deploy/azure/SETUP.md
+++ b/deploy/azure/SETUP.md
@@ -137,6 +137,7 @@ The deployment creates:
   Collector authentication
 - **DCR-scoped role assignment** — grants that identity
   **Monitoring Metrics Publisher** on the Data Collection Rule
+- **Prometheus rule group** — alerts when no `blogflow_*` metrics are ingested
 - **Container App** — BlogFlow plus an OTel Collector sidecar
 
 The workflow also runs automatically when the **Publish** workflow completes
@@ -236,6 +237,36 @@ image. The assumption is that the collector config remains small enough for ACA
 environment-variable limits; if the config grows substantially, switch to a small
 custom image with the YAML baked in.
 
+### Collector image pinning
+
+The collector image is assembled from two Bicep parameters instead of one free-form
+image string:
+
+- `otelCollectorImageRepository` — repository plus tag, default
+  `otel/opentelemetry-collector-contrib:0.148.0`
+- `otelCollectorImageDigest` — 64-character SHA-256 digest without the
+  `sha256:` prefix
+
+The deployed image is always rendered as
+`<repository>@sha256:<digest>`, so a tag-only collector override cannot be
+deployed accidentally. Update both parameters together when intentionally moving
+to a newer collector release.
+
+### Collector health probes and bind address
+
+The `otel-collector` sidecar has Startup, Readiness, and Liveness probes against
+the collector `health_check` extension on port 13133. Startup gives the collector
+up to two minutes to initialize, Readiness gates the Container App revision until
+the sidecar health endpoint is responding, and Liveness restarts a wedged
+collector. This reduces the cold-start window where BlogFlow could emit metrics
+before the collector pipeline is available.
+
+The collector `health_check` extension intentionally binds `0.0.0.0:13133` rather
+than `localhost:13133`. Azure Container Apps probes originate from the platform
+against the container, not from inside the collector process; loopback-only
+listeners are not reliably reachable by ACA HTTP probes. The port is still only
+used as an in-replica health endpoint and is not exposed through public ingress.
+
 ### DCR stream name
 
 The DCR uses the native OTLP custom metrics stream `Custom-Metrics-Otel` for the
@@ -249,6 +280,19 @@ https://<metrics-dce-domain>/datacollectionRules/<dcr-immutable-id>/streams/Cust
 
 The stream name must exactly match the DCR `dataFlows` stream. A mismatch can
 result in silently dropped metrics.
+
+### DCE network exposure
+
+The DCE defaults to `dcePublicNetworkAccess=Enabled` for compatibility with the
+standard Container Apps egress path to Azure Monitor ingestion. In this mode,
+ingestion is still gated by Microsoft Entra authorization: the collector's
+user-assigned managed identity must have **Monitoring Metrics Publisher** on the
+DCR scope, and no static OTLP API keys are configured.
+
+For stricter threat models, set `dcePublicNetworkAccess=Disabled` and provide a
+private endpoint / private DNS path that allows the Container App environment to
+reach the DCE metrics ingestion endpoint. Do not disable public network access
+until that private ingestion path is in place, or collector exports will fail.
 
 ### Temporality
 
@@ -271,6 +315,33 @@ RBAC propagates.
 
 See [Azure Monitor OTLP ingestion docs](https://learn.microsoft.com/en-us/azure/azure-monitor/containers/opentelemetry-protocol-ingestion)
 for the DCE/DCR ingestion model and the Entra-authenticated collector pattern.
+
+### Metrics ingestion absence alert
+
+Bicep deploys a Prometheus rule group named
+`<environmentName>-metrics-ingestion` by default. The alert
+`BlogFlowMetricsIngestionAbsent` evaluates this PromQL expression every minute:
+
+```promql
+absent_over_time({__name__=~"blogflow_.*"}[30m])
+```
+
+If the expression remains active for 10 minutes, Azure Monitor raises a severity
+2 alert indicating no BlogFlow custom metrics have arrived for the previous 30
+minutes. This is intended to catch persistent collector authentication/export
+failures, including 401/403 responses that otherwise appear only in
+`otel-collector` logs.
+
+Optional parameters:
+
+- `enableMetricsIngestionAbsenceAlert` — default `true`; set `false` if the app
+  intentionally scales to zero for long periods or metrics are not expected.
+- `metricsIngestionAbsenceActionGroupId` — Azure Monitor action group resource
+  ID for notifications. Leave empty to create the alert rule without notification
+  actions, then attach actions later in Azure Monitor.
+
+If `scaleMinReplicas=0`, expect this alert to fire during sustained idle periods
+unless an external synthetic check keeps the app warm or the alert is disabled.
 
 ## Rollback: Disable DCE Metrics Export
 
@@ -355,9 +426,14 @@ Container Apps runtime ──console logs──▶ Log Analytics workspace (defa
 - Traces go to App Insights → Log Analytics `AppTraces` table (acceptable cost)
 - Metrics go to Azure Monitor workspace through DCE/DCR OTLP ingestion
 - The app sets `OTEL_SERVICE_NAME=blogflow` so ingested series are attributable
-- The collector exposes `health_check` on port 13133 for liveness probing and
-  starts telemetry pipelines with `memory_limiter` to reduce OOM risk
+- The collector exposes `health_check` on port 13133 for Startup, Readiness,
+  and Liveness probing and starts telemetry pipelines with `memory_limiter` to
+  reduce OOM risk
 - The collector uses the Container App's user-assigned managed identity and the
   Azure auth extension to acquire Entra tokens for Azure Monitor
 - The DCR authorizes that identity with Monitoring Metrics Publisher at DCR
   scope only; no static OTLP API keys are stored
+- The DCE defaults to public network access for compatibility; use
+  `dcePublicNetworkAccess=Disabled` only with a working private ingestion path
+- A Prometheus rule group alerts when `blogflow_*` metrics disappear from the
+  Azure Monitor workspace

--- a/deploy/azure/SETUP.md
+++ b/deploy/azure/SETUP.md
@@ -338,10 +338,22 @@ Bicep deploys a Prometheus rule group named
 absent_over_time({__name__=~"blogflow_.*",deployment_environment="<environmentName>"}[30m])
 ```
 
-The app container sets `OTEL_RESOURCE_ATTRIBUTES=deployment.environment=<environmentName>`,
-which is translated to the Prometheus label `deployment_environment`. This keeps
-shared Azure Monitor workspaces from masking one environment's broken pipeline
-with another environment's healthy `blogflow_*` series.
+The app container sets `OTEL_RESOURCE_ATTRIBUTES=deployment.environment=<environmentName>`.
+OTLP resource attributes are not automatically labels on every metric series, so
+the collector metrics pipeline includes a targeted `transform/promote_env`
+processor that copies that single resource attribute onto each datapoint as
+`deployment_environment`. This keeps shared Azure Monitor workspaces from masking
+one environment's broken pipeline with another environment's healthy
+`blogflow_*` series.
+
+Verify the promoted label after deploy with:
+
+```promql
+count by (deployment_environment) (blogflow_http_requests_total)
+```
+
+The result should include the current `<environmentName>` value before enabling
+or depending on the absence alert.
 
 If the expression remains active for `PT5M`, Azure Monitor raises a severity
 2 alert indicating no BlogFlow custom metrics have arrived for the previous 30
@@ -448,8 +460,9 @@ Container Apps runtime ──console logs──▶ Log Analytics workspace (defa
 - Traces go to App Insights → Log Analytics `AppTraces` table (acceptable cost)
 - Metrics go to Azure Monitor workspace through DCE/DCR OTLP ingestion
 - The app sets `OTEL_SERVICE_NAME=blogflow` and
-  `OTEL_RESOURCE_ATTRIBUTES=deployment.environment=<environmentName>` so ingested
-  series are attributable and environment-scoped
+  `OTEL_RESOURCE_ATTRIBUTES=deployment.environment=<environmentName>`; the
+  collector `transform/promote_env` processor promotes that resource attribute to
+  the per-series `deployment_environment` metric label
 - The collector exposes `health_check` on port 13133 for Startup, Readiness,
   and Liveness probing and starts telemetry pipelines with `memory_limiter` to
   reduce OOM risk

--- a/deploy/azure/SETUP.md
+++ b/deploy/azure/SETUP.md
@@ -352,8 +352,13 @@ Verify the promoted label after deploy with:
 count by (deployment_environment) (blogflow_http_requests_total)
 ```
 
-The result should include the current `<environmentName>` value before enabling
-or depending on the absence alert.
+Generate a request first if the app is scaled to zero or idle, for example
+`curl -fsS https://<container-app-fqdn>/healthz`, then run the query. Otherwise
+an idle deployment with no recent `blogflow_http_requests_total` samples can
+return empty even when the label promotion is configured correctly. For older
+samples, use a wider range query in Azure Monitor. The result should include the
+current `<environmentName>` value before enabling or depending on the absence
+alert.
 
 If the expression remains active for `PT5M`, Azure Monitor raises a severity
 2 alert indicating no BlogFlow custom metrics have arrived for the previous 30

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -41,8 +41,26 @@ param containerImage string = 'ghcr.io/khaines/blogflow:main'
 @description('GitHub username for GHCR image pulls')
 param ghcrUsername string = 'khaines'
 
-@description('Pinned OpenTelemetry Collector Contrib image reference')
-param otelCollectorImage string = 'otel/opentelemetry-collector-contrib:0.148.0@sha256:8164eab2e6bca9c9b0837a8d2f118a6618489008a839db7f9d6510e66be3923c'
+@description('OpenTelemetry Collector Contrib image repository and tag. The digest is supplied separately so tag-only overrides are impossible.')
+param otelCollectorImageRepository string = 'otel/opentelemetry-collector-contrib:0.148.0'
+
+@description('OpenTelemetry Collector Contrib image SHA-256 digest, without the sha256: prefix.')
+@minLength(64)
+@maxLength(64)
+param otelCollectorImageDigest string = '8164eab2e6bca9c9b0837a8d2f118a6618489008a839db7f9d6510e66be3923c'
+
+@description('Data Collection Endpoint public network access. Keep Enabled for public Azure Monitor ingestion; set Disabled only with a private endpoint path for ingestion.')
+@allowed([
+  'Enabled'
+  'Disabled'
+])
+param dcePublicNetworkAccess string = 'Enabled'
+
+@description('Enable a Prometheus alert when no blogflow_* metrics are ingested into the Azure Monitor workspace.')
+param enableMetricsIngestionAbsenceAlert bool = true
+
+@description('Optional Azure Monitor action group resource ID for the metrics ingestion absence alert. Empty creates the alert rule without notification actions.')
+param metricsIngestionAbsenceActionGroupId string = ''
 
 @description('Minimum replica count (0 = scale to zero)')
 @minValue(0)
@@ -97,6 +115,20 @@ module dataCollection 'modules/data-collection.bicep' = {
     location: location
     environmentName: environmentName
     monitorWorkspaceId: monitorWorkspace.outputs.workspaceId
+    publicNetworkAccess: dcePublicNetworkAccess
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module: Metrics ingestion absence alert
+// ---------------------------------------------------------------------------
+module metricsIngestionAlerts 'modules/metric-alerts.bicep' = if (enableMetricsIngestionAbsenceAlert) {
+  name: 'metrics-ingestion-alerts'
+  params: {
+    location: location
+    environmentName: environmentName
+    monitorWorkspaceId: monitorWorkspace.outputs.workspaceId
+    actionGroupId: metricsIngestionAbsenceActionGroupId
   }
 }
 
@@ -124,7 +156,8 @@ module containerApp 'modules/container-app.bicep' = {
     containerImage: containerImage
     ghcrUsername: ghcrUsername
     ghcrPassword: ghcrPassword
-    otelCollectorImage: otelCollectorImage
+    otelCollectorImageRepository: otelCollectorImageRepository
+    otelCollectorImageDigest: otelCollectorImageDigest
     appInsightsConnectionString: appInsightsConnectionString
     dataCollectionRuleName: dataCollection.outputs.dataCollectionRuleName
     dataCollectionRuleImmutableId: dataCollection.outputs.dataCollectionRuleImmutableId

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -41,10 +41,10 @@ param containerImage string = 'ghcr.io/khaines/blogflow:main'
 @description('GitHub username for GHCR image pulls')
 param ghcrUsername string = 'khaines'
 
-@description('OpenTelemetry Collector Contrib image repository and tag. The digest is supplied separately so tag-only overrides are impossible.')
+@description('OpenTelemetry Collector Contrib image repository and tag, without @ or digest. The template rejects embedded digests so tag-only overrides remain impossible.')
 param otelCollectorImageRepository string = 'otel/opentelemetry-collector-contrib:0.148.0'
 
-@description('OpenTelemetry Collector Contrib image SHA-256 digest, without the sha256: prefix.')
+@description('OpenTelemetry Collector Contrib image lowercase-hex SHA-256 digest, without the sha256: prefix. The template enforces ^[0-9a-f]{64}$ before rendering @sha256:<digest>.')
 @minLength(64)
 @maxLength(64)
 param otelCollectorImageDigest string = '8164eab2e6bca9c9b0837a8d2f118a6618489008a839db7f9d6510e66be3923c'
@@ -56,7 +56,7 @@ param otelCollectorImageDigest string = '8164eab2e6bca9c9b0837a8d2f118a661848900
 ])
 param dcePublicNetworkAccess string = 'Enabled'
 
-@description('Enable a Prometheus alert when no blogflow_* metrics are ingested into the Azure Monitor workspace.')
+@description('Enable a Prometheus alert when no blogflow_* metrics are ingested into the Azure Monitor workspace. Effective only when scaleMinReplicas > 0 to avoid scale-to-zero false positives.')
 param enableMetricsIngestionAbsenceAlert bool = true
 
 @description('Optional Azure Monitor action group resource ID for the metrics ingestion absence alert. Empty creates the alert rule without notification actions.')
@@ -95,6 +95,13 @@ param appInsightsConnectionString string
 @maxValue(730)
 param logRetentionDays int = 30
 
+var otelCollectorDigestWithoutDigits = replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(otelCollectorImageDigest, '0', ''), '1', ''), '2', ''), '3', ''), '4', ''), '5', ''), '6', ''), '7', ''), '8', ''), '9', '')
+var otelCollectorDigestWithoutHex = replace(replace(replace(replace(replace(replace(otelCollectorDigestWithoutDigits, 'a', ''), 'b', ''), 'c', ''), 'd', ''), 'e', ''), 'f', '')
+var validatedOtelCollectorImageRepository = contains(otelCollectorImageRepository, '@') ? fail('otelCollectorImageRepository must not contain @ or an embedded digest. Set otelCollectorImageDigest separately.') : otelCollectorImageRepository
+var validatedOtelCollectorImageDigest = length(otelCollectorDigestWithoutHex) == 0 ? otelCollectorImageDigest : fail('otelCollectorImageDigest must be a 64-character lowercase hexadecimal SHA-256 digest without the sha256: prefix.')
+
+var metricsIngestionAbsenceAlertEnabled = enableMetricsIngestionAbsenceAlert && scaleMinReplicas > 0
+
 // ---------------------------------------------------------------------------
 // Module: Azure Monitor Workspace (Prometheus metrics destination)
 // ---------------------------------------------------------------------------
@@ -122,12 +129,13 @@ module dataCollection 'modules/data-collection.bicep' = {
 // ---------------------------------------------------------------------------
 // Module: Metrics ingestion absence alert
 // ---------------------------------------------------------------------------
-module metricsIngestionAlerts 'modules/metric-alerts.bicep' = if (enableMetricsIngestionAbsenceAlert) {
+module metricsIngestionAlerts 'modules/metric-alerts.bicep' = {
   name: 'metrics-ingestion-alerts'
   params: {
     location: location
     environmentName: environmentName
     monitorWorkspaceId: monitorWorkspace.outputs.workspaceId
+    enabled: metricsIngestionAbsenceAlertEnabled
     actionGroupId: metricsIngestionAbsenceActionGroupId
   }
 }
@@ -156,8 +164,9 @@ module containerApp 'modules/container-app.bicep' = {
     containerImage: containerImage
     ghcrUsername: ghcrUsername
     ghcrPassword: ghcrPassword
-    otelCollectorImageRepository: otelCollectorImageRepository
-    otelCollectorImageDigest: otelCollectorImageDigest
+    deploymentEnvironmentName: environmentName
+    otelCollectorImageRepository: validatedOtelCollectorImageRepository
+    otelCollectorImageDigest: validatedOtelCollectorImageDigest
     appInsightsConnectionString: appInsightsConnectionString
     dataCollectionRuleName: dataCollection.outputs.dataCollectionRuleName
     dataCollectionRuleImmutableId: dataCollection.outputs.dataCollectionRuleImmutableId

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -33,6 +33,7 @@ targetScope = 'resourceGroup'
 param location string = 'eastus2'
 
 @description('Base name prefix for all resources')
+@minLength(1)
 param environmentName string
 
 @description('Full container image reference')

--- a/deploy/azure/modules/container-app.bicep
+++ b/deploy/azure/modules/container-app.bicep
@@ -47,10 +47,13 @@ param metricsIngestionEndpoint string
 @description('DCR stream name for Azure Monitor OTLP metrics ingestion')
 param otelMetricsStreamName string
 
-@description('OpenTelemetry Collector Contrib image repository and tag. The digest is supplied separately so tag-only overrides are impossible.')
+@description('Deployment environment label value applied to OTEL_RESOURCE_ATTRIBUTES and alert scoping')
+param deploymentEnvironmentName string
+
+@description('OpenTelemetry Collector Contrib image repository and tag, without @ or digest. The template rejects embedded digests so tag-only overrides remain impossible.')
 param otelCollectorImageRepository string = 'otel/opentelemetry-collector-contrib:0.148.0'
 
-@description('OpenTelemetry Collector Contrib image SHA-256 digest, without the sha256: prefix.')
+@description('OpenTelemetry Collector Contrib image lowercase-hex SHA-256 digest, without the sha256: prefix. The template enforces ^[0-9a-f]{64}$ before rendering @sha256:<digest>.')
 @minLength(64)
 @maxLength(64)
 param otelCollectorImageDigest string = '8164eab2e6bca9c9b0837a8d2f118a6618489008a839db7f9d6510e66be3923c'
@@ -67,8 +70,13 @@ param customDomainName string = ''
 @description('Managed certificate ID for custom domain TLS. Required when customDomainName is set.')
 param customDomainCertificateId string = ''
 
+var otelCollectorDigestWithoutDigits = replace(replace(replace(replace(replace(replace(replace(replace(replace(replace(otelCollectorImageDigest, '0', ''), '1', ''), '2', ''), '3', ''), '4', ''), '5', ''), '6', ''), '7', ''), '8', ''), '9', '')
+var otelCollectorDigestWithoutHex = replace(replace(replace(replace(replace(replace(otelCollectorDigestWithoutDigits, 'a', ''), 'b', ''), 'c', ''), 'd', ''), 'e', ''), 'f', '')
+var validatedOtelCollectorImageRepository = contains(otelCollectorImageRepository, '@') ? fail('otelCollectorImageRepository must not contain @ or an embedded digest. Set otelCollectorImageDigest separately.') : otelCollectorImageRepository
+var validatedOtelCollectorImageDigest = length(otelCollectorDigestWithoutHex) == 0 ? otelCollectorImageDigest : fail('otelCollectorImageDigest must be a 64-character lowercase hexadecimal SHA-256 digest without the sha256: prefix.')
+
 var monitoringMetricsPublisherRoleDefinitionId = '3913510d-42f4-4e42-8a64-420c390055eb'
-var otelCollectorImage = '${otelCollectorImageRepository}@sha256:${otelCollectorImageDigest}'
+var otelCollectorImage = '${validatedOtelCollectorImageRepository}@sha256:${validatedOtelCollectorImageDigest}'
 var otlpMetricsEndpoint = '${metricsIngestionEndpoint}/datacollectionRules/${dataCollectionRuleImmutableId}/streams/${otelMetricsStreamName}/otlp/v1/metrics'
 var otelCollectorConfig = join([
   'receivers:'
@@ -231,6 +239,10 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
               value: 'blogflow'
             }
             {
+              name: 'OTEL_RESOURCE_ATTRIBUTES'
+              value: 'deployment.environment=${deploymentEnvironmentName}'
+            }
+            {
               name: 'OTEL_TRACES_EXPORTER'
               value: 'otlp'
             }
@@ -351,7 +363,6 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
                 path: '/'
                 port: 13133
               }
-              initialDelaySeconds: 5
               periodSeconds: 5
               failureThreshold: 12
             }

--- a/deploy/azure/modules/container-app.bicep
+++ b/deploy/azure/modules/container-app.bicep
@@ -47,8 +47,13 @@ param metricsIngestionEndpoint string
 @description('DCR stream name for Azure Monitor OTLP metrics ingestion')
 param otelMetricsStreamName string
 
-@description('Pinned OpenTelemetry Collector Contrib image reference')
-param otelCollectorImage string = 'otel/opentelemetry-collector-contrib:0.148.0@sha256:8164eab2e6bca9c9b0837a8d2f118a6618489008a839db7f9d6510e66be3923c'
+@description('OpenTelemetry Collector Contrib image repository and tag. The digest is supplied separately so tag-only overrides are impossible.')
+param otelCollectorImageRepository string = 'otel/opentelemetry-collector-contrib:0.148.0'
+
+@description('OpenTelemetry Collector Contrib image SHA-256 digest, without the sha256: prefix.')
+@minLength(64)
+@maxLength(64)
+param otelCollectorImageDigest string = '8164eab2e6bca9c9b0837a8d2f118a6618489008a839db7f9d6510e66be3923c'
 
 @description('Minimum replica count')
 param scaleMinReplicas int = 0
@@ -63,6 +68,7 @@ param customDomainName string = ''
 param customDomainCertificateId string = ''
 
 var monitoringMetricsPublisherRoleDefinitionId = '3913510d-42f4-4e42-8a64-420c390055eb'
+var otelCollectorImage = '${otelCollectorImageRepository}@sha256:${otelCollectorImageDigest}'
 var otlpMetricsEndpoint = '${metricsIngestionEndpoint}/datacollectionRules/${dataCollectionRuleImmutableId}/streams/${otelMetricsStreamName}/otlp/v1/metrics'
 var otelCollectorConfig = join([
   'receivers:'
@@ -84,6 +90,8 @@ var otelCollectorConfig = join([
   ''
   'extensions:'
   '  health_check:'
+  '    # ACA probes originate from the platform, not inside the container process.'
+  '    # Keep this on 0.0.0.0; loopback-only binds are not reachable by ACA probes.'
   '    endpoint: 0.0.0.0:13133'
   '  azure_auth:'
   '    managed_identity:'
@@ -328,6 +336,25 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
             }
           ]
           probes: [
+            {
+              type: 'Startup'
+              httpGet: {
+                path: '/'
+                port: 13133
+              }
+              periodSeconds: 2
+              failureThreshold: 60
+            }
+            {
+              type: 'Readiness'
+              httpGet: {
+                path: '/'
+                port: 13133
+              }
+              initialDelaySeconds: 5
+              periodSeconds: 5
+              failureThreshold: 12
+            }
             {
               type: 'Liveness'
               httpGet: {

--- a/deploy/azure/modules/container-app.bicep
+++ b/deploy/azure/modules/container-app.bicep
@@ -48,6 +48,7 @@ param metricsIngestionEndpoint string
 param otelMetricsStreamName string
 
 @description('Deployment environment label value applied to OTEL_RESOURCE_ATTRIBUTES and alert scoping')
+@minLength(1)
 param deploymentEnvironmentName string
 
 @description('OpenTelemetry Collector Contrib image repository and tag, without @ or digest. The template rejects embedded digests so tag-only overrides remain impossible.')

--- a/deploy/azure/modules/container-app.bicep
+++ b/deploy/azure/modules/container-app.bicep
@@ -92,6 +92,12 @@ var otelCollectorConfig = join([
   '    check_interval: 1s'
   '    limit_mib: 384'
   '    spike_limit_mib: 96'
+  '  transform/promote_env:'
+  '    error_mode: ignore'
+  '    metric_statements:'
+  '      - context: datapoint'
+  '        statements:'
+  '          - set(attributes["deployment_environment"], resource.attributes["deployment.environment"])'
   '  batch:'
   '    timeout: 10s'
   '    send_batch_size: 256'
@@ -128,7 +134,7 @@ var otelCollectorConfig = join([
   '      exporters: [azuremonitor/traces]'
   '    metrics:'
   '      receivers: [otlp]'
-  '      processors: [memory_limiter, batch]'
+  '      processors: [memory_limiter, transform/promote_env, batch]'
   '      exporters: [otlphttp/azuremonitor_metrics]'
 ], '\n')
 

--- a/deploy/azure/modules/data-collection.bicep
+++ b/deploy/azure/modules/data-collection.bicep
@@ -17,6 +17,13 @@ param environmentName string
 @description('Azure Monitor workspace resource ID for Prometheus metrics')
 param monitorWorkspaceId string
 
+@description('Data Collection Endpoint public network access. Set Disabled only when a private endpoint path exists for OTLP ingestion.')
+@allowed([
+  'Enabled'
+  'Disabled'
+])
+param publicNetworkAccess string = 'Enabled'
+
 var otelMetricsStreamName = 'Custom-Metrics-Otel'
 var monitorWorkspaceDestinationName = 'azureMonitorWorkspace'
 
@@ -29,7 +36,7 @@ resource dataCollectionEndpoint 'Microsoft.Insights/dataCollectionEndpoints@2024
   properties: {
     description: 'OTLP metrics ingestion endpoint for BlogFlow'
     networkAcls: {
-      publicNetworkAccess: 'Enabled'
+      publicNetworkAccess: publicNetworkAccess
     }
   }
 }

--- a/deploy/azure/modules/metric-alerts.bicep
+++ b/deploy/azure/modules/metric-alerts.bicep
@@ -1,0 +1,61 @@
+// ============================================================================
+// Metrics Alerts — Azure Monitor workspace / Prometheus rule groups
+// ============================================================================
+// Detects persistent absence of BlogFlow custom metric series. Collector export
+// auth failures (401/403) are visible in sidecar logs, but this alert surfaces a
+// broken app → collector → DCE/DCR → workspace path proactively.
+// ============================================================================
+
+@description('Azure region')
+param location string
+
+@description('Base name prefix for resources')
+param environmentName string
+
+@description('Azure Monitor workspace resource ID for Prometheus metrics')
+param monitorWorkspaceId string
+
+@description('Optional Azure Monitor action group resource ID. Empty creates an alert rule without notification actions.')
+param actionGroupId string = ''
+
+var noBlogflowMetricsExpression = 'absent_over_time({__name__=~"blogflow_.*"}[30m])'
+
+resource metricsIngestionAbsenceRuleGroup 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: '${environmentName}-metrics-ingestion'
+  location: location
+  properties: {
+    clusterName: ''
+    description: 'Detects when no blogflow_* metrics are ingested into the Azure Monitor workspace.'
+    enabled: true
+    interval: 'PT1M'
+    scopes: [
+      monitorWorkspaceId
+    ]
+    rules: [
+      {
+        alert: 'BlogFlowMetricsIngestionAbsent'
+        enabled: true
+        expression: noBlogflowMetricsExpression
+        for: '10m'
+        severity: 2
+        labels: {
+          service: 'blogflow'
+          signal: 'metrics'
+        }
+        annotations: {
+          summary: 'No blogflow_* metrics have been ingested for at least 30 minutes.'
+          description: 'The BlogFlow OTel metrics pipeline may be broken. Check Container App traffic, scale-to-zero settings, otel-collector logs, managed identity auth, and DCE/DCR configuration.'
+        }
+        actions: actionGroupId != '' ? [
+          {
+            actionGroupId: actionGroupId
+          }
+        ] : []
+        resolveConfiguration: {
+          autoResolved: true
+          timeToResolve: 'PT10M'
+        }
+      }
+    ]
+  }
+}

--- a/deploy/azure/modules/metric-alerts.bicep
+++ b/deploy/azure/modules/metric-alerts.bicep
@@ -15,18 +15,21 @@ param environmentName string
 @description('Azure Monitor workspace resource ID for Prometheus metrics')
 param monitorWorkspaceId string
 
+@description('Whether the Prometheus rule group and rule are enabled. Keep the resource deployed even when false so incremental deployments can disable prior alerts.')
+param enabled bool = true
+
 @description('Optional Azure Monitor action group resource ID. Empty creates an alert rule without notification actions.')
 param actionGroupId string = ''
 
-var noBlogflowMetricsExpression = 'absent_over_time({__name__=~"blogflow_.*"}[30m])'
+var noBlogflowMetricsExpression = 'absent_over_time({__name__=~"blogflow_.*",deployment_environment="${environmentName}"}[30m])'
 
 resource metricsIngestionAbsenceRuleGroup 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
   name: '${environmentName}-metrics-ingestion'
   location: location
   properties: {
     clusterName: ''
-    description: 'Detects when no blogflow_* metrics are ingested into the Azure Monitor workspace.'
-    enabled: true
+    description: 'Detects when no blogflow_* metrics are ingested into the Azure Monitor workspace for this environment.'
+    enabled: enabled
     interval: 'PT1M'
     scopes: [
       monitorWorkspaceId
@@ -34,17 +37,17 @@ resource metricsIngestionAbsenceRuleGroup 'Microsoft.AlertsManagement/prometheus
     rules: [
       {
         alert: 'BlogFlowMetricsIngestionAbsent'
-        enabled: true
+        enabled: enabled
         expression: noBlogflowMetricsExpression
-        for: '10m'
+        for: 'PT5M'
         severity: 2
         labels: {
           service: 'blogflow'
           signal: 'metrics'
         }
         annotations: {
-          summary: 'No blogflow_* metrics have been ingested for at least 30 minutes.'
-          description: 'The BlogFlow OTel metrics pipeline may be broken. Check Container App traffic, scale-to-zero settings, otel-collector logs, managed identity auth, and DCE/DCR configuration.'
+          summary: 'No blogflow_* metrics have been ingested for this environment for at least 30 minutes.'
+          description: 'The BlogFlow OTel metrics pipeline may be broken for ${environmentName}. Check Container App traffic, scale-to-zero settings, otel-collector logs, managed identity auth, and DCE/DCR configuration.'
         }
         actions: actionGroupId != '' ? [
           {

--- a/deploy/azure/otel/collector-config.yaml
+++ b/deploy/azure/otel/collector-config.yaml
@@ -33,6 +33,8 @@ processors:
 
 extensions:
   health_check:
+    # ACA probes originate from the platform, not inside the container process.
+    # Keep this on 0.0.0.0; loopback-only binds are not reachable by ACA probes.
     endpoint: 0.0.0.0:13133
   azure_auth:
     managed_identity:

--- a/deploy/azure/otel/collector-config.yaml
+++ b/deploy/azure/otel/collector-config.yaml
@@ -27,6 +27,12 @@ processors:
     check_interval: 1s
     limit_mib: 384
     spike_limit_mib: 96
+  transform/promote_env:
+    error_mode: ignore
+    metric_statements:
+      - context: datapoint
+        statements:
+          - set(attributes["deployment_environment"], resource.attributes["deployment.environment"])
   batch:
     timeout: 10s
     send_batch_size: 256
@@ -63,5 +69,5 @@ service:
       exporters: [azuremonitor/traces]
     metrics:
       receivers: [otlp]
-      processors: [memory_limiter, batch]
+      processors: [memory_limiter, transform/promote_env, batch]
       exporters: [otlphttp/azuremonitor_metrics]

--- a/deploy/azure/parameters/prod.bicepparam
+++ b/deploy/azure/parameters/prod.bicepparam
@@ -12,6 +12,13 @@
 //     GHCR_PASSWORD            — GitHub PAT with read:packages scope
 //     APPINSIGHTS_CONNECTION_STRING — Application Insights connection string
 //
+//   Optional non-secret overrides:
+//     otelCollectorImageRepository — repository plus tag; digest stays separate
+//     otelCollectorImageDigest     — 64-character SHA-256 digest, no sha256: prefix
+//     dcePublicNetworkAccess       — Enabled (default) or Disabled with private endpoint
+//     enableMetricsIngestionAbsenceAlert — true (default); false for scale-to-zero
+//     metricsIngestionAbsenceActionGroupId — optional Azure Monitor action group ID
+//
 // ============================================================================
 
 using '../main.bicep'

--- a/deploy/azure/parameters/prod.bicepparam
+++ b/deploy/azure/parameters/prod.bicepparam
@@ -13,8 +13,8 @@
 //     APPINSIGHTS_CONNECTION_STRING — Application Insights connection string
 //
 //   Optional non-secret overrides:
-//     otelCollectorImageRepository — repository plus tag; digest stays separate
-//     otelCollectorImageDigest     — 64-character SHA-256 digest, no sha256: prefix
+//     otelCollectorImageRepository — repository plus tag, no @/digest
+//     otelCollectorImageDigest     — 64-character lowercase hex digest, no sha256: prefix
 //     dcePublicNetworkAccess       — Enabled (default) or Disabled with private endpoint
 //     enableMetricsIngestionAbsenceAlert — true (default); false for scale-to-zero
 //     metricsIngestionAbsenceActionGroupId — optional Azure Monitor action group ID

--- a/deploy/azure/validate-collector-image-pin.py
+++ b/deploy/azure/validate-collector-image-pin.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Validate Azure OTel Collector image pinning parameters.
+
+Bicep 0.41 does not provide stable regex parameter validation. This lightweight
+check enforces the equivalent constraints for the checked-in defaults and can
+also validate override values by setting OTEL_COLLECTOR_IMAGE_REPOSITORY and
+OTEL_COLLECTOR_IMAGE_DIGEST in the environment.
+"""
+
+from pathlib import Path
+import os
+import re
+import sys
+
+PARAM_RE = re.compile(r"param\s+(otelCollectorImageRepository|otelCollectorImageDigest)\s+string\s+=\s+'([^']+)'")
+DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+FILES = [
+    Path("deploy/azure/main.bicep"),
+    Path("deploy/azure/modules/container-app.bicep"),
+]
+
+
+def validate(repository: str, digest: str, source: str) -> list[str]:
+    errors: list[str] = []
+    if "@" in repository:
+        errors.append(f"{source}: otelCollectorImageRepository must not contain @ or an embedded digest")
+    if not DIGEST_RE.fullmatch(digest):
+        errors.append(f"{source}: otelCollectorImageDigest must match ^[0-9a-f]{{64}}$")
+    return errors
+
+
+def defaults(path: Path) -> tuple[str, str]:
+    params = dict(PARAM_RE.findall(path.read_text()))
+    return params["otelCollectorImageRepository"], params["otelCollectorImageDigest"]
+
+
+def main() -> int:
+    errors: list[str] = []
+    for path in FILES:
+        errors.extend(validate(*defaults(path), str(path)))
+
+    env_repository = os.getenv("OTEL_COLLECTOR_IMAGE_REPOSITORY")
+    env_digest = os.getenv("OTEL_COLLECTOR_IMAGE_DIGEST")
+    if env_repository or env_digest:
+        if not env_repository or not env_digest:
+            errors.append("environment overrides must set both OTEL_COLLECTOR_IMAGE_REPOSITORY and OTEL_COLLECTOR_IMAGE_DIGEST")
+        else:
+            errors.extend(validate(env_repository, env_digest, "environment overrides"))
+
+    if errors:
+        for error in errors:
+            print(f"::error::{error}")
+        return 1
+
+    print("Collector image pinning parameters are valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Fixes #273.

Hardens the Azure Monitor metrics sidecar deployment from the #270 follow-ups and council review:

- Adds OTel Collector Startup and Readiness probes on the existing health_check endpoint, while retaining Liveness; Readiness has no redundant initial delay because Startup gates it.
- Keeps health_check bound to 0.0.0.0:13133 because ACA platform probes are not reliably able to reach loopback-only listeners; documented that readiness does not prove azure_auth token acquisition, with retry/batch buffering as mitigation.
- Replaces the free-form collector image with repository/tag + digest parameters and enforces no embedded @ plus lowercase-hex 64-char digest in Bicep, backed by CI/deploy validation.
- Parameterizes DCE publicNetworkAccess as dcePublicNetworkAccess, defaulting to Enabled for compatibility, with SETUP guidance for Disabled + private endpoint scenarios.
- Always deploys the Prometheus rule group for idempotency, passing an effective enabled flag that requires enableMetricsIngestionAbsenceAlert && scaleMinReplicas > 0.
- Sets OTEL_RESOURCE_ATTRIBUTES=deployment.environment=<environmentName> and adds a targeted collector transform/promote_env processor that copies that resource attribute to the per-series deployment_environment metric label, matching the absence PromQL in shared workspaces.
- Adds explicit non-empty environment name validation and documents that label verification needs recent traffic when scale-to-zero is enabled.

## Validation

- python3 deploy/azure/validate-collector-image-pin.py
- az bicep build --file deploy/azure/main.bicep --stdout
- az bicep build --file deploy/azure/modules/container-app.bicep --stdout
- az bicep build --file deploy/azure/modules/data-collection.bicep --stdout
- az bicep build --file deploy/azure/modules/metric-alerts.bicep --stdout
- python3 -c 'import yaml; yaml.safe_load(open("deploy/azure/otel/collector-config.yaml"'))'
- otelcol validate skipped locally: no otelcol/otelcol-contrib binary found

## Notes

- No deployment performed.
- Transform processor syntax checked against collector-contrib v0.148.0 transform processor docs and YAML parse.
- The only Bicep validation noise was the Azure CLI Bicep version-update notice.