### PR TITLE
chore(security): bump Go toolchain to 1.26.5 (clears 12 reachable stdlib vulns)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Security
 
+* [BUGFIX] Go: bump the Go toolchain to 1.26.5, fixing 12 reachable Go standard-library vulnerabilities that `govulncheck` flagged on 1.26.1 — including three `html/template` XSS issues (GO-2026-4865/4980/4982), a `crypto/x509` name-constraint auth bypass (GO-2026-4866), and TLS 1.3 KeyUpdate / HTTP/2 infinite-loop DoS (GO-2026-4870, GO-2026-4918). #279
 * [ENHANCEMENT] Webhook: the IP allowlist (`allowed_ips`) matches CIDR ranges (`net.ParseCIDR` / `net.IPNet.Contains`), and `NewWebhookStrategy` requires an explicit `IPResolver` so the built-in X-Forwarded-For fallback is no longer used in production. #237
 * [ENHANCEMENT] Webhook: additional security hardening — the HMAC signature is verified before event/branch filtering, IPv6-robust bare-IP allowlist matching (`net.IP.Equal` instead of exact-string comparison), and fail-closed client-IP resolution. #252
 * [CHANGE] Webhook: branch-mismatch response changed from `200 OK` ("accepted (no action)") to `202 Accepted` with an `X-Blogflow-Branch-Skipped` header. External consumers checking for a 200 status code on branch-skip responses must be updated. #237

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/khaines/blogflow
 
-go 1.26.1
+go 1.26.5
 
 require (
 	github.com/alecthomas/chroma/v2 v2.27.0


### PR DESCRIPTION
## Summary

Bumps the `go.mod` go directive **1.26.1 → 1.26.5** to remediate reachable Go standard-library vulnerabilities.

This came out of a security triage of the repo's flagged items. GitHub code scanning (Trivy) surfaced only one alert (`GO-2026-5932`, `x/crypto/openpgp`), which is a **false positive** — that package is not in our build graph (dismissed with explanation). Running `govulncheck ./...` for authoritative call-graph reachability told the real story: **12 stdlib vulnerabilities reachable from our code** when built on go 1.26.1.

## Reachable vulnerabilities fixed (go1.26.5)

| Sev | ID | Issue | Fixed in |
|---|---|---|---|
| High | GO-2026-4865 | XSS in `html/template` (JsBraceDepth) | 1.26.2 |
| High | GO-2026-4980 | XSS in `html/template` (escaper bypass) | 1.26.3 |
| High | GO-2026-4982 | XSS in `html/template` (meta URL escaping) | 1.26.3 |
| High | GO-2026-4866 | `crypto/x509` auth bypass (name constraints) | 1.26.2 |
| High | GO-2026-4870 | `crypto/tls` TLS 1.3 KeyUpdate DoS | 1.26.2 |
| High | GO-2026-4918 | `net/http` HTTP/2 infinite-loop DoS | 1.26.3 |
| Med | GO-2026-4946 / 4947 / 5037 | `crypto/x509` chain/policy DoS | 1.26.2–1.26.4 |
| Med | GO-2026-5039 | `net/textproto` unescaped error inputs | 1.26.4 |
| Med | GO-2026-5856 | `crypto/tls` ECH privacy leak | 1.26.5 |
| Low | GO-2026-4971 | `net` Dial NUL-byte panic (Windows-only) | 1.26.3 |

The three `html/template` XSS issues are the most relevant given BlogFlow renders untrusted content through that exact package.

## Verification

- **Before** (`go 1.26.1`): `govulncheck ./...` → *"Your code is affected by 12 vulnerabilities from the Go standard library."*
- **After** (`go 1.26.5`): `govulncheck ./...` → *"Your code is affected by 0 vulnerabilities."* (the one remaining "module you require" finding is the not-called `x/crypto/openpgp`.)
- `go build ./...`, `go vet ./...`, `go test ./...` — all pass on go1.26.5.

CI's `setup-go` uses the floating `go-version: '1.26'` (latest 1.26.x), so this bump makes the go.mod floor match the security-patched toolchain and keeps local/contributor builds and `govulncheck` clean; no workflow change needed.
