### PR TITLE
test(overlayfs): add single-layer hot-reload perf benchmarks

### DIFF
--- a/internal/content/scanner_bench_test.go
+++ b/internal/content/scanner_bench_test.go
@@ -1,0 +1,59 @@
+package content
+
+import (
+	"fmt"
+	"testing"
+	"testing/fstest"
+)
+
+func benchContentFS(posts, pages int) fstest.MapFS {
+	m := make(fstest.MapFS, posts+pages+2)
+	for i := range posts {
+		m[fmt.Sprintf("posts/2026/post-%04d.md", i)] = &fstest.MapFile{Data: []byte(benchPostMarkdown(i))}
+	}
+	for i := range pages {
+		m[fmt.Sprintf("pages/page-%04d.md", i)] = &fstest.MapFile{Data: []byte(benchPageMarkdown(i))}
+	}
+	m["posts/draft.md"] = &fstest.MapFile{Data: []byte(mkPost("Draft", "draft", "2026-01-01", nil, true, "draft"))}
+	m["static/ignored.txt"] = &fstest.MapFile{Data: []byte("not markdown")}
+	return m
+}
+
+func benchPostMarkdown(i int) string {
+	return mkPost(
+		fmt.Sprintf("Benchmark Post %04d", i),
+		fmt.Sprintf("benchmark-post-%04d", i),
+		fmt.Sprintf("2026-01-%02d", (i%28)+1),
+		[]string{fmt.Sprintf("tag-%02d", i%12), "reload"},
+		false,
+		fmt.Sprintf("# Heading %04d\n\nThis post exercises **markdown rendering**, summaries, tag indexes, and date sorting during reload scans.\n\n- item one\n- item two\n", i),
+	)
+}
+
+func benchPageMarkdown(i int) string {
+	return mkPage(
+		fmt.Sprintf("Benchmark Page %04d", i),
+		fmt.Sprintf("benchmark-page-%04d", i),
+		i+1,
+		"This page exercises static page indexing during content reload scans.\n",
+	)
+}
+
+// BenchmarkContentReindex measures the content rescan/re-index entry point used
+// by cmd/blogflow's ContentReloader after sync strategies report a change.
+func BenchmarkContentReindex(b *testing.B) {
+	fsys := benchContentFS(500, 75)
+	scanner := NewScanner(NewRenderer(), "posts", "pages", 200, nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		idx, err := scanner.Scan(fsys)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(idx.Posts) != 500 || len(idx.Pages) != 75 {
+			b.Fatalf("Scan indexed %d posts/%d pages, want 500/75", len(idx.Posts), len(idx.Pages))
+		}
+	}
+}

--- a/internal/overlayfs/overlayfs_bench_test.go
+++ b/internal/overlayfs/overlayfs_bench_test.go
@@ -304,6 +304,10 @@ func benchReadReloadPaths(b *testing.B, ofs *OverlayFS, names []string) {
 	}
 }
 
