### PR TITLE
feat(config): add BLOGFLOW_SYNC_WEBHOOK_ALLOWED_IPS env override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Configuration
 
+* [ENHANCEMENT] config: BLOGFLOW_SYNC_WEBHOOK_ALLOWED_IPS env var now overrides sync.webhook.allowed_ips (comma-separated). #249
 * [CHANGE] Webhook: the IP allowlist is now configured via `allowed_ips` (`[]string`, CIDR-aware). The earlier `ip_allowlist: true` boolean that shipped in the embedded default config (`defaults/config/defaults.yaml`) was removed; with strict config parsing (`KnownFields(true)`), a `site.yaml` that still sets `ip_allowlist` will fail to load and must be migrated to `allowed_ips`. #237
 
 ### Testing

--- a/docs/engineering/design/configuration-system.md
+++ b/docs/engineering/design/configuration-system.md
@@ -486,28 +486,36 @@ type SecretInYAMLError struct {
 
 #### Environment Variable Mapping
 
-Environment variables use a `BLOGFLOW_` prefix with underscore-separated paths that map directly to the YAML hierarchy:
+Environment variables use a `BLOGFLOW_` prefix with underscore-separated paths for a curated subset of fields. The supported config overrides are exactly the keys registered in `internal/config/loader.go`'s `envMap`:
 
 | YAML Path | Environment Variable | Example |
 |-----------|---------------------|---------|
 | `site.title` | `BLOGFLOW_SITE_TITLE` | `BLOGFLOW_SITE_TITLE="My Blog"` |
+| `site.description` | `BLOGFLOW_SITE_DESCRIPTION` | `BLOGFLOW_SITE_DESCRIPTION="Notes on Go"` |
 | `site.base_url` | `BLOGFLOW_SITE_BASE_URL` | `BLOGFLOW_SITE_BASE_URL="https://blog.example.com"` |
+| `site.homepage` | `BLOGFLOW_SITE_HOMEPAGE` | `BLOGFLOW_SITE_HOMEPAGE="/about"` |
 | `server.port` | `BLOGFLOW_SERVER_PORT` | `BLOGFLOW_SERVER_PORT=9090` |
 | `server.read_timeout` | `BLOGFLOW_SERVER_READ_TIMEOUT` | `BLOGFLOW_SERVER_READ_TIMEOUT=10s` |
+| `server.write_timeout` | `BLOGFLOW_SERVER_WRITE_TIMEOUT` | `BLOGFLOW_SERVER_WRITE_TIMEOUT=10s` |
 | `server.idle_timeout` | `BLOGFLOW_SERVER_IDLE_TIMEOUT` | `BLOGFLOW_SERVER_IDLE_TIMEOUT=120s` |
+| `server.tls_terminated` | `BLOGFLOW_SERVER_TLS_TERMINATED` | `BLOGFLOW_SERVER_TLS_TERMINATED=true` |
+| `server.hsts_max_age` | `BLOGFLOW_SERVER_HSTS_MAX_AGE` | `BLOGFLOW_SERVER_HSTS_MAX_AGE=31536000` |
+| `server.metrics_port` | `BLOGFLOW_SERVER_METRICS_PORT` | `BLOGFLOW_SERVER_METRICS_PORT=9091` |
 | `cache.enabled` | `BLOGFLOW_CACHE_ENABLED` | `BLOGFLOW_CACHE_ENABLED=false` |
 | `sync.strategy` | `BLOGFLOW_SYNC_STRATEGY` | `BLOGFLOW_SYNC_STRATEGY=webhook` |
-| `sync.webhook.secret` | `BLOGFLOW_WEBHOOK_SECRET` | `BLOGFLOW_WEBHOOK_SECRET=whsec_abc123` |
+| `sync.repo` | `BLOGFLOW_SYNC_REPO` | `BLOGFLOW_SYNC_REPO="git@github.com:org/content.git"` |
+| `sync.branch` | `BLOGFLOW_SYNC_BRANCH` | `BLOGFLOW_SYNC_BRANCH=main` |
 | `sync.webhook.rate_limit` | `BLOGFLOW_SYNC_WEBHOOK_RATE_LIMIT` | `BLOGFLOW_SYNC_WEBHOOK_RATE_LIMIT=20` |
+| `sync.webhook.allowed_ips` | `BLOGFLOW_SYNC_WEBHOOK_ALLOWED_IPS` | `BLOGFLOW_SYNC_WEBHOOK_ALLOWED_IPS="203.0.113.10,198.51.100.0/24"` |
+| `sync.poll_interval` | `BLOGFLOW_SYNC_POLL_INTERVAL` | `BLOGFLOW_SYNC_POLL_INTERVAL=5m` |
+| `sync.sparse_dirs` | `BLOGFLOW_SYNC_SPARSE_DIRS` | `BLOGFLOW_SYNC_SPARSE_DIRS="posts,pages"` |
+| `sync.clone_depth` | `BLOGFLOW_SYNC_CLONE_DEPTH` | `BLOGFLOW_SYNC_CLONE_DEPTH=10` |
 | `feed.type` | `BLOGFLOW_FEED_TYPE` | `BLOGFLOW_FEED_TYPE=rss` |
+| `content.posts_dir` | `BLOGFLOW_CONTENT_POSTS_DIR` | `BLOGFLOW_CONTENT_POSTS_DIR=posts` |
+| `content.pages_dir` | `BLOGFLOW_CONTENT_PAGES_DIR` | `BLOGFLOW_CONTENT_PAGES_DIR=pages` |
+| N/A (`yaml:"-"`) | `BLOGFLOW_WEBHOOK_SECRET` | `BLOGFLOW_WEBHOOK_SECRET=whsec_abc123` |
 
-**Secret-only variables** (no YAML equivalent):
-
-| Environment Variable | Maps to | Notes |
-|---------------------|---------|-------|
-| `BLOGFLOW_WEBHOOK_SECRET` | `sync.webhook.secret` | HMAC-SHA256 webhook signing secret |
-| `BLOGFLOW_GIT_TOKEN` | Git auth token | Used by `internal/gitops`, not in Config struct |
-| `BLOGFLOW_GIT_SSH_KEY` | SSH key path | Used by `internal/gitops`, not in Config struct |
+Git authentication environment variables used directly by `internal/gitops` are outside the configuration override `envMap` and are not listed here.
 
 ### 2.6 Dependencies
 

--- a/docs/engineering/design/configuration-system.md
+++ b/docs/engineering/design/configuration-system.md
@@ -16,7 +16,7 @@ The Configuration System (`internal/config`) is BlogFlow's centralized settings 
 ### 1.2 Functionality It Provides
 
 - **YAML-based configuration** — loads `site.yaml` from the config layer with fallback to the embedded `defaults.yaml`
-- **Environment variable overrides** — `BLOGFLOW_` prefixed env vars override any YAML value at runtime
+- **Environment variable overrides** — `BLOGFLOW_` prefixed env vars override a defined subset of YAML values at runtime; `internal/config/loader.go`'s `envMap` is the source of truth for supported keys.
 - **Embedded zero-config defaults** — a compiled-in `defaults.yaml` ensures the binary is fully functional with no external files
 - **Startup validation** — fails fast on invalid configuration with actionable error messages
 - **Secret isolation** — enforces that sensitive values (webhook secrets, git tokens) are injected only via env vars, never in YAML files

--- a/internal/config/env_override_test.go
+++ b/internal/config/env_override_test.go
@@ -2,7 +2,10 @@
 package config
 
 import (
+	"bytes"
+	"log/slog"
 	"reflect"
+	"strings"
 	"testing"
 	"testing/fstest"
 )
@@ -51,19 +54,73 @@ sync:
     allowed_ips:
       - "192.0.2.10"
 `
-	t.Setenv("BLOGFLOW_SYNC_WEBHOOK_ALLOWED_IPS", "203.0.113.10, 2001:db8::/32 , , 198.51.100.0/24")
-	fsys := fstest.MapFS{
-		"site.yaml": &fstest.MapFile{Data: []byte(yamlContent)},
-	}
-	loader := NewLoader(fsys)
-	cfg, err := loader.Load()
-	if err != nil {
-		t.Fatalf("unexpected error for valid allowed IP env override: %v", err)
+	tests := []struct {
+		name     string
+		envValue string
+		want     []string
+		wantWarn bool
+	}{
+		{
+			name:     "empty string disables allowlist",
+			envValue: "",
+			want:     nil,
+			wantWarn: true,
+		},
+		{
+			name:     "single value",
+			envValue: "203.0.113.10",
+			want:     []string{"203.0.113.10"},
+		},
+		{
+			name:     "trailing comma",
+			envValue: "203.0.113.10,",
+			want:     []string{"203.0.113.10"},
+		},
+		{
+			name:     "leading and trailing whitespace",
+			envValue: " 203.0.113.10 ",
+			want:     []string{"203.0.113.10"},
+		},
+		{
+			name:     "interior empty entry",
+			envValue: "203.0.113.10, , 198.51.100.0/24",
+			want:     []string{"203.0.113.10", "198.51.100.0/24"},
+		},
+		{
+			name:     "duplicates preserved",
+			envValue: "203.0.113.10,203.0.113.10",
+			want:     []string{"203.0.113.10", "203.0.113.10"},
+		},
+		{
+			name:     "whitespace and commas disable allowlist",
+			envValue: " ,  , ",
+			want:     []string{},
+			wantWarn: true,
+		},
 	}
 
-	want := []string{"203.0.113.10", "2001:db8::/32", "198.51.100.0/24"}
-	if !reflect.DeepEqual(cfg.Sync.Webhook.AllowedIPs, want) {
-		t.Errorf("sync.webhook.allowed_ips = %#v, want %#v", cfg.Sync.Webhook.AllowedIPs, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("BLOGFLOW_SYNC_WEBHOOK_ALLOWED_IPS", tt.envValue)
+			var logOutput bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&logOutput, &slog.HandlerOptions{Level: slog.LevelWarn}))
+			fsys := fstest.MapFS{
+				"site.yaml": &fstest.MapFile{Data: []byte(yamlContent)},
+			}
+			loader := NewLoader(fsys, WithLogger(logger))
+			cfg, err := loader.Load()
+			if err != nil {
+				t.Fatalf("unexpected error for valid allowed IP env override: %v", err)
+			}
+
+			if !reflect.DeepEqual(cfg.Sync.Webhook.AllowedIPs, tt.want) {
+				t.Errorf("sync.webhook.allowed_ips = %#v, want %#v", cfg.Sync.Webhook.AllowedIPs, tt.want)
+			}
+			hasWarn := strings.Contains(logOutput.String(), "BLOGFLOW_SYNC_WEBHOOK_ALLOWED_IPS is set but resolved to no entries")
+			if hasWarn != tt.wantWarn {
+				t.Fatalf("warning presence = %t, want %t; logs:\n%s", hasWarn, tt.wantWarn, logOutput.String())
+			}
+		})
 	}
 }
 

--- a/internal/config/env_override_test.go
+++ b/internal/config/env_override_test.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"reflect"
 	"testing"
 	"testing/fstest"
 )
@@ -40,6 +41,29 @@ func TestEnvOverrideValidServerPort(t *testing.T) {
 	}
 	if cfg.Server.Port != 9090 {
 		t.Errorf("server.port = %d, want 9090", cfg.Server.Port)
+	}
+}
+
+func TestEnvOverrideWebhookAllowedIPsParsesAndOverridesYAML(t *testing.T) {
+	yamlContent := `
+sync:
+  webhook:
+    allowed_ips:
+      - "192.0.2.10"
+`
+	t.Setenv("BLOGFLOW_SYNC_WEBHOOK_ALLOWED_IPS", "203.0.113.10, 2001:db8::/32 , , 198.51.100.0/24")
+	fsys := fstest.MapFS{
+		"site.yaml": &fstest.MapFile{Data: []byte(yamlContent)},
+	}
+	loader := NewLoader(fsys)
+	cfg, err := loader.Load()
+	if err != nil {
+		t.Fatalf("unexpected error for valid allowed IP env override: %v", err)
+	}
+
+	want := []string{"203.0.113.10", "2001:db8::/32", "198.51.100.0/24"}
+	if !reflect.DeepEqual(cfg.Sync.Webhook.AllowedIPs, want) {
+		t.Errorf("sync.webhook.allowed_ips = %#v, want %#v", cfg.Sync.Webhook.AllowedIPs, want)
 	}
 }
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -357,6 +357,21 @@ var envMap = map[string]func(*Config, string) error{
 		c.Sync.Webhook.RateLimit = n
 		return nil
 	},
+	"BLOGFLOW_SYNC_WEBHOOK_ALLOWED_IPS": func(c *Config, v string) error {
+		if v == "" {
+			c.Sync.Webhook.AllowedIPs = nil
+			return nil
+		}
+		parts := strings.Split(v, ",")
+		ips := make([]string, 0, len(parts))
+		for _, p := range parts {
+			if ip := strings.TrimSpace(p); ip != "" {
+				ips = append(ips, ip)
+			}
+		}
+		c.Sync.Webhook.AllowedIPs = ips
+		return nil
+	},
 	"BLOGFLOW_SYNC_POLL_INTERVAL": func(c *Config, v string) error {
 		c.Sync.PollInterval = v
 		return nil

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -280,20 +280,20 @@ func isWordChar(c byte) bool {
 }
 
 // envMap maps BLOGFLOW_* env var names to setter functions.
-var envMap = map[string]func(*Config, string) error{
-	"BLOGFLOW_SITE_TITLE": func(c *Config, v string) error {
+var envMap = map[string]func(*Config, string, *slog.Logger) error{
+	"BLOGFLOW_SITE_TITLE": func(c *Config, v string, _ *slog.Logger) error {
 		c.Site.Title = v
 		return nil
 	},
-	"BLOGFLOW_SITE_DESCRIPTION": func(c *Config, v string) error {
+	"BLOGFLOW_SITE_DESCRIPTION": func(c *Config, v string, _ *slog.Logger) error {
 		c.Site.Description = v
 		return nil
 	},
-	"BLOGFLOW_SITE_BASE_URL": func(c *Config, v string) error {
+	"BLOGFLOW_SITE_BASE_URL": func(c *Config, v string, _ *slog.Logger) error {
 		c.Site.BaseURL = v
 		return nil
 	},
-	"BLOGFLOW_SERVER_PORT": func(c *Config, v string) error {
+	"BLOGFLOW_SERVER_PORT": func(c *Config, v string, _ *slog.Logger) error {
 		n, err := strconv.Atoi(v)
 		if err != nil {
 			return fmt.Errorf("cannot parse env var BLOGFLOW_SERVER_PORT as int: %w", err)
@@ -301,7 +301,7 @@ var envMap = map[string]func(*Config, string) error{
 		c.Server.Port = n
 		return nil
 	},
-	"BLOGFLOW_SERVER_READ_TIMEOUT": func(c *Config, v string) error {
+	"BLOGFLOW_SERVER_READ_TIMEOUT": func(c *Config, v string, _ *slog.Logger) error {
 		d, err := time.ParseDuration(v)
 		if err != nil {
 			return fmt.Errorf("cannot parse env var BLOGFLOW_SERVER_READ_TIMEOUT as duration: %w", err)
@@ -309,7 +309,7 @@ var envMap = map[string]func(*Config, string) error{
 		c.Server.ReadTimeout = d
 		return nil
 	},
-	"BLOGFLOW_SERVER_WRITE_TIMEOUT": func(c *Config, v string) error {
+	"BLOGFLOW_SERVER_WRITE_TIMEOUT": func(c *Config, v string, _ *slog.Logger) error {
 		d, err := time.ParseDuration(v)
 		if err != nil {
 			return fmt.Errorf("cannot parse env var BLOGFLOW_SERVER_WRITE_TIMEOUT as duration: %w", err)
@@ -317,7 +317,7 @@ var envMap = map[string]func(*Config, string) error{
 		c.Server.WriteTimeout = d
 		return nil
 	},
-	"BLOGFLOW_SERVER_IDLE_TIMEOUT": func(c *Config, v string) error {
+	"BLOGFLOW_SERVER_IDLE_TIMEOUT": func(c *Config, v string, _ *slog.Logger) error {
 		d, err := time.ParseDuration(v)
 		if err != nil {
 			return fmt.Errorf("cannot parse env var BLOGFLOW_SERVER_IDLE_TIMEOUT as duration: %w", err)
@@ -325,7 +325,7 @@ var envMap = map[string]func(*Config, string) error{
 		c.Server.IdleTimeout = d
 		return nil
 	},
-	"BLOGFLOW_CACHE_ENABLED": func(c *Config, v string) error {
+	"BLOGFLOW_CACHE_ENABLED": func(c *Config, v string, _ *slog.Logger) error {
 		b, err := strconv.ParseBool(v)
 		if err != nil {
 			return fmt.Errorf("cannot parse env var BLOGFLOW_CACHE_ENABLED as bool: %w", err)
@@ -333,23 +333,23 @@ var envMap = map[string]func(*Config, string) error{
 		c.Cache.Enabled = b
 		return nil
 	},
-	"BLOGFLOW_SYNC_STRATEGY": func(c *Config, v string) error {
+	"BLOGFLOW_SYNC_STRATEGY": func(c *Config, v string, _ *slog.Logger) error {
 		c.Sync.Strategy = v
 		return nil
 	},
-	"BLOGFLOW_SYNC_REPO": func(c *Config, v string) error {
+	"BLOGFLOW_SYNC_REPO": func(c *Config, v string, _ *slog.Logger) error {
 		c.Sync.Repo = v
 		return nil
 	},
-	"BLOGFLOW_SYNC_BRANCH": func(c *Config, v string) error {
+	"BLOGFLOW_SYNC_BRANCH": func(c *Config, v string, _ *slog.Logger) error {
 		c.Sync.Branch = v
 		return nil
 	},
-	"BLOGFLOW_WEBHOOK_SECRET": func(c *Config, v string) error {
+	"BLOGFLOW_WEBHOOK_SECRET": func(c *Config, v string, _ *slog.Logger) error {
 		c.Sync.Webhook.Secret = v
 		return nil
 	},
-	"BLOGFLOW_SYNC_WEBHOOK_RATE_LIMIT": func(c *Config, v string) error {
+	"BLOGFLOW_SYNC_WEBHOOK_RATE_LIMIT": func(c *Config, v string, _ *slog.Logger) error {
 		n, err := strconv.Atoi(v)
 		if err != nil {
 			return fmt.Errorf("cannot parse env var BLOGFLOW_SYNC_WEBHOOK_RATE_LIMIT as int: %w", err)
@@ -357,8 +357,12 @@ var envMap = map[string]func(*Config, string) error{
 		c.Sync.Webhook.RateLimit = n
 		return nil
 	},
-	"BLOGFLOW_SYNC_WEBHOOK_ALLOWED_IPS": func(c *Config, v string) error {
+	"BLOGFLOW_SYNC_WEBHOOK_ALLOWED_IPS": func(c *Config, v string, log *slog.Logger) error {
 		if v == "" {
+			if log == nil {
+				log = slog.Default()
+			}
+			log.Warn("BLOGFLOW_SYNC_WEBHOOK_ALLOWED_IPS is set but resolved to no entries — webhook IP allowlist enforcement is disabled")
 			c.Sync.Webhook.AllowedIPs = nil
 			return nil
 		}
@@ -369,14 +373,20 @@ var envMap = map[string]func(*Config, string) error{
 				ips = append(ips, ip)
 			}
 		}
+		if len(ips) == 0 {
+			if log == nil {
+				log = slog.Default()
+			}
+			log.Warn("BLOGFLOW_SYNC_WEBHOOK_ALLOWED_IPS is set but resolved to no entries — webhook IP allowlist enforcement is disabled")
+		}
 		c.Sync.Webhook.AllowedIPs = ips
 		return nil
 	},
-	"BLOGFLOW_SYNC_POLL_INTERVAL": func(c *Config, v string) error {
+	"BLOGFLOW_SYNC_POLL_INTERVAL": func(c *Config, v string, _ *slog.Logger) error {
 		c.Sync.PollInterval = v
 		return nil
 	},
-	"BLOGFLOW_SYNC_SPARSE_DIRS": func(c *Config, v string) error {
+	"BLOGFLOW_SYNC_SPARSE_DIRS": func(c *Config, v string, _ *slog.Logger) error {
 		if v == "" {
 			c.Sync.SparseDirs = nil
 			return nil
@@ -391,7 +401,7 @@ var envMap = map[string]func(*Config, string) error{
 		c.Sync.SparseDirs = dirs
 		return nil
 	},
-	"BLOGFLOW_SYNC_CLONE_DEPTH": func(c *Config, v string) error {
+	"BLOGFLOW_SYNC_CLONE_DEPTH": func(c *Config, v string, _ *slog.Logger) error {
 		n, err := strconv.Atoi(v)
 		if err != nil {
 			return fmt.Errorf("cannot parse env var BLOGFLOW_SYNC_CLONE_DEPTH as int: %w", err)
@@ -399,11 +409,11 @@ var envMap = map[string]func(*Config, string) error{
 		c.Sync.CloneDepth = n
 		return nil
 	},
-	"BLOGFLOW_FEED_TYPE": func(c *Config, v string) error {
+	"BLOGFLOW_FEED_TYPE": func(c *Config, v string, _ *slog.Logger) error {
 		c.Feed.Type = v
 		return nil
 	},
-	"BLOGFLOW_SERVER_TLS_TERMINATED": func(c *Config, v string) error {
+	"BLOGFLOW_SERVER_TLS_TERMINATED": func(c *Config, v string, _ *slog.Logger) error {
 		b, err := strconv.ParseBool(v)
 		if err != nil {
 			return fmt.Errorf("cannot parse env var BLOGFLOW_SERVER_TLS_TERMINATED as bool: %w", err)
@@ -411,7 +421,7 @@ var envMap = map[string]func(*Config, string) error{
 		c.Server.TLSTerminated = b
 		return nil
 	},
-	"BLOGFLOW_SERVER_HSTS_MAX_AGE": func(c *Config, v string) error {
+	"BLOGFLOW_SERVER_HSTS_MAX_AGE": func(c *Config, v string, _ *slog.Logger) error {
 		n, err := strconv.Atoi(v)
 		if err != nil {
 			return fmt.Errorf("cannot parse env var BLOGFLOW_SERVER_HSTS_MAX_AGE as int: %w", err)
@@ -419,7 +429,7 @@ var envMap = map[string]func(*Config, string) error{
 		c.Server.HSTSMaxAge = n
 		return nil
 	},
-	"BLOGFLOW_SERVER_METRICS_PORT": func(c *Config, v string) error {
+	"BLOGFLOW_SERVER_METRICS_PORT": func(c *Config, v string, _ *slog.Logger) error {
 		n, err := strconv.Atoi(v)
 		if err != nil {
 			return fmt.Errorf("cannot parse env var BLOGFLOW_SERVER_METRICS_PORT as int: %w", err)
@@ -427,15 +437,15 @@ var envMap = map[string]func(*Config, string) error{
 		c.Server.MetricsPort = n
 		return nil
 	},
-	"BLOGFLOW_SITE_HOMEPAGE": func(c *Config, v string) error {
+	"BLOGFLOW_SITE_HOMEPAGE": func(c *Config, v string, _ *slog.Logger) error {
 		c.Site.Homepage = v
 		return nil
 	},
-	"BLOGFLOW_CONTENT_POSTS_DIR": func(c *Config, v string) error {
+	"BLOGFLOW_CONTENT_POSTS_DIR": func(c *Config, v string, _ *slog.Logger) error {
 		c.Content.PostsDir = v
 		return nil
 	},
-	"BLOGFLOW_CONTENT_PAGES_DIR": func(c *Config, v string) error {
+	"BLOGFLOW_CONTENT_PAGES_DIR": func(c *Config, v string, _ *slog.Logger) error {
 		c.Content.PagesDir = v
 		return nil
 	},
@@ -465,7 +475,7 @@ func applyEnvOverrides(cfg *Config, log *slog.Logger) ([]string, error) {
 		if !ok {
 			continue
 		}
-		if err := setter(cfg, v); err != nil {
+		if err := setter(cfg, v, log); err != nil {
 			return nil, err
 		}
 		applied = append(applied, name)

--- a/internal/gitops/webhook_ip_allowlist_test.go
+++ b/internal/gitops/webhook_ip_allowlist_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/fstest"
 
 	"github.com/khaines/blogflow/internal/config"
 	"github.com/khaines/blogflow/internal/gitops"
@@ -102,6 +103,51 @@ func TestWebhookHandler_IPAllowlistAllowedIP(t *testing.T) {
 
 	if !called.Load() {
 		t.Fatal("reloader should be called for allowed IP")
+	}
+}
+
+func TestWebhookHandler_IPAllowlistFromConfigEnvOverrideEnforced(t *testing.T) {
+	t.Setenv("BLOGFLOW_SYNC_WEBHOOK_ALLOWED_IPS", "203.0.113.10")
+
+	cfg, err := config.NewLoader(fstest.MapFS{}).Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	secret := "test-secure-webhook-secret-long-enough32bytes!!!"
+	var called atomic.Int32
+	webhookCfg := cfg.Sync.Webhook
+	webhookCfg.Path = "/hook"
+	webhookCfg.Secret = secret
+	webhookCfg.BranchFilter = "main"
+
+	w, err := gitops.NewWebhookStrategy(webhookCfg, gitops.ContentReloader(func() error {
+		called.Add(1)
+		return nil
+	}), webhookLogger(), testResolverIPIns)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sendWithIP := func(ip string) int {
+		payload := makePayload("refs/heads/main")
+		req := httptest.NewRequest(http.MethodPost, "/hook", bytes.NewReader(payload))
+		req.Header.Set("X-Hub-Signature-256", signPayload([]byte(secret), payload))
+		req.Header.Set("X-GitHub-Event", "push")
+		req.RemoteAddr = ip + ":12345"
+		rec := httptest.NewRecorder()
+		w.Handler().ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	if code := sendWithIP("203.0.113.10"); code != http.StatusOK {
+		t.Fatalf("listed IP: got %d, want %d", code, http.StatusOK)
+	}
+	if code := sendWithIP("198.51.100.10"); code != http.StatusForbidden {
+		t.Fatalf("unlisted IP: got %d, want %d", code, http.StatusForbidden)
+	}
+	if got := called.Load(); got != 1 {
+		t.Fatalf("reloader calls = %d, want 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #249.

## Changes
- Adds BLOGFLOW_SYNC_WEBHOOK_ALLOWED_IPS to the config env override map.
- Parses comma-separated allowed IP/CIDR entries with whitespace trimming and empty-entry skipping.
- Updates the configuration design doc to describe env overrides as a curated subset with envMap as source of truth.
- Adds changelog entry for the new override.

## Validation
- go build ./...
- go vet ./...
- golangci-lint run ./internal/config/...
- go test -race -count=1 ./internal/config/...
- go test -race -count=1 ./...