+// benchWarmReloadNegCache warms the negative cache by resolving names once. It
+// marks the "warm" setup phase of a reload benchmark and must be called inside a
+// b.StopTimer()/b.StartTimer() bracket so the warm-up is excluded from the
+// measured region.
 func benchWarmReloadNegCache(b *testing.B, ofs *OverlayFS, names []string) {
 	b.Helper()
 	benchReadReloadPaths(b, ofs, names)
@@ -348,6 +352,10 @@ func BenchmarkReplaceLayer_SingleLayer(b *testing.B) {
 // start from a warm neg-cache, invalidate the changed config layer, then resolve
 // the same paths. Entries cached for higher-priority content-layer hits survive,
 // so this detects regressions that accidentally wipe the whole cache.
+//
+// For a stable comparison against BenchmarkInvalidateAll_WarmNegCache, run with a
+// longer benchtime (e.g. -benchtime=2s -count=6) so b.N>1 and the single-layer
+// vs full-invalidation signal reflects an average rather than a single sample.
 func BenchmarkInvalidateLayer_SingleLayer(b *testing.B) {
 	const (
 		filesPerLayer = 1_000

--- a/internal/overlayfs/overlayfs_bench_test.go
+++ b/internal/overlayfs/overlayfs_bench_test.go
@@ -238,9 +238,10 @@ func BenchmarkOpen_Parallel(b *testing.B) {
 }
 
 // benchSingleLayerReloadOverlay builds a BlogFlow-shaped overlay for reload
-// benchmarks. The content layer starts empty while the defaults layer contains
-// the hot path, so warming that path records a neg-cache entry for the upper
-// layers that a later content-layer replacement must invalidate.
+// benchmarks. Most warm paths resolve from the content layer and should survive
+// a lower-priority config-layer invalidation; the rest resolve from defaults and
+// must be rebuilt. That split makes targeted invalidation visibly different from
+// a full cache wipe in the subsequent resolve phase.
 func benchSingleLayerReloadOverlay(filesPerLayer, warmEntries int) (*OverlayFS, fs.FS, fs.FS, []string) {
 	layers := make([]fs.FS, 4)
 	names := []string{"theme", "content", "config", "defaults"}
@@ -256,26 +257,37 @@ func benchSingleLayerReloadOverlay(filesPerLayer, warmEntries int) (*OverlayFS, 
 
 	defaults := layers[3].(fstest.MapFS)
 	warmNames := make([]string, 0, warmEntries+1)
+	contentWarmNames := make([]string, 0, warmEntries)
 	for i := range warmEntries {
-		name := fmt.Sprintf("reload/lower-only-%05d.md", i)
-		defaults[name] = &fstest.MapFile{Data: []byte("---\ntitle: lower\n---\n")}
+		if i%8 == 0 {
+			name := fmt.Sprintf("reload/default-only-%05d.md", i)
+			defaults[name] = &fstest.MapFile{Data: []byte("---\ntitle: lower\n---\n")}
+			warmNames = append(warmNames, name)
+			continue
+		}
+
+		name := fmt.Sprintf("reload/content-layer-%05d.md", i)
+		contentWarmNames = append(contentWarmNames, name)
 		warmNames = append(warmNames, name)
 	}
 	defaults["reload/hot.md"] = &fstest.MapFile{Data: []byte("old-default")}
 	warmNames = append(warmNames, "reload/hot.md")
 
-	oldContent := benchReloadContentLayer(filesPerLayer, "")
-	newContent := benchReloadContentLayer(filesPerLayer, "new-content")
+	oldContent := benchReloadContentLayer(filesPerLayer, "", contentWarmNames)
+	newContent := benchReloadContentLayer(filesPerLayer, "new-content", contentWarmNames)
 	layers[1] = oldContent
 
 	return NewOverlayFS(layers...).WithLayerNames(names), oldContent, newContent, warmNames
 }
 
-func benchReloadContentLayer(filesPerLayer int, hotData string) fs.FS {
-	m := make(fstest.MapFS, filesPerLayer+1)
+func benchReloadContentLayer(filesPerLayer int, hotData string, warmNames []string) fs.FS {
+	m := make(fstest.MapFS, filesPerLayer+len(warmNames)+1)
 	for fi := range filesPerLayer {
 		key := fmt.Sprintf("content/file%d.txt", fi)
 		m[key] = &fstest.MapFile{Data: []byte("content")}
+	}
+	for _, name := range warmNames {
+		m[name] = &fstest.MapFile{Data: []byte("content-warm")}
 	}
 	if hotData != "" {
 		m["reload/hot.md"] = &fstest.MapFile{Data: []byte(hotData)}
@@ -283,13 +295,18 @@ func benchReloadContentLayer(filesPerLayer int, hotData string) fs.FS {
 	return m
 }
 
-func benchWarmReloadNegCache(b *testing.B, ofs *OverlayFS, names []string) {
+func benchReadReloadPaths(b *testing.B, ofs *OverlayFS, names []string) {
 	b.Helper()
 	for _, name := range names {
 		if _, err := ofs.ReadFile(name); err != nil {
-			b.Fatalf("warm ReadFile(%q): %v", name, err)
+			b.Fatalf("ReadFile(%q): %v", name, err)
 		}
 	}
+}
+
+func benchWarmReloadNegCache(b *testing.B, ofs *OverlayFS, names []string) {
+	b.Helper()
+	benchReadReloadPaths(b, ofs, names)
 }
 
 // BenchmarkReplaceLayer_SingleLayer measures the hot-reload path used when a
@@ -327,14 +344,15 @@ func BenchmarkReplaceLayer_SingleLayer(b *testing.B) {
 	}
 }
 
-// BenchmarkInvalidateLayer_SingleLayer measures targeted neg-cache invalidation
-// for one changed layer after re-warming the cache each iteration, guarding
-// against regressions that make single-layer reloads approach full-cache cost.
+// BenchmarkInvalidateLayer_SingleLayer measures a single-layer reload cycle:
+// start from a warm neg-cache, invalidate the changed config layer, then resolve
+// the same paths. Entries cached for higher-priority content-layer hits survive,
+// so this detects regressions that accidentally wipe the whole cache.
 func BenchmarkInvalidateLayer_SingleLayer(b *testing.B) {
 	const (
 		filesPerLayer = 1_000
 		warmEntries   = 8_192
-		contentLayer  = 1
+		configLayer   = 2
 	)
 
 	ofs, _, _, warmNames := benchSingleLayerReloadOverlay(filesPerLayer, warmEntries)
@@ -342,14 +360,18 @@ func BenchmarkInvalidateLayer_SingleLayer(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
+		b.StopTimer()
 		benchWarmReloadNegCache(b, ofs, warmNames)
-		ofs.InvalidateLayer(contentLayer)
+		b.StartTimer()
+
+		ofs.InvalidateLayer(configLayer)
+		benchReadReloadPaths(b, ofs, warmNames)
 	}
 }
 
 // BenchmarkInvalidateAll_WarmNegCache is the full-cache baseline for reloads
-// that cannot prove only one layer changed. It uses the same re-warmed cache
-// cycle as the targeted invalidation benchmark for regression comparisons.
+// that cannot prove only one layer changed. It uses the same warm-cache and
+// post-invalidation resolve cycle as the targeted benchmark above.
 func BenchmarkInvalidateAll_WarmNegCache(b *testing.B) {
 	const (
 		filesPerLayer = 1_000
@@ -361,8 +383,12 @@ func BenchmarkInvalidateAll_WarmNegCache(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
+		b.StopTimer()
 		benchWarmReloadNegCache(b, ofs, warmNames)
+		b.StartTimer()
+
 		ofs.InvalidateAll()
+		benchReadReloadPaths(b, ofs, warmNames)
 	}
 }
 

--- a/internal/overlayfs/overlayfs_bench_test.go
+++ b/internal/overlayfs/overlayfs_bench_test.go
@@ -237,6 +237,135 @@ func BenchmarkOpen_Parallel(b *testing.B) {
 	})
 }
 
+// benchSingleLayerReloadOverlay builds a BlogFlow-shaped overlay for reload
+// benchmarks. The content layer starts empty while the defaults layer contains
+// the hot path, so warming that path records a neg-cache entry for the upper
+// layers that a later content-layer replacement must invalidate.
+func benchSingleLayerReloadOverlay(filesPerLayer, warmEntries int) (*OverlayFS, fs.FS, fs.FS, []string) {
+	layers := make([]fs.FS, 4)
+	names := []string{"theme", "content", "config", "defaults"}
+
+	for li := range layers {
+		m := make(fstest.MapFS, filesPerLayer)
+		for fi := range filesPerLayer {
+			key := fmt.Sprintf("layer%d/file%d.txt", li, fi)
+			m[key] = &fstest.MapFile{Data: []byte("data")}
+		}
+		layers[li] = m
+	}
+
+	defaults := layers[3].(fstest.MapFS)
+	warmNames := make([]string, 0, warmEntries+1)
+	for i := range warmEntries {
+		name := fmt.Sprintf("reload/lower-only-%05d.md", i)
+		defaults[name] = &fstest.MapFile{Data: []byte("---\ntitle: lower\n---\n")}
+		warmNames = append(warmNames, name)
+	}
+	defaults["reload/hot.md"] = &fstest.MapFile{Data: []byte("old-default")}
+	warmNames = append(warmNames, "reload/hot.md")
+
+	oldContent := benchReloadContentLayer(filesPerLayer, "")
+	newContent := benchReloadContentLayer(filesPerLayer, "new-content")
+	layers[1] = oldContent
+
+	return NewOverlayFS(layers...).WithLayerNames(names), oldContent, newContent, warmNames
+}
+
+func benchReloadContentLayer(filesPerLayer int, hotData string) fs.FS {
+	m := make(fstest.MapFS, filesPerLayer+1)
+	for fi := range filesPerLayer {
+		key := fmt.Sprintf("content/file%d.txt", fi)
+		m[key] = &fstest.MapFile{Data: []byte("content")}
+	}
+	if hotData != "" {
+		m["reload/hot.md"] = &fstest.MapFile{Data: []byte(hotData)}
+	}
+	return m
+}
+
+func benchWarmReloadNegCache(b *testing.B, ofs *OverlayFS, names []string) {
+	b.Helper()
+	for _, name := range names {
+		if _, err := ofs.ReadFile(name); err != nil {
+			b.Fatalf("warm ReadFile(%q): %v", name, err)
+		}
+	}
+}
+
+// BenchmarkReplaceLayer_SingleLayer measures the hot-reload path used when a
+// sync strategy swaps one overlay layer: replace the content layer, invalidate
+// only affected neg-cache entries, then resolve a changed file from that layer.
+func BenchmarkReplaceLayer_SingleLayer(b *testing.B) {
+	const (
+		filesPerLayer = 1_000
+		warmEntries   = 8_192
+		contentLayer  = 1
+	)
+
+	ofs, oldContent, newContent, warmNames := benchSingleLayerReloadOverlay(filesPerLayer, warmEntries)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		if err := ofs.ReplaceLayer(contentLayer, oldContent); err != nil {
+			b.Fatal(err)
+		}
+		benchWarmReloadNegCache(b, ofs, warmNames)
+		b.StartTimer()
+
+		if err := ofs.ReplaceLayer(contentLayer, newContent); err != nil {
+			b.Fatal(err)
+		}
+		data, err := ofs.ReadFile("reload/hot.md")
+		if err != nil {
+			b.Fatal(err)
+		}
+		if string(data) != "new-content" {
+			b.Fatalf("ReadFile returned %q, want new-content", data)
+		}
+	}
+}
+
+// BenchmarkInvalidateLayer_SingleLayer measures targeted neg-cache invalidation
+// for one changed layer after re-warming the cache each iteration, guarding
+// against regressions that make single-layer reloads approach full-cache cost.
+func BenchmarkInvalidateLayer_SingleLayer(b *testing.B) {
+	const (
+		filesPerLayer = 1_000
+		warmEntries   = 8_192
+		contentLayer  = 1
+	)
+
+	ofs, _, _, warmNames := benchSingleLayerReloadOverlay(filesPerLayer, warmEntries)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		benchWarmReloadNegCache(b, ofs, warmNames)
+		ofs.InvalidateLayer(contentLayer)
+	}
+}
+
+// BenchmarkInvalidateAll_WarmNegCache is the full-cache baseline for reloads
+// that cannot prove only one layer changed. It uses the same re-warmed cache
+// cycle as the targeted invalidation benchmark for regression comparisons.
+func BenchmarkInvalidateAll_WarmNegCache(b *testing.B) {
+	const (
+		filesPerLayer = 1_000
+		warmEntries   = 8_192
+	)
+
+	ofs, _, _, warmNames := benchSingleLayerReloadOverlay(filesPerLayer, warmEntries)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		benchWarmReloadNegCache(b, ofs, warmNames)
+		ofs.InvalidateAll()
+	}
+}
+
 func benchCrossShardNames(keysPerShard int) []string {
 	namesByShard := make([][]string, negCacheShardCount)
 	for i := 0; i < 100_000; i++ {


### PR DESCRIPTION
## Summary

Fixes #235.

Benchmark-only change for detecting hot-reload regressions when sync strategies change one layer. Scope settled on:
- OverlayFS single-layer reload: warm neg-cache, `ReplaceLayer(content, newFS)`, then resolve the changed path.
- OverlayFS targeted invalidation vs full invalidation baseline with the same warm-cache cycle and post-invalidation resolves, so spared neg-cache entries make the single-layer benefit observable.
- Content rescan/re-index benchmark using the clean `content.Scanner.Scan` entry point called by `cmd/blogflow`'s reloader.

No production code changes; CHANGELOG skipped.

## Reload path found

Sync strategies (`watch`, `webhook`, `sidecar`, `poll`) call `gitops.ContentReloader`. In `cmd/blogflow/reload.go`, that reloads config, reloads theme templates, runs `scanner.Scan(fsys)`, swaps the handler index, then flushes the render cache. Overlay layer swaps are supported by `OverlayFS.ReplaceLayer`, which atomically replaces one layer and invalidates affected negative-cache entries.

## Benchmark numbers

Command:

```sh
go test -run '^$' -bench 'ReplaceLayer|InvalidateLayer|InvalidateAll|ContentReindex' -benchtime=100ms ./internal/overlayfs/ ./internal/content/
```

Results on darwin/amd64, VirtualApple @ 2.50GHz:

```text
BenchmarkReplaceLayer_SingleLayer-16        255     488132 ns/op       768 B/op       7 allocs/op
BenchmarkInvalidateLayer_SingleLayer-16       1  111747667 ns/op   5530464 B/op   37897 allocs/op
BenchmarkInvalidateAll_WarmNegCache-16        1  163479376 ns/op   7261152 B/op   59673 allocs/op
BenchmarkContentReindex-16                    7   15514470 ns/op  13283083 B/op   92104 allocs/op
```

`InvalidateLayer_SingleLayer` is meaningfully cheaper than `InvalidateAll_WarmNegCache` because the fixture now warms mostly content-layer entries that survive a config-layer invalidation; the full wipe has to rebuild those entries during the timed post-invalidation resolve phase.

## Validation

- `go build ./...` ✅
- `go vet ./...` ✅
- `golangci-lint run ./internal/overlayfs/... ./internal/content/...` ✅
- `go test -race -count=1 ./internal/overlayfs/... ./internal/content/...` ✅
- Corrected benchmarks command above ✅
