### PR TITLE
feat(server): full-text search for blog posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### BlogFlow
 
+* [FEATURE] search: optional server-rendered full-text search (no JavaScript). Enable with `search.enabled: true`; adds `GET /search?q=&page=` with a Unicode-normalized tokenizer, a bounded in-memory inverted index (`max_docs`/`max_tokens`/`max_index_bytes` caps), deterministic weighted TF-IDF ranking, plain-text excerpts, accessible default-theme templates (`search.html` + `search-result`/`search-pagination` partials, conditional header search box), and `blogflow_search_*` metrics. Content and search publish atomically in one snapshot generation. #280
 * [BUGFIX] overlayfs: guard negative-cache stores with an invalidation generation so concurrent layer invalidations cannot resurrect stale upper-layer misses. #272
 * [ENHANCEMENT] overlayfs: shard the negative-cache LRU to reduce hot-path contention under parallel cache hits. #271
 * [CHANGE] overlayfs: negative cache now uses true LRU eviction of the least-recently-used entry at capacity (previously admission-capped — stopped caching new misses once full). #245

--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -190,6 +190,15 @@ func main() {
 	// 7. Build handler dependencies
 	deps := handlers.NewDeps(cfg, idx, themeEngine)
 	deps.Overlay = contentOverlay
+	deps.SetSearchEnabled(cfg.Search.Enabled)
+
+	// Build the initial search index (when enabled) and publish the
+	// content+search snapshot atomically. Disabled search leaves the gen-0
+	// content-only snapshot from NewDeps in place.
+	if cfg.Search.Enabled {
+		publishContentSnapshot(context.Background(), deps, idx, true, cfg.Search, logger)
+		logger.Info("search enabled", "route", "GET /search")
+	}
 
 	// Wire config reload → handlers: when config changes, update deps atomically
 	cfgLoader.OnChange(func(newCfg *config.Config) {
@@ -244,6 +253,9 @@ func main() {
 		FeedHandler:      feedHandler.ServeHTTP,
 		SitemapHandler:   sitemapHandler.ServeHTTP,
 		StaticFS:         staticFS,
+	}
+	if cfg.Search.Enabled {
+		routeOpts.SearchHandler = handlers.SearchHandler(deps)
 	}
 	if ws, ok := syncStrategy.(*gitops.WebhookStrategy); ok {
 		routeOpts.WebhookHandler = ws.Handler()

--- a/cmd/blogflow/reload.go
+++ b/cmd/blogflow/reload.go
@@ -1,16 +1,99 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"time"
 
 	"github.com/khaines/blogflow/internal/config"
 	"github.com/khaines/blogflow/internal/content"
 	"github.com/khaines/blogflow/internal/gitops"
+	"github.com/khaines/blogflow/internal/search"
 	"github.com/khaines/blogflow/internal/server/handlers"
 	"github.com/khaines/blogflow/internal/theme"
 )
+
+// publishContentSnapshot builds the search index (when buildSearch is true) for
+// a content generation and publishes the content+search snapshot atomically via
+// deps. Content and search always share one generation, so a query never mixes
+// generations. When buildSearch is false the snapshot's Search is nil and the
+// /search route (if it exists) returns 503 until a build is published.
+//
+// buildSearch reflects the router-build value of search.enabled (fixed for the
+// process lifetime), not the possibly-reloaded config value; searchCfg supplies
+// the reloadable tunables (caps, limits) for this generation.
+func publishContentSnapshot(
+	ctx context.Context,
+	deps *handlers.Deps,
+	idx *content.Index,
+	buildSearch bool,
+	searchCfg config.SearchConfig,
+	logger *slog.Logger,
+) {
+	gen := deps.NextGeneration()
+	if !buildSearch {
+		deps.SetSnapshot(gen, idx, nil)
+		return
+	}
+
+	var oldBytes int64
+	if prev := deps.LoadSearch(); prev != nil {
+		oldBytes = prev.LogicalBytes()
+	}
+
+	start := time.Now()
+	si := buildSearchIndexSafe(ctx, idx, searchCfg, gen, logger)
+	dur := time.Since(start)
+
+	// A nil index means the build failed (panicked). Publish the new content
+	// with Search=nil so the site keeps serving; the registered /search route
+	// then returns 503 until a later successful rebuild (design §2.3, §3.2 #15).
+	if si == nil {
+		deps.SetSnapshot(gen, idx, nil)
+		search.RecordRebuildFailure(gen, dur)
+		return
+	}
+
+	// Publish first so search becomes queryable, then record metrics.
+	deps.SetSnapshot(gen, idx, si)
+	search.ObserveRebuild(si, dur, si.LogicalBytes()+oldBytes)
+
+	if si.Truncated() {
+		logger.Warn("search index truncated",
+			"reason", si.TruncationReason(),
+			"indexed_docs", si.DocCount(),
+			"max_docs", searchCfg.MaxDocs,
+			"max_tokens", searchCfg.MaxTokens,
+			"max_index_bytes", searchCfg.MaxIndexBytes,
+		)
+	}
+	logger.Info("search index rebuilt",
+		"generation", gen,
+		"posts", si.DocCount(),
+		"tokens", si.TokenCount(),
+		"duration", dur,
+		"truncated", si.Truncated(),
+	)
+}
+
+// buildSearchIndexSafe builds the search index and converts a panic into a nil
+// result so a search build failure degrades to content-only service instead of
+// crashing the reload goroutine — the HTTP recovery middleware does not cover
+// this background code path.
+func buildSearchIndexSafe(ctx context.Context, idx *content.Index, cfg config.SearchConfig, gen uint64, logger *slog.Logger) (si *search.SearchIndex) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			logger.Error("search index build failed; serving content without search",
+				"generation", gen,
+				"panic", fmt.Sprint(rec),
+			)
+			si = nil
+		}
+	}()
+	return search.Build(ctx, idx, cfg, gen)
+}
 
 // newContentReloader builds a ContentReloader that reloads config, theme
 // templates, and content (in that order), then flushes the render cache.
@@ -49,10 +132,26 @@ func newContentReloader(
 		if err != nil {
 			return fmt.Errorf("content reload: %w", err)
 		}
-		deps.SetIndex(newIdx)
+
+		// 4. Rebuild search (if enabled at router build) and publish the
+		// content+search snapshot atomically. search.enabled is restart-scoped:
+		// route registration never changes at runtime, so we build based on the
+		// router-build value while honoring reloaded search tunables.
+		var searchCfg config.SearchConfig
+		if cfgLoader != nil {
+			cfg := cfgLoader.Get()
+			searchCfg = cfg.Search
+			if cfg.Search.Enabled != deps.SearchEnabled() {
+				logger.Warn("search.enabled change ignored until restart",
+					"router_enabled", deps.SearchEnabled(),
+					"config_enabled", cfg.Search.Enabled,
+				)
+			}
+		}
+		publishContentSnapshot(context.Background(), deps, newIdx, deps.SearchEnabled(), searchCfg, logger)
 		logger.Info("content reloaded", "posts", len(newIdx.Posts), "pages", len(newIdx.Pages))
 
-		// 4. Cache flush.
+		// 5. Cache flush.
 		if cache != nil {
 			cache.InvalidateAll()
 			logger.Info("render cache flushed after content reload")

--- a/cmd/blogflow/reload_search_test.go
+++ b/cmd/blogflow/reload_search_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"html/template"
+	"log/slog"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/khaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/content"
+	"github.com/khaines/blogflow/internal/search"
+	"github.com/khaines/blogflow/internal/server/handlers"
+)
+
+// discardLogger returns a logger that discards all output, for quiet tests.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(discard{}, nil))
+}
+
+// TestContentReloader_ScanFailureRetainsSnapshot verifies that when a content
+// rescan fails, the previously published snapshot remains active and the
+// generation counter does not advance (design §3.2 #14 / §3.3).
+func TestContentReloader_ScanFailureRetainsSnapshot(t *testing.T) {
+	// Duplicate explicit slug makes scanner.Scan return an error in strict mode.
+	badFS := fstest.MapFS{
+		"posts/a.md": &fstest.MapFile{Data: []byte("---\ntitle: A\nslug: dup\ndate: 2026-01-01T00:00:00Z\n---\nA")},
+		"posts/b.md": &fstest.MapFile{Data: []byte("---\ntitle: B\nslug: dup\ndate: 2026-01-02T00:00:00Z\n---\nB")},
+	}
+	scanner := content.NewScanner(content.NewRenderer(), "posts", "pages", 200, nil)
+
+	deps := handlers.NewDeps(config.Default(), searchTestIndex(), nil)
+	origSnap := deps.LoadSnapshot()
+	origGen := origSnap.Generation
+	origPosts := deps.PostCount()
+
+	reloader := newContentReloader(scanner, badFS, deps, nil, nil, nil, discardLogger())
+	if err := reloader(); err == nil {
+		t.Fatal("expected reloader to return an error when content scan fails")
+	}
+
+	snap := deps.LoadSnapshot()
+	if snap != origSnap {
+		t.Error("snapshot pointer changed after a failed scan; the previous snapshot should be retained")
+	}
+	if snap.Generation != origGen {
+		t.Errorf("generation advanced after failed scan: %d -> %d", origGen, snap.Generation)
+	}
+	if deps.PostCount() != origPosts {
+		t.Errorf("post count changed after failed scan: %d -> %d", origPosts, deps.PostCount())
+	}
+}
+
+func searchTestIndex() *content.Index {
+	idx := &content.Index{BySlug: make(map[string]*content.Post)}
+	p := &content.Post{Slug: "hello", Content: template.HTML("<p>overlay filesystem</p>")} //nolint:gosec // test data
+	p.Title = "Hello overlay"
+	p.Date = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	idx.Posts = []*content.Post{p}
+	idx.BySlug[p.Slug] = p
+	return idx
+}
+
+// TestPublishContentSnapshot_BuildsSearchWhenEnabled verifies the wiring helper
+// builds and publishes a queryable search index when buildSearch is true.
+func TestPublishContentSnapshot_BuildsSearchWhenEnabled(t *testing.T) {
+	deps := handlers.NewDeps(config.Default(), &content.Index{}, nil)
+	idx := searchTestIndex()
+	sc := config.Default().Search
+	sc.Enabled = true
+
+	publishContentSnapshot(context.Background(), deps, idx, true, sc, slog.New(slog.NewTextHandler(discard{}, nil)))
+
+	snap := deps.LoadSnapshot()
+	if snap.Search == nil {
+		t.Fatal("expected non-nil search index when buildSearch is true")
+	}
+	resp, err := snap.Search.Search(context.Background(), snap.Content, "overlay", search.SearchOptions{Limit: 20})
+	if err != nil {
+		t.Fatalf("search error: %v", err)
+	}
+	if resp.Total != 1 {
+		t.Errorf("expected 1 result, got %d", resp.Total)
+	}
+}
+
+// TestPublishContentSnapshot_NilSearchWhenDisabled verifies content is published
+// with a nil search index when search is not built (router-build disabled).
+func TestPublishContentSnapshot_NilSearchWhenDisabled(t *testing.T) {
+	deps := handlers.NewDeps(config.Default(), &content.Index{}, nil)
+	idx := searchTestIndex()
+
+	publishContentSnapshot(context.Background(), deps, idx, false, config.SearchConfig{}, slog.New(slog.NewTextHandler(discard{}, nil)))
+
+	snap := deps.LoadSnapshot()
+	if snap.Search != nil {
+		t.Fatal("expected nil search index when buildSearch is false")
+	}
+	if snap.Content != idx {
+		t.Error("content should still be published")
+	}
+	if deps.PostCount() != 1 {
+		t.Errorf("PostCount = %d, want 1", deps.PostCount())
+	}
+}
+
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }

--- a/defaults/config/defaults.yaml
+++ b/defaults/config/defaults.yaml
@@ -50,3 +50,17 @@ feed:
   enabled: true
   type: "atom"
   items: 20
+
+# Full-text search (opt-in, server-rendered, no JavaScript required).
+# Disabled by default. `enabled` takes effect only at startup/router build;
+# toggling it at runtime requires a restart. Other tunables reload with content.
+search:
+  enabled: false
+  max_results: 20          # results per page
+  min_query_length: 2      # minimum normalized query runes
+  max_query_length: 128    # maximum normalized query runes
+  max_query_terms: 32      # maximum unique normalized query terms
+  excerpt_length: 200      # excerpt display runes
+  max_docs: 10000          # maximum indexed posts
+  max_tokens: 2000000      # maximum posting occurrences
+  max_index_bytes: 67108864 # logical index budget in bytes (64 MiB)

--- a/defaults/static/css/main.css
+++ b/defaults/static/css/main.css
@@ -633,3 +633,161 @@ main {
     html { scroll-behavior: auto; }
     .tag { transition: none; }
 }
+
+/* --------------------------------------------------------------------------
+   18. Search
+   -------------------------------------------------------------------------- */
+
+/* Accessible visually-hidden utility: hides content visually while keeping it
+   available to screen readers and keyboard users. */
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+/* Header search form */
+.site-nav {
+    gap: 1rem;
+    flex-wrap: wrap;
+    justify-content: space-between;
+}
+
+.site-search {
+    display: flex;
+    gap: 0.375rem;
+    margin-left: auto;
+}
+
+.site-search-input {
+    padding: 0.35rem 0.6rem;
+    font: inherit;
+    color: var(--text);
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+}
+
+.site-search-submit,
+.search-submit {
+    padding: 0.35rem 0.8rem;
+    font: inherit;
+    font-weight: 600;
+    color: #fff;
+    background: var(--accent);
+    border: 1px solid var(--accent);
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.site-search-submit:hover,
+.search-submit:hover {
+    background: var(--accent-hover);
+    border-color: var(--accent-hover);
+}
+
+.site-search-input:focus-visible,
+.search-input:focus-visible,
+.site-search-submit:focus-visible,
+.search-submit:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+/* Search page */
+.search-page {
+    max-width: 44rem;
+}
+
+.search-form {
+    margin-block: 1.25rem 1.5rem;
+}
+
+.search-form-label {
+    display: block;
+    margin-bottom: 0.4rem;
+    font-weight: 600;
+}
+
+.search-form-controls {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.search-input {
+    flex: 1;
+    padding: 0.55rem 0.75rem;
+    font: inherit;
+    color: var(--text);
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+}
+
+.search-error {
+    padding: 0.6rem 0.85rem;
+    color: var(--code-text);
+    background: var(--blockquote-bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+}
+
+.search-notice {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}
+
+.search-summary {
+    color: var(--text-secondary);
+    margin-block: 1rem 0.5rem;
+}
+
+.search-results {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+}
+
+.search-result-title {
+    margin: 0 0 0.25rem;
+    font-size: 1.25rem;
+}
+
+.search-result-title a {
+    color: var(--text);
+    text-decoration: none;
+}
+
+.search-result-title a:hover {
+    color: var(--accent);
+}
+
+.search-result-excerpt {
+    margin: 0.4rem 0 0.5rem;
+    color: var(--text-secondary);
+}
+
+.search-empty {
+    color: var(--text-secondary);
+}
+
+.pagination.search-pagination {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-top: 2rem;
+}
+
+.pagination-status {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}

--- a/defaults/templates/partials/header.html
+++ b/defaults/templates/partials/header.html
@@ -2,6 +2,15 @@
 <header class="site-header" role="banner">
     <nav class="site-nav" aria-label="Main navigation">
         <a href="/" class="site-title">{{.Site.Title}}</a>
+        {{with .Search}}{{if .Enabled}}
+        <form class="site-search" role="search" action="/search" method="get">
+            <label for="site-search-input" class="visually-hidden">Search posts</label>
+            <input type="search" id="site-search-input" name="q" class="site-search-input"
+                   placeholder="Search…" autocomplete="off">
+            <button type="submit" class="site-search-submit">Search</button>
+        </form>
+        {{end}}{{end}}
     </nav>
 </header>
 {{end}}
+

--- a/defaults/templates/partials/search-pagination.html
+++ b/defaults/templates/partials/search-pagination.html
@@ -1,0 +1,15 @@
+{{/*
+  Search results pagination. Dot is a handlers.SearchData.
+  Override by placing templates/partials/search-pagination.html in a custom theme.
+  On a page beyond the last, the previous link targets the true last page so
+  readers can navigate back to real results.
+*/}}
+{{define "search-pagination"}}
+{{if or .HasPrev .HasNext}}
+<nav class="pagination search-pagination" aria-label="Search results pages">
+    {{if .HasPrev}}<a href="{{.PrevURL}}" class="pagination-prev" rel="prev">&larr; Previous</a>{{end}}
+    <span class="pagination-status">Page {{.Page}} of {{.TotalPages}}</span>
+    {{if .HasNext}}<a href="{{.NextURL}}" class="pagination-next" rel="next">Next &rarr;</a>{{end}}
+</nav>
+{{end}}
+{{end}}

--- a/defaults/templates/partials/search-result.html
+++ b/defaults/templates/partials/search-result.html
@@ -1,0 +1,20 @@
+{{/*
+  Search result item. Dot is a search.SearchResult.
+  Override by placing templates/partials/search-result.html in a custom theme.
+  The relevance score is available as {{.Score}} for custom themes but is
+  intentionally not shown in the default reader-visible result body.
+*/}}
+{{define "search-result"}}
+<article class="search-result-item">
+    <h2 class="search-result-title"><a href="{{.URL}}">{{.Title}}</a></h2>
+    <div class="post-meta">
+        <time datetime="{{.Date.Format "2006-01-02"}}">{{.Date.Format "January 2, 2006"}}</time>
+    </div>
+    {{if .Excerpt}}<p class="search-result-excerpt">{{.Excerpt}}</p>{{end}}
+    {{if .Tags}}
+    <div class="post-tags" role="list" aria-label="Tags">
+        {{range .Tags}}<a href="/tags/{{.}}" class="tag" role="listitem">{{.}}</a>{{end}}
+    </div>
+    {{end}}
+</article>
+{{end}}

--- a/defaults/templates/search.html
+++ b/defaults/templates/search.html
@@ -1,0 +1,49 @@
+{{define "title"}}{{if .Title}}{{.Title}} — {{end}}{{.Site.Title}}{{end}}
+
+{{define "meta_description"}}Search {{.Site.Title}}{{end}}
+
+{{define "content"}}
+<section class="search-page">
+    <h1>Search</h1>
+
+    <form class="search-form" role="search" action="/search" method="get">
+        <label for="search-input" class="search-form-label">Search posts</label>
+        <div class="search-form-controls">
+            <input type="search" id="search-input" name="q" class="search-input"
+                   value="{{.Search.Query}}" placeholder="Search posts…" autocomplete="off"
+                   {{if .Search.Error}}aria-describedby="search-error" aria-invalid="true"{{end}}>
+            <button type="submit" class="search-submit">Search</button>
+        </div>
+    </form>
+
+    {{if .Search.Error}}
+    <p id="search-error" class="search-error" role="alert">{{.Search.Error}}</p>
+    {{end}}
+
+    {{if .Search.Executed}}
+        {{if .Search.Truncated}}
+        <p class="search-notice" role="status">Some results may be omitted because the search index is at capacity.</p>
+        {{end}}
+
+        {{if gt .Search.Total 0}}
+        <p class="search-summary" role="status" aria-live="polite">
+            {{.Search.Total}} result{{if ne .Search.Total 1}}s{{end}} for “{{.Search.Query}}” — page {{.Search.Page}} of {{.Search.TotalPages}}
+        </p>
+        {{if .Search.Results}}
+        <ol class="search-results" role="list">
+            {{range .Search.Results}}
+            <li class="search-result" role="listitem">{{template "search-result" .}}</li>
+            {{end}}
+        </ol>
+        {{else}}
+        <p class="search-empty">No results on this page. Use the links below to return to earlier results.</p>
+        {{end}}
+        {{template "search-pagination" .Search}}
+        {{else}}
+        <p class="search-summary search-empty" role="status" aria-live="polite">
+            No results found for “{{.Search.Query}}”. Try different or fewer keywords.
+        </p>
+        {{end}}
+    {{end}}
+</section>
+{{end}}

--- a/docs/theme-development.md
+++ b/docs/theme-development.md
@@ -218,6 +218,7 @@ Every template receives a `PageData` struct as its root context (`.`):
 | `.Tag`       | `string`          | `list.html` (tag)    | Current tag filter (empty on homepage). |
 | `.Title`     | `string`          | All templates        | Page title override.                 |
 | `.Pagination`| `*Pagination`     | `list.html`          | Pagination metadata.                 |
+| `.Search`    | `*SearchData`     | All templates        | Search affordance state (always set); results on `search.html`. |
 
 ### Post (and Page)
 
@@ -271,6 +272,33 @@ Posts and pages share the same structure:
 | `.Pagination.PrevPage`      | `int`  | Previous page number.               |
 | `.Pagination.NextPage`      | `int`  | Next page number.                   |
 
+### SearchData
+
+`.Search` is set on **every** page so the header/nav can render or omit a
+global search box based on `.Search.Enabled`. On `search.html` it also carries
+the query, results, and pagination. Search is opt-in — enable it with
+`search.enabled: true` in `site.yaml` (takes effect at startup; toggling
+requires a restart).
+
+| Field                 | Type                  | Description                                                        |
+|-----------------------|-----------------------|-------------------------------------------------------------------|
+| `.Search.Enabled`     | `bool`                | Whether the `/search` route is registered. Guard header UI with this. |
+| `.Search.Executed`    | `bool`                | Whether a query was run (vs. the empty landing form).             |
+| `.Search.Query`       | `string`              | The user's query, echoed (auto-escaped).                         |
+| `.Search.Results`     | `[]SearchResult`      | Current page of hits.                                             |
+| `.Search.Total`       | `int`                 | Total matching posts.                                            |
+| `.Search.Page`        | `int`                 | Current page number.                                            |
+| `.Search.TotalPages`  | `int`                 | Total result pages.                                             |
+| `.Search.HasPrev` / `.HasNext` | `bool`       | Whether prev/next result pages exist.                           |
+| `.Search.PrevURL` / `.NextURL` | `string`     | URLs for prev/next result pages.                                |
+| `.Search.Error`       | `string`              | Accessible validation/unavailable message (empty when none).     |
+| `.Search.Truncated`   | `bool`                | Whether the index was capped (results may be incomplete).        |
+
+Each `SearchResult` exposes `.Title`, `.URL`, `.Slug`, `.Date` (`time.Time`),
+`.Excerpt`, `.Tags`, and `.Score`. The relevance `.Score` is available for
+custom themes (e.g. to sort or display), but the default theme intentionally
+does **not** show numeric scores in the reader-visible result body.
+
 ---
 
 ## 5. Partial Templates
@@ -293,6 +321,8 @@ BlogFlow ships these partials in the embedded defaults:
 | `partials/footer.html`     | `partials/footer.html`       | Site footer with copyright and attribution.           |
 | `post-meta`                | `partials/post-meta.html`    | Post metadata: date, reading time, tag links.         |
 | `pagination`               | `partials/pagination.html`   | Previous / next page navigation with aria labels.     |
+| `search-result`            | `partials/search-result.html`| A single search hit (title, date, excerpt, tags).     |
+| `search-pagination`        | `partials/search-pagination.html` | Search results prev/next navigation.             |
 
 > **Naming convention**: The `{{define}}` name must match exactly what
 > `{{template}}` uses. The default header and footer use full-path names
@@ -535,3 +565,58 @@ the `base.html` meta tag alone has no effect.
 > ⚠️ `frame-ancestors` **cannot** be set via a `<meta>` tag — the browser spec
 > forbids it. This directive is only effective in the HTTP header, which
 > BlogFlow already sets.
+
+---
+
+## 9. Full-Text Search
+
+BlogFlow ships an optional, server-rendered full-text search that requires **no
+client-side JavaScript**. It is disabled by default.
+
+### Enabling search
+
+Add to `site.yaml`:
+
+```yaml
+search:
+  enabled: true          # opt-in; evaluated at startup (restart to toggle)
+  max_results: 20        # results per page
+  min_query_length: 2    # minimum normalized query runes
+  max_query_length: 128  # maximum normalized query runes
+  max_query_terms: 32    # maximum unique normalized query terms
+  excerpt_length: 200    # excerpt display runes
+  max_docs: 10000        # index admission caps (memory safety)
+  max_tokens: 2000000
+  max_index_bytes: 67108864  # 64 MiB logical budget
+```
+
+When enabled, BlogFlow registers `GET /search?q=...&page=N` and the default
+theme renders a global search box in the header. When disabled, the route is
+not registered (requests 404) and no search affordance is emitted anywhere.
+`enabled` is evaluated when the router is built — changing it requires a
+restart; other tunables reload with content.
+
+### Templates and override points
+
+| File                                  | Purpose                                        |
+|---------------------------------------|------------------------------------------------|
+| `templates/search.html`               | The search page (form, results region, states).|
+| `templates/partials/search-result.html` | One result item (`{{define "search-result"}}`). |
+| `templates/partials/search-pagination.html` | Results prev/next nav (`{{define "search-pagination"}}`). |
+
+Override any of these through the overlay filesystem exactly like other
+templates (Section 6). If a custom theme omits a search partial, the embedded
+default is used, so you can override just the page or just a partial.
+
+Within `search.html`, the search-specific data lives under `.Search` (see the
+**SearchData** table in Section 4). The `search-result` partial receives a
+single `SearchResult` as its dot; the `search-pagination` partial receives the
+`.Search` value.
+
+### Accessibility contract
+
+The default search UI is keyboard-navigable and screen-reader friendly: the
+form uses `role="search"`, the query input has an associated label, the result
+count is exposed via `role="status"`, the no-results state is explicit, and
+pagination uses real `<a>` links inside a labelled `<nav>`. Preserve these
+semantics when overriding the templates.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	Cache   CacheConfig   `yaml:"cache"`
 	Sync    SyncConfig    `yaml:"sync"`
 	Feed    FeedConfig    `yaml:"feed"`
+	Search  SearchConfig  `yaml:"search"`
 }
 
 // SiteConfig holds site identity settings.
@@ -152,6 +153,26 @@ type FeedConfig struct {
 	Items   int    `yaml:"items"`
 }
 
+// SearchConfig holds full-text search settings.
+//
+// Enabled is evaluated when the HTTP router is built (startup/restart). A
+// runtime config reload that flips Enabled logs a warning and does not
+// register or unregister the /search route until the process restarts. The
+// remaining tunables reload together with content in a single snapshot
+// generation. All rune-length limits are counted after Unicode NFC
+// normalization and lower-casing.
+type SearchConfig struct {
+	Enabled        bool  `yaml:"enabled"`          // opt-in; startup/router-build only. Default false.
+	MaxResults     int   `yaml:"max_results"`      // per-page result window. Default 20.
+	MaxQueryLength int   `yaml:"max_query_length"` // max normalized query runes. Default 128.
+	MinQueryLength int   `yaml:"min_query_length"` // min normalized query runes. Default 2.
+	MaxQueryTerms  int   `yaml:"max_query_terms"`  // max unique normalized query terms. Default 32.
+	ExcerptLength  int   `yaml:"excerpt_length"`   // excerpt display runes. Default 200.
+	MaxDocs        int   `yaml:"max_docs"`         // max indexed posts. Default 10000.
+	MaxTokens      int   `yaml:"max_tokens"`       // max posting occurrences. Default 2000000.
+	MaxIndexBytes  int64 `yaml:"max_index_bytes"`  // logical index byte budget. Default 67108864 (64 MiB).
+}
+
 // Default returns a Config with sensible defaults.
 // This is what the binary uses when no external config is provided.
 func Default() *Config {
@@ -203,6 +224,17 @@ func Default() *Config {
 			Enabled: true,
 			Type:    "atom",
 			Items:   20,
+		},
+		Search: SearchConfig{
+			Enabled:        false,
+			MaxResults:     20,
+			MaxQueryLength: 128,
+			MinQueryLength: 2,
+			MaxQueryTerms:  32,
+			ExcerptLength:  200,
+			MaxDocs:        10000,
+			MaxTokens:      2000000,
+			MaxIndexBytes:  67108864, // 64 MiB
 		},
 	}
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -874,6 +874,80 @@ func Validate(cfg *Config) error {
 		}
 	}
 
+	// Search cap/tunable validation runs regardless of search.enabled. Unlike
+	// feed/webhook settings (which are inert when disabled), search tunables are
+	// consumed by the content reloader's index rebuild whenever the /search
+	// route was registered at startup — search enablement is restart-scoped, so
+	// a runtime reload keeps rebuilding with these caps. Validating them always
+	// ensures an invalid runtime edit fails validation (retaining the last-good
+	// config) instead of feeding unbounded/degenerate caps into the rebuild.
+	{
+		if cfg.Search.MaxResults < 1 || cfg.Search.MaxResults > 100 {
+			errs = append(errs, FieldError{
+				Field:   "search.max_results",
+				Value:   cfg.Search.MaxResults,
+				Message: "must be between 1 and 100",
+			})
+		}
+		if cfg.Search.MinQueryLength < 1 || cfg.Search.MinQueryLength > 16 {
+			errs = append(errs, FieldError{
+				Field:   "search.min_query_length",
+				Value:   cfg.Search.MinQueryLength,
+				Message: "must be between 1 and 16",
+			})
+		}
+		if cfg.Search.MaxQueryLength < 8 || cfg.Search.MaxQueryLength > 1024 {
+			errs = append(errs, FieldError{
+				Field:   "search.max_query_length",
+				Value:   cfg.Search.MaxQueryLength,
+				Message: "must be between 8 and 1024",
+			})
+		}
+		if cfg.Search.MaxQueryLength < cfg.Search.MinQueryLength {
+			errs = append(errs, FieldError{
+				Field:   "search.max_query_length",
+				Value:   cfg.Search.MaxQueryLength,
+				Message: "must be >= search.min_query_length",
+			})
+		}
+		if cfg.Search.MaxQueryTerms < 1 || cfg.Search.MaxQueryTerms > 128 {
+			errs = append(errs, FieldError{
+				Field:   "search.max_query_terms",
+				Value:   cfg.Search.MaxQueryTerms,
+				Message: "must be between 1 and 128",
+			})
+		}
+		if cfg.Search.ExcerptLength < 50 || cfg.Search.ExcerptLength > 1000 {
+			errs = append(errs, FieldError{
+				Field:   "search.excerpt_length",
+				Value:   cfg.Search.ExcerptLength,
+				Message: "must be between 50 and 1000",
+			})
+		}
+		if cfg.Search.MaxDocs < 1 || cfg.Search.MaxDocs > 1000000 {
+			errs = append(errs, FieldError{
+				Field:   "search.max_docs",
+				Value:   cfg.Search.MaxDocs,
+				Message: "must be between 1 and 1000000",
+			})
+		}
+		if cfg.Search.MaxTokens < 1 {
+			errs = append(errs, FieldError{
+				Field:   "search.max_tokens",
+				Value:   cfg.Search.MaxTokens,
+				Message: "must be >= 1",
+			})
+		}
+		const minSearchIndexBytes int64 = 1 << 20 // 1 MiB
+		if cfg.Search.MaxIndexBytes < minSearchIndexBytes {
+			errs = append(errs, FieldError{
+				Field:   "search.max_index_bytes",
+				Value:   cfg.Search.MaxIndexBytes,
+				Message: "must be >= 1048576 (1 MiB)",
+			})
+		}
+	}
+
 	if len(errs) > 0 {
 		return &ConfigError{Errors: errs}
 	}

--- a/internal/config/search_test.go
+++ b/internal/config/search_test.go
@@ -1,0 +1,83 @@
+package config
+
+import "testing"
+
+func hasFieldError(err error, field string) bool {
+	cfgErr, ok := err.(*ConfigError)
+	if !ok {
+		return false
+	}
+	for _, fe := range cfgErr.Errors {
+		if fe.Field == field {
+			return true
+		}
+	}
+	return false
+}
+
+func TestValidate_SearchDefaultsValid(t *testing.T) {
+	cfg := Default()
+	cfg.Search.Enabled = true
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("default search config should validate, got %v", err)
+	}
+}
+
+func TestValidate_SearchCapsValidatedEvenWhenDisabled(t *testing.T) {
+	// Search tunables are consumed by the restart-scoped reloader whenever the
+	// route was registered at startup, so caps are validated regardless of
+	// enabled. An explicitly invalid cap must fail even with search disabled.
+	cfg := Default()
+	cfg.Search.Enabled = false
+	cfg.Search.MaxResults = 0
+	cfg.Search.MaxIndexBytes = 0
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected validation error for invalid search caps even when disabled")
+	}
+	if !hasFieldError(err, "search.max_results") || !hasFieldError(err, "search.max_index_bytes") {
+		t.Errorf("expected search cap field errors, got %v", err)
+	}
+}
+
+func TestValidate_SearchDefaultDisabledValid(t *testing.T) {
+	// The default disabled config (valid caps) must still pass.
+	cfg := Default()
+	cfg.Search.Enabled = false
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("default disabled search config should validate, got %v", err)
+	}
+}
+
+func TestValidate_SearchBounds(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Config)
+		field  string
+	}{
+		{"max_results too low", func(c *Config) { c.Search.MaxResults = 0 }, "search.max_results"},
+		{"max_results too high", func(c *Config) { c.Search.MaxResults = 101 }, "search.max_results"},
+		{"min_query_length zero", func(c *Config) { c.Search.MinQueryLength = 0 }, "search.min_query_length"},
+		{"max_query_length too low", func(c *Config) { c.Search.MaxQueryLength = 4 }, "search.max_query_length"},
+		{"max < min", func(c *Config) { c.Search.MinQueryLength = 10; c.Search.MaxQueryLength = 8 }, "search.max_query_length"},
+		{"max_query_terms zero", func(c *Config) { c.Search.MaxQueryTerms = 0 }, "search.max_query_terms"},
+		{"excerpt too low", func(c *Config) { c.Search.ExcerptLength = 10 }, "search.excerpt_length"},
+		{"max_docs zero", func(c *Config) { c.Search.MaxDocs = 0 }, "search.max_docs"},
+		{"max_tokens zero", func(c *Config) { c.Search.MaxTokens = 0 }, "search.max_tokens"},
+		{"max_index_bytes below 1MiB", func(c *Config) { c.Search.MaxIndexBytes = 1024 }, "search.max_index_bytes"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Default()
+			cfg.Search.Enabled = true
+			tt.mutate(cfg)
+			err := Validate(cfg)
+			if err == nil {
+				t.Fatalf("expected validation error for %s", tt.field)
+			}
+			if !hasFieldError(err, tt.field) {
+				t.Errorf("expected field error %q, got %v", tt.field, err)
+			}
+		})
+	}
+}

--- a/internal/content/scanner.go
+++ b/internal/content/scanner.go
@@ -28,6 +28,15 @@ type Post struct {
 	Path        string        // original .md file path relative to content root
 }
 
+// PlainText returns the canonical plain-text representation of the post's
+// rendered HTML body: HTML tags stripped and entities unescaped, using the
+// same state-machine extractor that produces post summaries. This is the
+// single source of truth for body text consumed by full-text search
+// tokenization and excerpt generation.
+func (p *Post) PlainText() string {
+	return stripHTML(string(p.Content))
+}
+
 // Index is the in-memory content index, built by scanning the content directory.
 type Index struct {
 	Posts      []*Post            // sorted by date descending

--- a/internal/search/bench_test.go
+++ b/internal/search/bench_test.go
@@ -1,0 +1,96 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/khaines/blogflow/internal/content"
+)
+
+// vocab is a small deterministic vocabulary for synthetic corpora.
+var vocab = []string{
+	"go", "search", "overlay", "filesystem", "content", "pipeline", "render",
+	"cache", "template", "index", "token", "query", "score", "unicode", "café",
+	"東京", "concurrency", "goroutine", "channel", "context", "handler", "server",
+}
+
+// genCorpus builds a deterministic synthetic corpus of n posts.
+func genCorpus(n, bodyWords int) *content.Index {
+	posts := make([]*content.Post, 0, n)
+	for i := 0; i < n; i++ {
+		var body strings.Builder
+		for w := 0; w < bodyWords; w++ {
+			body.WriteString(vocab[(i+w)%len(vocab)])
+			body.WriteByte(' ')
+		}
+		p := mkPost(
+			fmt.Sprintf("post-%d", i),
+			fmt.Sprintf("%s %s post %d", vocab[i%len(vocab)], vocab[(i+3)%len(vocab)], i),
+			[]string{vocab[i%len(vocab)], vocab[(i+5)%len(vocab)]},
+			time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, i),
+			body.String(),
+		)
+		posts = append(posts, p)
+	}
+	return mkIndex(posts...)
+}
+
+func BenchmarkTokenize(b *testing.B) {
+	text := strings.Repeat("The quick brown fox jumps over the lazy overlay filesystem. ", 20)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tokenize(text)
+	}
+}
+
+func benchmarkBuild(b *testing.B, n int) {
+	idx := genCorpus(n, 200)
+	cfg := testCfg()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		si := Build(context.Background(), idx, cfg, uint64(i))
+		if si.DocCount() == 0 {
+			b.Fatal("empty index")
+		}
+	}
+}
+
+func BenchmarkBuild100(b *testing.B)   { benchmarkBuild(b, 100) }
+func BenchmarkBuild1000(b *testing.B)  { benchmarkBuild(b, 1000) }
+func BenchmarkBuild10000(b *testing.B) { benchmarkBuild(b, 10000) }
+
+func benchmarkSearch(b *testing.B, query string) {
+	idx := genCorpus(10000, 200)
+	si := Build(context.Background(), idx, testCfg(), 1)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := si.Search(ctx, idx, query, SearchOptions{Limit: 20}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSearchCommon(b *testing.B)    { benchmarkSearch(b, "go") }
+func BenchmarkSearchRare(b *testing.B)      { benchmarkSearch(b, "goroutine") }
+func BenchmarkSearchMultiTerm(b *testing.B) { benchmarkSearch(b, "overlay filesystem content") }
+func BenchmarkSearchUnicode(b *testing.B)   { benchmarkSearch(b, "café 東京") }
+
+// BenchmarkBuildMemory10000 reports the logical index size for the default
+// corpus so memory-budget regressions are visible in benchmark output.
+func BenchmarkBuildMemory10000(b *testing.B) {
+	idx := genCorpus(10000, 200)
+	cfg := testCfg()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		si := Build(context.Background(), idx, cfg, 1)
+		b.ReportMetric(float64(si.LogicalBytes()), "logical_bytes")
+	}
+}

--- a/internal/search/excerpt_test.go
+++ b/internal/search/excerpt_test.go
@@ -1,0 +1,90 @@
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+func termSet(terms ...string) map[string]struct{} {
+	s := make(map[string]struct{}, len(terms))
+	for _, t := range terms {
+		s[t] = struct{}{}
+	}
+	return s
+}
+
+func TestMakeExcerpt_CentersOnMatch(t *testing.T) {
+	plain := "The quick brown fox jumps over the lazy dog near the overlay filesystem boundary today."
+	got := makeExcerpt(plain, termSet("overlay"), 30)
+	if !strings.Contains(strings.ToLower(got), "overlay") {
+		t.Fatalf("excerpt %q does not contain the match", got)
+	}
+	// A window this small in the middle of the text should be ellipsed on both ends.
+	if !strings.HasPrefix(got, "…") || !strings.HasSuffix(got, "…") {
+		t.Errorf("expected leading and trailing ellipsis, got %q", got)
+	}
+}
+
+func TestMakeExcerpt_NoMatchUsesLeading(t *testing.T) {
+	plain := "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi"
+	got := makeExcerpt(plain, termSet("nomatch"), 20)
+	if !strings.HasPrefix(got, "alpha") {
+		t.Errorf("no-match excerpt should start at the beginning, got %q", got)
+	}
+	if strings.HasPrefix(got, "…") {
+		t.Errorf("no-match excerpt should not have a leading ellipsis, got %q", got)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncated excerpt should have a trailing ellipsis, got %q", got)
+	}
+}
+
+func TestMakeExcerpt_StripsHTMLAndCollapsesWhitespace(t *testing.T) {
+	// Excerpts operate on already-plain text; ensure whitespace is collapsed and
+	// no markup survives (defense-in-depth, since PlainText strips tags upstream).
+	plain := "hello    world\n\n\tfoo"
+	got := makeExcerpt(plain, termSet("world"), 100)
+	if strings.Contains(got, "\n") || strings.Contains(got, "\t") || strings.Contains(got, "  ") {
+		t.Errorf("excerpt whitespace not collapsed: %q", got)
+	}
+	if got != "hello world foo" {
+		t.Errorf("excerpt = %q, want %q", got, "hello world foo")
+	}
+}
+
+func TestMakeExcerpt_Unicode(t *testing.T) {
+	plain := "Un petit café au lait le matin à Paris avec un croissant chaud et du beurre."
+	got := makeExcerpt(plain, termSet("café"), 20)
+	if !strings.Contains(strings.ToLower(got), "café") {
+		t.Fatalf("unicode excerpt %q missing match", got)
+	}
+	// Ensure we did not split a multi-byte rune (valid UTF-8 result).
+	if !isValidRunes(got) {
+		t.Errorf("excerpt contains invalid runes: %q", got)
+	}
+}
+
+func TestMakeExcerpt_ShortTextNoEllipsis(t *testing.T) {
+	got := makeExcerpt("short text", termSet("text"), 200)
+	if got != "short text" {
+		t.Errorf("excerpt = %q, want whole text with no ellipsis", got)
+	}
+}
+
+func TestMakeExcerpt_Empty(t *testing.T) {
+	if got := makeExcerpt("", termSet("x"), 200); got != "" {
+		t.Errorf("empty plain text excerpt = %q, want empty", got)
+	}
+	if got := makeExcerpt("text", termSet("x"), 0); got != "" {
+		t.Errorf("zero-length excerpt = %q, want empty", got)
+	}
+}
+
+func isValidRunes(s string) bool {
+	for _, r := range s {
+		if r == '\uFFFD' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -1,0 +1,278 @@
+package search
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/khaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/content"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// Field identifies which part of a post a posting came from. Field weights are
+// applied during scoring so title matches outrank tag matches, which outrank
+// body matches.
+const (
+	FieldTitle uint8 = iota
+	FieldTag
+	FieldBody
+)
+
+// fieldWeight returns the scoring weight for a field.
+func fieldWeight(field uint8) float64 {
+	switch field {
+	case FieldTitle:
+		return 3.0
+	case FieldTag:
+		return 2.0
+	default:
+		return 1.0
+	}
+}
+
+// Posting is one (document, field) contribution for a term. Term frequency is
+// capped at 255 so a posting fits in 8 bytes after alignment. No per-occurrence
+// strings are retained.
+type Posting struct {
+	DocID uint32
+	TF    uint8 // min(rawCount, 255)
+	Field uint8 // FieldTitle, FieldTag, or FieldBody
+}
+
+// SearchDoc is the retained metadata for one indexed post. The full body text
+// is intentionally not stored; excerpts are re-derived on demand from the
+// same-generation content index.
+type SearchDoc struct { //nolint:revive // name matches the full-text-search design doc; Search prefix is intentional
+	ID    uint32
+	Slug  string
+	Title string
+	Tags  []string
+	Date  time.Time
+}
+
+// TruncationReason names the cap that stopped admission when an index is
+// published truncated.
+type TruncationReason string
+
+// Truncation reasons reported by TruncationReason.
+const (
+	TruncationNone      TruncationReason = ""
+	TruncationMaxDocs   TruncationReason = "max_docs"
+	TruncationMaxTokens TruncationReason = "max_tokens"
+	TruncationMaxBytes  TruncationReason = "max_index_bytes"
+)
+
+// SearchIndex is an immutable in-memory inverted index over post title, tags,
+// and body text. It is safe for concurrent reads; it is never mutated after
+// Build returns.
+type SearchIndex struct { //nolint:revive // name matches the full-text-search design doc; Search prefix is intentional
+	docs         []SearchDoc
+	postings     map[string][]Posting // normalized token -> postings sorted by DocID
+	docFreq      map[string]int       // normalized token -> number of docs containing it
+	logicalBytes int64
+	tokenCount   int // total posting entries
+	truncated    bool
+	reason       TruncationReason
+	generation   uint64
+	cfg          config.SearchConfig
+}
+
+// perDocOverheadBytes is the fixed logical byte estimate charged per document
+// for its ID and date, on top of variable slug/title/tag string bytes.
+const perDocOverheadBytes = 16
+
+// perTokenOverheadBytes is the logical byte estimate charged once per unique
+// token for map-entry and posting-slice-header overhead.
+const perTokenOverheadBytes = 48
+
+// docBuild accumulates one candidate document's postings before admission.
+type docBuild struct {
+	// fieldTF[field][term] = capped term frequency in that field.
+	titleTF map[string]uint8
+	tagTF   map[string]uint8
+	bodyTF  map[string]uint8
+	terms   map[string]struct{} // union of terms across fields (for docFreq)
+}
+
+// Build constructs a SearchIndex from the posts in idx using the given search
+// configuration. Admission is document-granular and deterministic: posts are
+// considered in the scanner's post order (date descending) and admission stops
+// before a document that would exceed max_docs, max_tokens, or max_index_bytes.
+// A document is never partially indexed. When truncation occurs the incomplete
+// index is still returned with Truncated()==true so content keeps serving.
+//
+// Build never returns nil; an empty corpus yields an empty, queryable index.
+func Build(ctx context.Context, idx *content.Index, cfg config.SearchConfig, generation uint64) *SearchIndex {
+	tracer := otel.Tracer("github.com/khaines/blogflow/search")
+	ctx, span := tracer.Start(ctx, "search.IndexBuild")
+	defer span.End()
+
+	si := &SearchIndex{
+		postings:   make(map[string][]Posting),
+		docFreq:    make(map[string]int),
+		generation: generation,
+		cfg:        cfg,
+	}
+
+	if idx != nil {
+		si.build(ctx, idx.Posts)
+	}
+
+	// Postings are appended in ascending DocID order (documents are admitted in
+	// order and each doc's postings are added together), so no sort is required
+	// to keep them DocID-sorted. Term order within a doc is stabilized below.
+	span.SetAttributes(
+		attribute.Int("search.index_docs", len(si.docs)),
+		attribute.Int("search.index_tokens", si.tokenCount),
+		attribute.Bool("search.truncated", si.truncated),
+	)
+	return si
+}
+
+func (si *SearchIndex) build(ctx context.Context, posts []*content.Post) {
+	for _, post := range posts {
+		if ctx.Err() != nil {
+			return
+		}
+		if post == nil {
+			continue
+		}
+		cand := buildDoc(post)
+
+		postingCount := len(cand.titleTF) + len(cand.tagTF) + len(cand.bodyTF)
+		delta := si.candidateBytes(post, cand)
+
+		// Document-granular cap checks. Stop before admitting a doc that would
+		// exceed any cap; never partially index a document. A non-positive cap
+		// means "unlimited" for that dimension, consistently across all three
+		// caps (memory stays bounded by whichever caps are positive).
+		if si.cfg.MaxDocs > 0 && len(si.docs) >= si.cfg.MaxDocs {
+			si.markTruncated(TruncationMaxDocs)
+			return
+		}
+		if si.cfg.MaxTokens > 0 && si.tokenCount+postingCount > si.cfg.MaxTokens {
+			si.markTruncated(TruncationMaxTokens)
+			return
+		}
+		if si.cfg.MaxIndexBytes > 0 && si.logicalBytes+delta > si.cfg.MaxIndexBytes {
+			si.markTruncated(TruncationMaxBytes)
+			return
+		}
+
+		si.admit(post, cand, delta)
+	}
+}
+
+// candidateBytes returns the logical-byte delta of admitting this candidate,
+// using the same estimator exported by the memory metric.
+func (si *SearchIndex) candidateBytes(post *content.Post, cand *docBuild) int64 {
+	var b int64
+	b += int64(len(post.Slug)) + int64(len(post.Title)) + perDocOverheadBytes
+	for _, tag := range post.Tags {
+		b += int64(len(tag))
+	}
+	postingCount := len(cand.titleTF) + len(cand.tagTF) + len(cand.bodyTF)
+	b += int64(postingCount) * 8
+	for term := range cand.terms {
+		if _, exists := si.postings[term]; !exists {
+			b += int64(len(term)) + perTokenOverheadBytes
+		}
+	}
+	return b
+}
+
+// admit adds a fully-vetted candidate document to the index.
+func (si *SearchIndex) admit(post *content.Post, cand *docBuild, delta int64) {
+	id := uint32(len(si.docs)) //nolint:gosec // G115: len(si.docs) is bounded by max_docs (validated <= 1e6), well within uint32
+	tags := make([]string, len(post.Tags))
+	copy(tags, post.Tags)
+	si.docs = append(si.docs, SearchDoc{
+		ID:    id,
+		Slug:  post.Slug,
+		Title: post.Title,
+		Tags:  tags,
+		Date:  post.Date,
+	})
+
+	si.addPostings(id, cand.titleTF, FieldTitle)
+	si.addPostings(id, cand.tagTF, FieldTag)
+	si.addPostings(id, cand.bodyTF, FieldBody)
+	for term := range cand.terms {
+		si.docFreq[term]++
+	}
+	si.logicalBytes += delta
+}
+
+// addPostings appends this document's postings for one field. Terms are added
+// in sorted order so index construction is deterministic for a given corpus.
+func (si *SearchIndex) addPostings(id uint32, tf map[string]uint8, field uint8) {
+	if len(tf) == 0 {
+		return
+	}
+	terms := make([]string, 0, len(tf))
+	for t := range tf {
+		terms = append(terms, t)
+	}
+	sort.Strings(terms)
+	for _, t := range terms {
+		si.postings[t] = append(si.postings[t], Posting{DocID: id, TF: tf[t], Field: field})
+		si.tokenCount++
+	}
+}
+
+func (si *SearchIndex) markTruncated(reason TruncationReason) {
+	si.truncated = true
+	if si.reason == TruncationNone {
+		si.reason = reason
+	}
+}
+
+// buildDoc tokenizes a post's title, tags, and body into per-field capped term
+// frequencies and the union of terms across fields.
+func buildDoc(post *content.Post) *docBuild {
+	d := &docBuild{
+		titleTF: map[string]uint8{},
+		tagTF:   map[string]uint8{},
+		bodyTF:  map[string]uint8{},
+		terms:   map[string]struct{}{},
+	}
+	addField(d.titleTF, d.terms, tokenize(post.Title))
+	for _, tag := range post.Tags {
+		addField(d.tagTF, d.terms, tokenize(tag))
+	}
+	addField(d.bodyTF, d.terms, tokenize(post.PlainText()))
+	return d
+}
+
+// addField accumulates capped term frequencies for one field and records the
+// terms in the document-wide union set.
+func addField(tf map[string]uint8, terms map[string]struct{}, tokens []string) {
+	for _, t := range tokens {
+		if tf[t] < 255 {
+			tf[t]++
+		}
+		terms[t] = struct{}{}
+	}
+}
+
+// Generation returns the content generation this index was built from.
+func (si *SearchIndex) Generation() uint64 { return si.generation }
+
+// DocCount returns the number of admitted documents.
+func (si *SearchIndex) DocCount() int { return len(si.docs) }
+
+// TokenCount returns the number of indexed posting entries.
+func (si *SearchIndex) TokenCount() int { return si.tokenCount }
+
+// LogicalBytes returns the conservative logical byte estimate of the active
+// index (distinct from actual Go heap usage).
+func (si *SearchIndex) LogicalBytes() int64 { return si.logicalBytes }
+
+// Truncated reports whether admission stopped early due to a cap.
+func (si *SearchIndex) Truncated() bool { return si.truncated }
+
+// TruncationReason returns the first cap that triggered truncation, or the
+// empty reason when the index is complete.
+func (si *SearchIndex) TruncationReason() TruncationReason { return si.reason }

--- a/internal/search/index_test.go
+++ b/internal/search/index_test.go
@@ -1,0 +1,167 @@
+package search
+
+import (
+	"context"
+	"testing"
+
+	"github.com/khaines/blogflow/internal/content"
+)
+
+// TestBuild_LogicalBytesEstimate locks the documented logical-byte estimator
+// for a known tiny corpus.
+func TestBuild_LogicalBytesEstimate(t *testing.T) {
+	// slug "a" (1) + title "" (0) + tags (0) + 16 overhead = 17
+	// body "go go" -> 1 posting (8 bytes); 1 unique token "go" -> 2+48 = 50
+	// total = 17 + 8 + 50 = 75
+	idx := mkIndex(mkPost("a", "", nil, date(2026, 1, 1), "go go"))
+	si := Build(context.Background(), idx, testCfg(), 1)
+	if got := si.LogicalBytes(); got != 75 {
+		t.Fatalf("LogicalBytes = %d, want 75", got)
+	}
+	if si.TokenCount() != 1 {
+		t.Fatalf("TokenCount = %d, want 1", si.TokenCount())
+	}
+	if si.DocCount() != 1 {
+		t.Fatalf("DocCount = %d, want 1", si.DocCount())
+	}
+}
+
+func TestBuild_EmptyCorpus(t *testing.T) {
+	si := Build(context.Background(), mkIndex(), testCfg(), 7)
+	if si == nil {
+		t.Fatal("Build returned nil for empty corpus")
+	}
+	if si.DocCount() != 0 || si.Truncated() {
+		t.Fatalf("empty corpus: docs=%d truncated=%v", si.DocCount(), si.Truncated())
+	}
+	if si.Generation() != 7 {
+		t.Errorf("Generation = %d, want 7", si.Generation())
+	}
+	resp, err := si.Search(context.Background(), mkIndex(), "go", SearchOptions{Limit: 20})
+	if err != nil {
+		t.Fatalf("query on empty index: %v", err)
+	}
+	if resp.Total != 0 {
+		t.Errorf("empty index Total = %d, want 0", resp.Total)
+	}
+}
+
+func TestBuild_NilIndex(t *testing.T) {
+	si := Build(context.Background(), nil, testCfg(), 1)
+	if si == nil || si.DocCount() != 0 {
+		t.Fatal("Build(nil) should return an empty non-nil index")
+	}
+}
+
+// TestBuild_TruncateMaxDocs stops admission at the document boundary and reports
+// the reason.
+func TestBuild_TruncateMaxDocs(t *testing.T) {
+	cfg := testCfg()
+	cfg.MaxDocs = 2
+	idx := mkIndex(
+		mkPost("d1", "one", nil, date(2026, 1, 3), "alpha"),
+		mkPost("d2", "two", nil, date(2026, 1, 2), "beta"),
+		mkPost("d3", "three", nil, date(2026, 1, 1), "gamma"),
+	)
+	si := Build(context.Background(), idx, cfg, 1)
+	if si.DocCount() != 2 {
+		t.Fatalf("DocCount = %d, want 2", si.DocCount())
+	}
+	if !si.Truncated() || si.TruncationReason() != TruncationMaxDocs {
+		t.Fatalf("truncated=%v reason=%q, want true/max_docs", si.Truncated(), si.TruncationReason())
+	}
+	// The third document must not be searchable (never partially indexed).
+	resp, _ := si.Search(context.Background(), idx, "gamma", SearchOptions{Limit: 20})
+	if resp.Total != 0 {
+		t.Errorf("truncated-out doc is searchable: total=%d", resp.Total)
+	}
+}
+
+// TestBuild_TruncateMaxTokens stops when the posting budget is exhausted.
+func TestBuild_TruncateMaxTokens(t *testing.T) {
+	cfg := testCfg()
+	cfg.MaxTokens = 1 // each doc contributes exactly one body posting
+	idx := mkIndex(
+		mkPost("d1", "", nil, date(2026, 1, 2), "alpha"),
+		mkPost("d2", "", nil, date(2026, 1, 1), "beta"),
+	)
+	si := Build(context.Background(), idx, cfg, 1)
+	if si.DocCount() != 1 {
+		t.Fatalf("DocCount = %d, want 1", si.DocCount())
+	}
+	if si.TruncationReason() != TruncationMaxTokens {
+		t.Fatalf("reason = %q, want max_tokens", si.TruncationReason())
+	}
+}
+
+// TestBuild_TruncateMaxBytes stops when the logical byte budget is exhausted.
+func TestBuild_TruncateMaxBytes(t *testing.T) {
+	cfg := testCfg()
+	// First doc "aa"/body "x": 2 + 16 + 8 + (1+48) = 75 bytes. Budget 100 admits
+	// one doc; the second would push past 100.
+	cfg.MaxIndexBytes = 100
+	idx := mkIndex(
+		mkPost("aa", "", nil, date(2026, 1, 2), "x"),
+		mkPost("bb", "", nil, date(2026, 1, 1), "y"),
+	)
+	si := Build(context.Background(), idx, cfg, 1)
+	if si.DocCount() != 1 {
+		t.Fatalf("DocCount = %d, want 1 (bytes=%d)", si.DocCount(), si.LogicalBytes())
+	}
+	if si.TruncationReason() != TruncationMaxBytes {
+		t.Fatalf("reason = %q, want max_index_bytes", si.TruncationReason())
+	}
+}
+
+func TestBuild_NoTruncationWithDefaults(t *testing.T) {
+	si := Build(context.Background(), baseCorpus(), testCfg(), 1)
+	if si.Truncated() {
+		t.Errorf("default caps should not truncate the tiny corpus")
+	}
+}
+
+// TestBuild_NonPositiveMaxDocsMeansUnlimited verifies max_docs <= 0 is treated
+// as "unlimited" (consistent with max_tokens/max_index_bytes), not as an
+// index-nothing cap. This guards against a restart-scoped reload feeding a
+// degenerate cap into the rebuild and silently emptying the index.
+func TestBuild_NonPositiveMaxDocsMeansUnlimited(t *testing.T) {
+	for _, maxDocs := range []int{0, -1} {
+		cfg := testCfg()
+		cfg.MaxDocs = maxDocs
+		si := Build(context.Background(), baseCorpus(), cfg, 1)
+		if si.DocCount() != 3 {
+			t.Errorf("max_docs=%d: DocCount = %d, want 3 (unlimited)", maxDocs, si.DocCount())
+		}
+		if si.Truncated() {
+			t.Errorf("max_docs=%d: should not truncate on doc count", maxDocs)
+		}
+	}
+}
+
+// TestSearch_Pagination exercises limit/offset windows and page-overflow.
+func TestSearch_Pagination(t *testing.T) {
+	posts := make([]*content.Post, 0, 5)
+	for i, slug := range []string{"p1", "p2", "p3", "p4", "p5"} {
+		// All match "term"; distinct dates keep ordering deterministic.
+		posts = append(posts, mkPost(slug, "term", nil, date(2026, 1, 10-i), "term"))
+	}
+	idx := mkIndex(posts...)
+	si := Build(context.Background(), idx, testCfg(), 1)
+
+	page1, _ := si.Search(context.Background(), idx, "term", SearchOptions{Limit: 2, Offset: 0})
+	if page1.Total != 5 || len(page1.Results) != 2 || page1.Page != 1 || page1.TotalPages != 3 {
+		t.Fatalf("page1: total=%d n=%d page=%d/%d", page1.Total, len(page1.Results), page1.Page, page1.TotalPages)
+	}
+	page3, _ := si.Search(context.Background(), idx, "term", SearchOptions{Limit: 2, Offset: 4})
+	if len(page3.Results) != 1 || page3.Page != 3 {
+		t.Fatalf("page3: n=%d page=%d", len(page3.Results), page3.Page)
+	}
+	// Overflow: offset beyond total -> empty page, true last page reported.
+	overflow, _ := si.Search(context.Background(), idx, "term", SearchOptions{Limit: 2, Offset: 10})
+	if len(overflow.Results) != 0 {
+		t.Fatalf("overflow should have 0 results, got %d", len(overflow.Results))
+	}
+	if overflow.Page != 6 || overflow.TotalPages != 3 {
+		t.Errorf("overflow paging = page %d of %d, want 6 of 3", overflow.Page, overflow.TotalPages)
+	}
+}

--- a/internal/search/metrics.go
+++ b/internal/search/metrics.go
@@ -1,0 +1,170 @@
+package search
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// searchBuckets are histogram buckets tuned for search latency, which the
+// design targets at p50 ≤ 10 ms / p95 ≤ 50 ms / p99 ≤ 150 ms.
+var searchBuckets = []float64{0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0}
+
+// resultCountBuckets bucket the number of results returned per query.
+var resultCountBuckets = []float64{0, 1, 2, 5, 10, 20, 50, 100, 250, 500, 1000}
+
+var (
+	queriesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "blogflow_search_queries_total",
+			Help: "Total search requests handled, by outcome status (ok, invalid, error).",
+		},
+		[]string{"status"},
+	)
+
+	queryDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "blogflow_search_query_duration_seconds",
+			Help:    "End-to-end search handler latency in seconds, by status.",
+			Buckets: searchBuckets,
+		},
+		[]string{"status"},
+	)
+
+	resultsTotal = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "blogflow_search_results_total",
+			Help:    "Distribution of result counts per successful query.",
+			Buckets: resultCountBuckets,
+		},
+	)
+
+	zeroResultsTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "blogflow_search_zero_results_total",
+			Help: "Count of valid queries returning zero results.",
+		},
+	)
+
+	indexDocuments = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "blogflow_search_index_documents",
+			Help: "Number of posts in the active search index.",
+		},
+	)
+
+	indexTokens = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "blogflow_search_index_tokens",
+			Help: "Number of indexed token occurrences in the active search index.",
+		},
+	)
+
+	indexRebuildDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "blogflow_search_index_rebuild_duration_seconds",
+			Help:    "Search index rebuild duration during content scans, by status.",
+			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0},
+		},
+		[]string{"status"},
+	)
+
+	indexMemoryBytes = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "blogflow_search_index_memory_bytes",
+			Help: "Active logical index byte estimate (distinct from actual Go heap).",
+		},
+	)
+
+	indexRebuildPeakBytes = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "blogflow_search_index_rebuild_peak_bytes",
+			Help: "Peak logical bytes observed during the latest rebuild.",
+		},
+	)
+
+	indexTruncatedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "blogflow_search_index_truncated_total",
+			Help: "Count of rebuilds that published a truncated index, by reason.",
+		},
+		[]string{"reason"},
+	)
+
+	snapshotGeneration = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "blogflow_search_snapshot_generation",
+			Help: "Current published snapshot generation.",
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(
+		queriesTotal,
+		queryDuration,
+		resultsTotal,
+		zeroResultsTotal,
+		indexDocuments,
+		indexTokens,
+		indexRebuildDuration,
+		indexMemoryBytes,
+		indexRebuildPeakBytes,
+		indexTruncatedTotal,
+		snapshotGeneration,
+	)
+}
+
+// Query outcome statuses used as metric labels.
+const (
+	StatusOK      = "ok"
+	StatusInvalid = "invalid"
+	StatusError   = "error"
+)
+
+// RecordQuery records a completed search request's outcome and latency.
+func RecordQuery(status string, d time.Duration) {
+	queriesTotal.WithLabelValues(status).Inc()
+	queryDuration.WithLabelValues(status).Observe(d.Seconds())
+}
+
+// RecordResults records the result-count distribution for a successful query
+// and increments the zero-result counter when appropriate.
+func RecordResults(count int) {
+	resultsTotal.Observe(float64(count))
+	if count == 0 {
+		zeroResultsTotal.Inc()
+	}
+}
+
+// ObserveRebuild publishes gauges and the rebuild histogram for a successful
+// index build. peakBytes is the peak logical estimate while both the old and
+// new generations were live.
+func ObserveRebuild(si *SearchIndex, d time.Duration, peakBytes int64) {
+	indexRebuildDuration.WithLabelValues(StatusOK).Observe(d.Seconds())
+	if si == nil {
+		return
+	}
+	indexDocuments.Set(float64(len(si.docs)))
+	indexTokens.Set(float64(si.tokenCount))
+	indexMemoryBytes.Set(float64(si.logicalBytes))
+	indexRebuildPeakBytes.Set(float64(peakBytes))
+	snapshotGeneration.Set(float64(si.generation))
+	if si.truncated {
+		indexTruncatedTotal.WithLabelValues(string(si.reason)).Inc()
+	}
+}
+
+// RecordRebuildFailure records a failed search index build for a generation.
+// Content still serves with a nil search index; the /search route returns 503
+// until the next successful build. It advances the snapshot-generation gauge and
+// zeroes the active-index gauges so dashboards reflect that no search index is
+// currently published (rather than showing the last successful values).
+func RecordRebuildFailure(gen uint64, d time.Duration) {
+	indexRebuildDuration.WithLabelValues(StatusError).Observe(d.Seconds())
+	indexDocuments.Set(0)
+	indexTokens.Set(0)
+	indexMemoryBytes.Set(0)
+	indexRebuildPeakBytes.Set(0)
+	snapshotGeneration.Set(float64(gen))
+}

--- a/internal/search/metrics_test.go
+++ b/internal/search/metrics_test.go
@@ -1,0 +1,101 @@
+package search
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// TestRecordQuery_IncrementsByStatus verifies the query counter and latency
+// histogram record per-status outcomes.
+func TestRecordQuery_IncrementsByStatus(t *testing.T) {
+	for _, status := range []string{StatusOK, StatusInvalid, StatusError} {
+		before := testutil.ToFloat64(queriesTotal.WithLabelValues(status))
+		RecordQuery(status, 3*time.Millisecond)
+		after := testutil.ToFloat64(queriesTotal.WithLabelValues(status))
+		if after-before != 1 {
+			t.Errorf("queriesTotal{status=%s} delta = %v, want 1", status, after-before)
+		}
+	}
+}
+
+// TestRecordResults_ZeroResultCounter verifies the zero-result counter fires
+// only on empty result sets.
+func TestRecordResults_ZeroResultCounter(t *testing.T) {
+	before := testutil.ToFloat64(zeroResultsTotal)
+	RecordResults(0)
+	if got := testutil.ToFloat64(zeroResultsTotal) - before; got != 1 {
+		t.Errorf("zeroResultsTotal delta on 0 results = %v, want 1", got)
+	}
+	steady := testutil.ToFloat64(zeroResultsTotal)
+	RecordResults(7)
+	if got := testutil.ToFloat64(zeroResultsTotal); got != steady {
+		t.Errorf("zeroResultsTotal changed on non-zero results: %v", got-steady)
+	}
+}
+
+// TestObserveRebuild_SetsGauges verifies rebuild observation updates the index
+// gauges and the snapshot-generation gauge.
+func TestObserveRebuild_SetsGauges(t *testing.T) {
+	si := Build(context.Background(), baseCorpus(), testCfg(), 42)
+	ObserveRebuild(si, 2*time.Millisecond, si.LogicalBytes())
+
+	if got := testutil.ToFloat64(indexDocuments); got != float64(si.DocCount()) {
+		t.Errorf("indexDocuments = %v, want %d", got, si.DocCount())
+	}
+	if got := testutil.ToFloat64(indexTokens); got != float64(si.TokenCount()) {
+		t.Errorf("indexTokens = %v, want %d", got, si.TokenCount())
+	}
+	if got := testutil.ToFloat64(indexMemoryBytes); got != float64(si.LogicalBytes()) {
+		t.Errorf("indexMemoryBytes = %v, want %d", got, si.LogicalBytes())
+	}
+	if got := testutil.ToFloat64(snapshotGeneration); got != 42 {
+		t.Errorf("snapshotGeneration = %v, want 42", got)
+	}
+}
+
+// TestObserveRebuild_TruncationCounter verifies a truncated build increments the
+// truncation counter labelled by reason.
+func TestObserveRebuild_TruncationCounter(t *testing.T) {
+	cfg := testCfg()
+	cfg.MaxDocs = 1 // force truncation on the 3-doc corpus
+	si := Build(context.Background(), baseCorpus(), cfg, 1)
+	if !si.Truncated() {
+		t.Fatal("expected truncated index for the test")
+	}
+	label := string(TruncationMaxDocs)
+	before := testutil.ToFloat64(indexTruncatedTotal.WithLabelValues(label))
+	ObserveRebuild(si, time.Millisecond, si.LogicalBytes())
+	if got := testutil.ToFloat64(indexTruncatedTotal.WithLabelValues(label)) - before; got != 1 {
+		t.Errorf("indexTruncatedTotal{reason=%s} delta = %v, want 1", label, got)
+	}
+}
+
+// TestRecordRebuildFailure_UpdatesState verifies the failure path advances the
+// snapshot-generation gauge and zeroes the active-index gauges so dashboards do
+// not show a stale healthy index while /search serves 503.
+func TestRecordRebuildFailure_UpdatesState(t *testing.T) {
+	// Seed gauges with a successful build first.
+	si := Build(context.Background(), baseCorpus(), testCfg(), 10)
+	ObserveRebuild(si, time.Millisecond, si.LogicalBytes())
+
+	RecordRebuildFailure(11, 2*time.Millisecond)
+
+	if got := testutil.ToFloat64(indexDocuments); got != 0 {
+		t.Errorf("indexDocuments after failure = %v, want 0", got)
+	}
+	if got := testutil.ToFloat64(indexTokens); got != 0 {
+		t.Errorf("indexTokens after failure = %v, want 0", got)
+	}
+	if got := testutil.ToFloat64(indexMemoryBytes); got != 0 {
+		t.Errorf("indexMemoryBytes after failure = %v, want 0", got)
+	}
+	if got := testutil.ToFloat64(indexRebuildPeakBytes); got != 0 {
+		t.Errorf("indexRebuildPeakBytes after failure = %v, want 0", got)
+	}
+	if got := testutil.ToFloat64(snapshotGeneration); got != 11 {
+		t.Errorf("snapshotGeneration after failure = %v, want 11", got)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1,0 +1,316 @@
+package search
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/khaines/blogflow/internal/content"
+	"golang.org/x/text/unicode/norm"
+)
+
+// Typed errors returned by Search. The handler maps these to HTTP status codes.
+var (
+	// ErrIndexUnavailable indicates the route is registered but this
+	// generation's search index is nil (build failed). Handler returns 503.
+	ErrIndexUnavailable = errors.New("search index unavailable")
+	// ErrQueryTooComplex indicates the query has more unique normalized terms
+	// than max_query_terms. Handler returns 400.
+	ErrQueryTooComplex = errors.New("search query too complex")
+)
+
+// Searcher executes a query against a same-generation content index and returns
+// a ranked page of results. It exists so the concrete SearchIndex can be
+// swapped for an alternative implementation (e.g. a future Bleve-backed index)
+// behind a stable boundary, per design §2.5.
+//
+// Note: the design sketches Search(ctx, *SiteSnapshot, ...); the concrete
+// signature takes the same-generation *content.Index directly to avoid an
+// import cycle between this package and the handlers package that owns
+// SiteSnapshot. The handler always passes snapshot.Content from the same
+// atomic snapshot as the SearchIndex, preserving the same-generation guarantee.
+type Searcher interface {
+	Search(ctx context.Context, src *content.Index, query string, opts SearchOptions) (SearchResponse, error)
+}
+
+// Compile-time assertion that *SearchIndex satisfies Searcher.
+var _ Searcher = (*SearchIndex)(nil)
+
+// scoreQuantum is the rounding granularity applied to scores before sorting so
+// that ranking is reproducible and float noise does not affect tie-breaks.
+const scoreQuantum = 1e6
+
+// SearchOptions controls pagination for a query.
+type SearchOptions struct { //nolint:revive // name matches the full-text-search design doc; Search prefix is intentional
+	Limit  int // per-page window; defaults to cfg.MaxResults when <= 0
+	Offset int // (page-1) * Limit
+}
+
+// SearchResult is a single ranked hit rendered by the search template. Every
+// string field is plain text escaped by html/template; none is template.HTML.
+type SearchResult struct { //nolint:revive // name matches the full-text-search design doc; Search prefix is intentional
+	Title   string
+	Slug    string
+	URL     string
+	Date    time.Time
+	Excerpt string
+	Score   float64 // ordering/metadata; not shown by the default result body
+	Tags    []string
+}
+
+// SearchResponse is the full result of a query for one page.
+type SearchResponse struct { //nolint:revive // name matches the full-text-search design doc; Search prefix is intentional
+	Query      string
+	Results    []SearchResult
+	Total      int
+	Page       int
+	TotalPages int
+	Duration   time.Duration
+	Truncated  bool
+}
+
+// scored is an intermediate (document, quantized score) pair used for ranking.
+type scored struct {
+	docID     uint32
+	quantized float64
+}
+
+// Search executes query against the index and returns the requested page of
+// ranked results. src is the same-generation content index used only to
+// re-derive excerpts for the current page; passing a different generation
+// would break the same-generation excerpt guarantee and must not happen.
+//
+// Search validates only what the index owns: index availability and query term
+// count. Query rune-length and page bounds are validated by the handler.
+func (si *SearchIndex) Search(ctx context.Context, src *content.Index, query string, opts SearchOptions) (SearchResponse, error) {
+	start := time.Now()
+	if si == nil {
+		return SearchResponse{}, ErrIndexUnavailable
+	}
+
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = si.cfg.MaxResults
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	offset := opts.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	terms := parseQueryTerms(query)
+	if len(terms) > si.cfg.MaxQueryTerms {
+		return SearchResponse{}, ErrQueryTooComplex
+	}
+
+	resp := SearchResponse{
+		Query:     query,
+		Truncated: si.truncated,
+		Duration:  0,
+	}
+
+	ranked := si.rank(terms)
+	resp.Total = len(ranked)
+	resp.TotalPages = totalPages(resp.Total, limit)
+	resp.Page = offset/limit + 1
+
+	if offset < resp.Total {
+		end := offset + limit
+		if end > resp.Total {
+			end = resp.Total
+		}
+		termSet := toSet(terms)
+		page := ranked[offset:end]
+		resp.Results = make([]SearchResult, 0, len(page))
+		for _, s := range page {
+			doc := si.docs[s.docID]
+			resp.Results = append(resp.Results, si.buildResult(doc, s.quantized, src, termSet))
+		}
+	}
+
+	resp.Duration = time.Since(start)
+	return resp, nil
+}
+
+// rank scores all documents matching any query term and returns them sorted by
+// quantized score descending, then Date descending, then Slug ascending.
+func (si *SearchIndex) rank(terms []string) []scored {
+	if len(terms) == 0 {
+		return nil
+	}
+	n := len(si.docs)
+	scores := make(map[uint32]float64)
+
+	// Accumulate contributions in sorted term order for reproducibility.
+	for _, t := range terms {
+		postings := si.postings[t]
+		if len(postings) == 0 {
+			continue
+		}
+		idf := si.idf(n, si.docFreq[t])
+		for _, p := range postings {
+			scores[p.DocID] += idf * fieldWeight(p.Field) * float64(p.TF)
+		}
+	}
+
+	ranked := make([]scored, 0, len(scores))
+	for id, sc := range scores {
+		ranked = append(ranked, scored{docID: id, quantized: quantize(sc)})
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		a, b := ranked[i], ranked[j]
+		if a.quantized != b.quantized {
+			return a.quantized > b.quantized
+		}
+		da, db := si.docs[a.docID].Date, si.docs[b.docID].Date
+		if !da.Equal(db) {
+			return da.After(db)
+		}
+		return si.docs[a.docID].Slug < si.docs[b.docID].Slug
+	})
+	return ranked
+}
+
+// idf computes the inverse document frequency for a term:
+//
+//	idf(t) = ln(1 + (N+1)/(df+1))
+func (si *SearchIndex) idf(n, df int) float64 {
+	return math.Log(1 + float64(n+1)/float64(df+1))
+}
+
+// buildResult assembles a SearchResult, re-deriving the excerpt from the
+// same-generation content index.
+func (si *SearchIndex) buildResult(doc SearchDoc, score float64, src *content.Index, termSet map[string]struct{}) SearchResult {
+	var excerpt string
+	if src != nil {
+		if post, ok := src.BySlug[doc.Slug]; ok && post != nil {
+			excerpt = makeExcerpt(post.PlainText(), termSet, si.cfg.ExcerptLength)
+		}
+	}
+	tags := make([]string, len(doc.Tags))
+	copy(tags, doc.Tags)
+	return SearchResult{
+		Title:   doc.Title,
+		Slug:    doc.Slug,
+		URL:     "/posts/" + doc.Slug,
+		Date:    doc.Date,
+		Excerpt: excerpt,
+		Score:   score,
+		Tags:    tags,
+	}
+}
+
+// makeExcerpt returns a plain-text excerpt of up to length runes, centered on
+// the first query-term match. When no term matches, the leading runes are used.
+// The result is NFC-normalized and whitespace-collapsed, with ellipses marking
+// truncation. It never contains HTML markup.
+func makeExcerpt(plain string, termSet map[string]struct{}, length int) string {
+	if length <= 0 {
+		return ""
+	}
+	display := collapseWhitespace(norm.NFC.String(plain))
+	if display == "" {
+		return ""
+	}
+	runes := []rune(display)
+	total := len(runes)
+
+	matchRune := firstMatchRuneIndex(runes, termSet)
+	var startRune int
+	if matchRune < 0 {
+		startRune = 0
+	} else {
+		startRune = matchRune - length/2
+		if startRune < 0 {
+			startRune = 0
+		}
+	}
+	endRune := startRune + length
+	if endRune > total {
+		endRune = total
+		if startRune > endRune-length {
+			startRune = endRune - length
+		}
+		if startRune < 0 {
+			startRune = 0
+		}
+	}
+
+	var b strings.Builder
+	if startRune > 0 {
+		b.WriteString("…")
+	}
+	b.WriteString(string(runes[startRune:endRune]))
+	if endRune < total {
+		b.WriteString("…")
+	}
+	return b.String()
+}
+
+// firstMatchRuneIndex returns the rune index at which the first token that
+// matches any query term begins, or -1 if none match. Matching is
+// case-insensitive; runes are compared against the normalized term set.
+func firstMatchRuneIndex(runes []rune, termSet map[string]struct{}) int {
+	if len(termSet) == 0 {
+		return -1
+	}
+	start := -1
+	for i, r := range runes {
+		if isTokenRune(r) {
+			if start < 0 {
+				start = i
+			}
+			continue
+		}
+		if start >= 0 {
+			if _, ok := termSet[strings.ToLower(string(runes[start:i]))]; ok {
+				return start
+			}
+			start = -1
+		}
+	}
+	if start >= 0 {
+		if _, ok := termSet[strings.ToLower(string(runes[start:]))]; ok {
+			return start
+		}
+	}
+	return -1
+}
+
+// collapseWhitespace replaces runs of Unicode whitespace with single spaces and
+// trims the ends.
+func collapseWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// quantize rounds a score to the fixed ranking granularity.
+func quantize(score float64) float64 {
+	return math.Round(score*scoreQuantum) / scoreQuantum
+}
+
+// totalPages returns the number of pages for total results at the given limit,
+// never less than 1.
+func totalPages(total, limit int) int {
+	if limit <= 0 {
+		return 1
+	}
+	pages := (total + limit - 1) / limit
+	if pages < 1 {
+		return 1
+	}
+	return pages
+}
+
+// toSet builds a set from a term slice.
+func toSet(terms []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(terms))
+	for _, t := range terms {
+		set[t] = struct{}{}
+	}
+	return set
+}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -1,0 +1,230 @@
+package search
+
+import (
+	"context"
+	"html/template"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/khaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/content"
+)
+
+const scoreEps = 1e-6
+
+// mkPost builds a content.Post for tests. body is treated as already-rendered
+// HTML (PlainText strips tags), so plain strings work directly.
+func mkPost(slug, title string, tags []string, date time.Time, body string) *content.Post {
+	p := &content.Post{
+		Slug:    slug,
+		Content: template.HTML(body), //nolint:gosec // G203: test data
+	}
+	p.Title = title
+	p.Tags = tags
+	p.Date = date
+	return p
+}
+
+// mkIndex builds a minimal content.Index (Posts + BySlug) from posts.
+func mkIndex(posts ...*content.Post) *content.Index {
+	idx := &content.Index{BySlug: make(map[string]*content.Post, len(posts))}
+	idx.Posts = posts
+	for _, p := range posts {
+		idx.BySlug[p.Slug] = p
+	}
+	return idx
+}
+
+func date(y int, m time.Month, d int) time.Time {
+	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+}
+
+// baseCorpus is the golden fixture corpus from the design (§3.3), returned in
+// scanner order (date descending).
+func baseCorpus() *content.Index {
+	d1 := mkPost("alpha", "Go Search", []string{"go"}, date(2026, 1, 2), "go go search")
+	d2 := mkPost("beta", "Search", nil, date(2026, 1, 3), "go")
+	d3 := mkPost("gamma", "Other", []string{"go"}, date(2026, 1, 1), "search search")
+	return mkIndex(d2, d1, d3) // date desc: 01-03, 01-02, 01-01
+}
+
+func testCfg() config.SearchConfig {
+	c := config.Default().Search
+	c.Enabled = true
+	return c
+}
+
+func runQuery(t *testing.T, idx *content.Index, query string) SearchResponse {
+	t.Helper()
+	si := Build(context.Background(), idx, testCfg(), 1)
+	resp, err := si.Search(context.Background(), idx, query, SearchOptions{Limit: 20})
+	if err != nil {
+		t.Fatalf("Search(%q) error: %v", query, err)
+	}
+	return resp
+}
+
+func assertOrder(t *testing.T, resp SearchResponse, wantSlugs []string) {
+	t.Helper()
+	if len(resp.Results) != len(wantSlugs) {
+		t.Fatalf("got %d results, want %d: %+v", len(resp.Results), len(wantSlugs), slugsOf(resp))
+	}
+	for i, want := range wantSlugs {
+		if resp.Results[i].Slug != want {
+			t.Fatalf("result[%d].Slug = %q, want %q (order %v)", i, resp.Results[i].Slug, want, slugsOf(resp))
+		}
+	}
+}
+
+func slugsOf(resp SearchResponse) []string {
+	out := make([]string, len(resp.Results))
+	for i, r := range resp.Results {
+		out[i] = r.Slug
+	}
+	return out
+}
+
+// TestSearch_GoldenRanking pins the exact weighted TF-IDF scores and ordering
+// from the design's golden fixtures.
+func TestSearch_GoldenRanking(t *testing.T) {
+	idx := baseCorpus()
+	ln2 := math.Log(2)
+
+	t.Run("query go", func(t *testing.T) {
+		resp := runQuery(t, idx, "go")
+		assertOrder(t, resp, []string{"alpha", "gamma", "beta"})
+		wantScores := map[string]float64{"alpha": 7 * ln2, "gamma": 2 * ln2, "beta": 1 * ln2}
+		for _, r := range resp.Results {
+			if math.Abs(r.Score-quantize(wantScores[r.Slug])) > scoreEps {
+				t.Errorf("score(%s) = %f, want %f", r.Slug, r.Score, quantize(wantScores[r.Slug]))
+			}
+		}
+		// Spot-check the documented decimal values.
+		if math.Abs(resp.Results[0].Score-4.852030) > scoreEps {
+			t.Errorf("alpha score = %f, want 4.852030", resp.Results[0].Score)
+		}
+	})
+
+	t.Run("query search", func(t *testing.T) {
+		resp := runQuery(t, idx, "search")
+		assertOrder(t, resp, []string{"alpha", "beta", "gamma"})
+		want := []float64{4 * ln2, 3 * ln2, 2 * ln2}
+		for i, r := range resp.Results {
+			if math.Abs(r.Score-quantize(want[i])) > scoreEps {
+				t.Errorf("result[%d]=%s score %f, want %f", i, r.Slug, r.Score, quantize(want[i]))
+			}
+		}
+	})
+
+	t.Run("query go go equals go", func(t *testing.T) {
+		a := runQuery(t, idx, "go")
+		b := runQuery(t, idx, "go go")
+		assertOrder(t, b, slugsOf(a))
+		for i := range a.Results {
+			if a.Results[i].Score != b.Results[i].Score {
+				t.Errorf("duplicate term changed score: %f vs %f", a.Results[i].Score, b.Results[i].Score)
+			}
+		}
+	})
+
+	t.Run("query search go OR semantics with date tie-break", func(t *testing.T) {
+		resp := runQuery(t, idx, "search go")
+		// D1 top; D2 and D3 tie at 4*ln2 -> date desc puts beta (01-03) before gamma (01-01).
+		assertOrder(t, resp, []string{"alpha", "beta", "gamma"})
+		if math.Abs(resp.Results[0].Score-quantize(11*ln2)) > scoreEps {
+			t.Errorf("alpha combined score = %f, want %f", resp.Results[0].Score, quantize(11*ln2))
+		}
+		if resp.Results[1].Score != resp.Results[2].Score {
+			t.Errorf("expected beta/gamma tie, got %f vs %f", resp.Results[1].Score, resp.Results[2].Score)
+		}
+	})
+}
+
+// TestSearch_TFCapping verifies term frequency is capped at 255 and scored with
+// the capped value.
+func TestSearch_TFCapping(t *testing.T) {
+	body := ""
+	for i := 0; i < 300; i++ {
+		body += "cap "
+	}
+	idx := mkIndex(mkPost("capdoc", "Title", nil, date(2026, 1, 1), body))
+	si := Build(context.Background(), idx, testCfg(), 1)
+
+	if got := si.postings["cap"][0].TF; got != 255 {
+		t.Fatalf("stored TF = %d, want 255 (capped)", got)
+	}
+	resp, err := si.Search(context.Background(), idx, "cap", SearchOptions{Limit: 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// N=1, df=1 -> idf=ln(2); body weight 1.0; TF 255 -> 255*ln(2).
+	want := quantize(255 * math.Log(2))
+	if math.Abs(resp.Results[0].Score-want) > scoreEps {
+		t.Errorf("capped score = %f, want %f (176.752531)", resp.Results[0].Score, want)
+	}
+}
+
+// TestSearch_TieBreaks verifies equal quantized scores break by date desc, then
+// slug asc when dates are equal.
+func TestSearch_TieBreaks(t *testing.T) {
+	// Three docs identical except date/slug, each matching "term" once in body.
+	same := date(2026, 5, 1)
+	idx := mkIndex(
+		mkPost("bbb", "T", nil, same, "term"),
+		mkPost("aaa", "T", nil, same, "term"),
+		mkPost("older", "T", nil, date(2026, 4, 1), "term"),
+		mkPost("newer", "T", nil, date(2026, 6, 1), "term"),
+	)
+	resp := runQuery(t, idx, "term")
+	// newer (06-01) first, then the same-date pair by slug asc (aaa, bbb), then older.
+	assertOrder(t, resp, []string{"newer", "aaa", "bbb", "older"})
+}
+
+// TestSearch_MultiFieldRanking verifies a multi-field match outranks a body-only
+// match.
+func TestSearch_MultiFieldRanking(t *testing.T) {
+	idx := mkIndex(
+		mkPost("titlebody", "search", nil, date(2026, 1, 1), "search here"),
+		mkPost("bodyonly", "Other", nil, date(2026, 1, 2), "search here"),
+	)
+	resp := runQuery(t, idx, "search")
+	assertOrder(t, resp, []string{"titlebody", "bodyonly"})
+	if resp.Results[0].Score <= resp.Results[1].Score {
+		t.Errorf("multi-field score %f should exceed body-only %f", resp.Results[0].Score, resp.Results[1].Score)
+	}
+}
+
+// TestSearch_NoResults returns an explicit empty state, page 1 of 1.
+func TestSearch_NoResults(t *testing.T) {
+	resp := runQuery(t, baseCorpus(), "nonexistentterm")
+	if resp.Total != 0 || len(resp.Results) != 0 {
+		t.Fatalf("expected no results, got total=%d results=%d", resp.Total, len(resp.Results))
+	}
+	if resp.Page != 1 || resp.TotalPages != 1 {
+		t.Errorf("no-results paging = page %d of %d, want 1 of 1", resp.Page, resp.TotalPages)
+	}
+}
+
+// TestSearch_QueryTooComplex rejects queries with more unique terms than allowed.
+func TestSearch_QueryTooComplex(t *testing.T) {
+	cfg := testCfg()
+	cfg.MaxQueryTerms = 3
+	si := Build(context.Background(), baseCorpus(), cfg, 1)
+	_, err := si.Search(context.Background(), baseCorpus(), "one two three four five", SearchOptions{Limit: 20})
+	if err != ErrQueryTooComplex {
+		t.Fatalf("expected ErrQueryTooComplex, got %v", err)
+	}
+	// At the limit it is accepted.
+	if _, err := si.Search(context.Background(), baseCorpus(), "one two three", SearchOptions{Limit: 20}); err != nil {
+		t.Fatalf("query at term limit should succeed, got %v", err)
+	}
+}
+
+// TestSearch_NilIndex returns ErrIndexUnavailable.
+func TestSearch_NilIndex(t *testing.T) {
+	var si *SearchIndex
+	if _, err := si.Search(context.Background(), nil, "go", SearchOptions{}); err != ErrIndexUnavailable {
+		t.Fatalf("nil index Search = %v, want ErrIndexUnavailable", err)
+	}
+}

--- a/internal/search/tokenizer.go
+++ b/internal/search/tokenizer.go
@@ -1,0 +1,117 @@
+// Package search provides BlogFlow's optional server-side full-text search:
+// a lightweight in-memory inverted index built from the content scan, with
+// Unicode-aware tokenization, deterministic weighted TF-IDF ranking, and
+// on-demand plain-text excerpts. It requires no client-side JavaScript.
+//
+// The index is immutable once built and is published together with the
+// content generation it was derived from, so a query never mixes a search
+// index with content from a different generation.
+package search
+
+import (
+	"sort"
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// normalize applies the canonical v1 search normalization: Unicode NFC
+// normalization followed by lower-casing. Query strings and document text are
+// normalized identically before tokenization and before any rune-length
+// counting so that matching is deterministic and case-insensitive.
+func normalize(s string) string {
+	return strings.ToLower(norm.NFC.String(s))
+}
+
+// isTokenRune reports whether r is part of a token. Tokens are maximal runs of
+// letters and digits; everything else (whitespace, punctuation, symbols) is a
+// delimiter. This preserves CJK text as whole-rune tokens; CJK bigrams are
+// deliberately deferred to a future revision.
+func isTokenRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+// tokenizeInto appends the tokens of an already-normalized string to dst and
+// returns the extended slice. Splitting is allocation-light and uses no
+// regular expressions (ReDoS-safe).
+func tokenizeInto(dst []string, normalized string) []string {
+	start := -1
+	for i, r := range normalized {
+		if isTokenRune(r) {
+			if start < 0 {
+				start = i
+			}
+			continue
+		}
+		if start >= 0 {
+			dst = append(dst, normalized[start:i])
+			start = -1
+		}
+	}
+	if start >= 0 {
+		dst = append(dst, normalized[start:])
+	}
+	return dst
+}
+
+// tokenizeNormalized splits an already-normalized string into tokens.
+func tokenizeNormalized(normalized string) []string {
+	return tokenizeInto(nil, normalized)
+}
+
+// tokenize normalizes then tokenizes a raw string.
+func tokenize(s string) []string {
+	return tokenizeNormalized(normalize(s))
+}
+
+// parseQueryTerms normalizes, tokenizes, de-duplicates, and lexicographically
+// sorts the query's terms. Duplicate normalized terms are collapsed so that a
+// query like "go go" scores identically to "go". Sorting makes score
+// accumulation order deterministic.
+func parseQueryTerms(q string) []string {
+	raw := tokenize(q)
+	if len(raw) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(raw))
+	terms := make([]string, 0, len(raw))
+	for _, t := range raw {
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		terms = append(terms, t)
+	}
+	sort.Strings(terms)
+	return terms
+}
+
+// countRunes returns the number of runes in s. Used for query length limits,
+// which are expressed in normalized runes rather than bytes.
+func countRunes(s string) int {
+	n := 0
+	for range s {
+		n++
+	}
+	return n
+}
+
+// NormalizeQuery trims surrounding whitespace and applies the canonical search
+// normalization (Unicode NFC + lower-case). The handler uses it to detect
+// empty/whitespace queries and to count query length in normalized runes.
+func NormalizeQuery(raw string) string {
+	return normalize(strings.TrimSpace(raw))
+}
+
+// RuneLen returns the number of runes in s. Exposed so the handler can count
+// normalized query length for min/max length validation.
+func RuneLen(s string) int {
+	return countRunes(s)
+}
+
+// CountQueryTerms returns the number of unique normalized terms in a raw query.
+// The handler uses it as a span attribute without exposing the raw query.
+func CountQueryTerms(q string) int {
+	return len(parseQueryTerms(q))
+}

--- a/internal/search/tokenizer_test.go
+++ b/internal/search/tokenizer_test.go
@@ -1,0 +1,90 @@
+package search
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"lowercase", "Go Internals", "go internals"},
+		{"unicode nfc + fold", "CAFÉ", "café"},
+		{"already normal", "overlay filesystem", "overlay filesystem"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalize(tt.in); got != tt.want {
+				t.Errorf("normalize(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTokenize(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"simple", "go go search", []string{"go", "go", "search"}},
+		{"punctuation delimiters", "hello, world! foo-bar", []string{"hello", "world", "foo", "bar"}},
+		{"mixed case", "Go INTERNALS", []string{"go", "internals"}},
+		{"digits kept", "go1.26 release", []string{"go1", "26", "release"}},
+		{"empty", "", nil},
+		{"only delimiters", "  --  ", nil},
+		{"leading/trailing delims", "!go!", []string{"go"}},
+		{"unicode accent folded to single token", "café au lait", []string{"café", "au", "lait"}},
+		{"cjk kept whole (no bigrams)", "東京", []string{"東京"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tokenize(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("tokenize(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseQueryTerms_DedupeAndSort(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"dedupe repeated", "go go", []string{"go"}},
+		{"sort lexicographically", "search go", []string{"go", "search"}},
+		{"dedupe and sort", "Go SEARCH go search", []string{"go", "search"}},
+		{"empty", "   ", nil},
+		{"punctuation only", "!!! ???", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseQueryTerms(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseQueryTerms(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeQueryAndRuneLen(t *testing.T) {
+	// Trimming + normalization is what the handler counts for length limits.
+	if got := NormalizeQuery("   Hello World   "); got != "hello world" {
+		t.Errorf("NormalizeQuery trim/normalize = %q", got)
+	}
+	if got := NormalizeQuery("   \t\n "); got != "" {
+		t.Errorf("NormalizeQuery whitespace-only = %q, want empty", got)
+	}
+	// Rune length counts runes, not bytes (é is one rune, two bytes).
+	if got := RuneLen("café"); got != 4 {
+		t.Errorf("RuneLen(café) = %d, want 4", got)
+	}
+	if got := RuneLen("東京"); got != 2 {
+		t.Errorf("RuneLen(東京) = %d, want 2", got)
+	}
+}

--- a/internal/server/handlers/handlers.go
+++ b/internal/server/handlers/handlers.go
@@ -15,23 +15,46 @@ import (
 
 	"github.com/khaines/blogflow/internal/config"
 	"github.com/khaines/blogflow/internal/content"
+	"github.com/khaines/blogflow/internal/search"
 	"github.com/khaines/blogflow/internal/theme"
 )
 
+// SiteSnapshot bundles the content index and its optional search index for a
+// single reload generation. Content and search are published together via one
+// atomic pointer store so a request never observes a search index built from a
+// different content generation than the one it re-derives excerpts from.
+//
+// Search is nil when search is disabled (not built) or when this generation's
+// search build failed while the content build succeeded (the handler then
+// returns 503 until a later successful build swaps in a non-nil Search).
+type SiteSnapshot struct {
+	Generation uint64
+	Content    *content.Index
+	Search     *search.SearchIndex
+}
+
 // Deps holds shared dependencies for all handlers.
-// Both the content index and config are stored as atomic pointers so that
-// background reloaders can swap them without racing with HTTP handlers.
+// The config is stored as an atomic pointer, and the content+search snapshot is
+// stored as a single atomic pointer, so background reloaders can swap them
+// without racing with HTTP handlers.
 type Deps struct {
 	config atomic.Pointer[config.Config]
-	index  atomic.Pointer[content.Index]
+	snap   atomic.Pointer[SiteSnapshot]
+	gen    atomic.Uint64
 	Theme  *theme.Engine
 
 	// Overlay is the layered filesystem (content → theme → defaults).
 	// Used by HomeHandler to serve static HTML files.
 	Overlay fs.FS
 
+	// searchEnabled is the router-build value of search.enabled. It is fixed
+	// for the process lifetime (toggling requires a restart/router rebuild) and
+	// is surfaced to templates as PageData.Search.Enabled so global search
+	// affordances cannot diverge from whether the /search route is registered.
+	searchEnabled bool
+
 	// staticHTML caches the rendered static homepage content.
-	// Cleared on content sync (SetIndex).
+	// Cleared on content sync (SetSnapshot/SetIndex).
 	staticHTML atomic.Pointer[[]byte]
 }
 
@@ -39,7 +62,7 @@ type Deps struct {
 func NewDeps(cfg *config.Config, idx *content.Index, themeEngine *theme.Engine) *Deps {
 	d := &Deps{Theme: themeEngine}
 	d.config.Store(cfg)
-	d.index.Store(idx)
+	d.snap.Store(&SiteSnapshot{Generation: 0, Content: idx})
 	return d
 }
 
@@ -53,21 +76,57 @@ func (d *Deps) SetConfig(cfg *config.Config) {
 	d.staticHTML.Store(nil) // invalidate; homepage path may have changed
 }
 
-// LoadIndex returns the current content index. Safe for concurrent use.
-func (d *Deps) LoadIndex() *content.Index { return d.index.Load() }
+// NextGeneration returns the next monotonic snapshot generation. Reloaders call
+// it before building a search index so the search index and the snapshot share
+// one generation number.
+func (d *Deps) NextGeneration() uint64 { return d.gen.Add(1) }
 
-// SetIndex atomically replaces the content index and clears cached
-// static homepage content so the next request re-reads from the overlay FS.
-func (d *Deps) SetIndex(idx *content.Index) {
-	d.index.Store(idx)
+// SetSearchEnabled records the router-build value of search.enabled. Call once
+// during wiring, before serving traffic.
+func (d *Deps) SetSearchEnabled(v bool) { d.searchEnabled = v }
+
+// SearchEnabled reports whether the /search route is registered.
+func (d *Deps) SearchEnabled() bool { return d.searchEnabled }
+
+// LoadSnapshot returns the current content+search snapshot. Safe for concurrent
+// use; the returned snapshot and the maps/slices inside it are immutable.
+func (d *Deps) LoadSnapshot() *SiteSnapshot { return d.snap.Load() }
+
+// LoadIndex returns the current content index. Safe for concurrent use.
+func (d *Deps) LoadIndex() *content.Index {
+	if s := d.snap.Load(); s != nil {
+		return s.Content
+	}
+	return nil
+}
+
+// LoadSearch returns the current search index, or nil when search is disabled
+// or this generation's search build failed.
+func (d *Deps) LoadSearch() *search.SearchIndex {
+	if s := d.snap.Load(); s != nil {
+		return s.Search
+	}
+	return nil
+}
+
+// SetSnapshot atomically publishes a new content+search generation and clears
+// the cached static homepage.
+func (d *Deps) SetSnapshot(gen uint64, idx *content.Index, si *search.SearchIndex) {
+	d.snap.Store(&SiteSnapshot{Generation: gen, Content: idx, Search: si})
 	d.staticHTML.Store(nil) // invalidate static homepage cache
+}
+
+// SetIndex atomically replaces the content index with a new generation that has
+// no search index. Retained for callers that do not build search (e.g. tests).
+func (d *Deps) SetIndex(idx *content.Index) {
+	d.SetSnapshot(d.NextGeneration(), idx, nil)
 }
 
 // PostCount returns the number of posts in the current index.
 // Implements server.ContentChecker.
 func (d *Deps) PostCount() int {
-	if idx := d.index.Load(); idx != nil {
-		return len(idx.Posts)
+	if s := d.snap.Load(); s != nil && s.Content != nil {
+		return len(s.Content.Posts)
 	}
 	return 0
 }
@@ -82,6 +141,27 @@ type PageData struct {
 	Tag        string          // current tag filter
 	Title      string          // page title override
 	Pagination *Pagination
+	Search     *SearchData // search affordance state + search page results
+}
+
+// SearchData carries search state to templates. On every page it exposes
+// Enabled so the header/nav can render or omit a global search form. On the
+// search page it additionally carries the query, results, pagination, and any
+// validation message.
+type SearchData struct {
+	Enabled    bool                  // /search route registered at router build
+	Executed   bool                  // a query was run (vs. the landing form)
+	Query      string                // echoed, escaped by html/template
+	Results    []search.SearchResult // current page of hits
+	Total      int
+	Page       int
+	TotalPages int
+	HasPrev    bool
+	HasNext    bool
+	PrevURL    string
+	NextURL    string
+	Error      string // accessible validation/unavailable message
+	Truncated  bool   // index was truncated by caps
 }
 
 // Pagination holds paging metadata for list views.
@@ -136,7 +216,7 @@ func HomeHandler(deps *Deps) http.HandlerFunc {
 			Title: page.Title,
 		}
 
-		renderTemplate(w, r, deps.Theme, "templates/page.html", data, http.StatusOK)
+		renderTemplate(w, r, deps, "templates/page.html", data, http.StatusOK)
 	}
 }
 
@@ -203,7 +283,7 @@ func PostsListHandler(deps *Deps) http.HandlerFunc {
 			Pagination: pag,
 		}
 
-		renderTemplate(w, r, deps.Theme, "templates/list.html", data, http.StatusOK)
+		renderTemplate(w, r, deps, "templates/list.html", data, http.StatusOK)
 	}
 }
 
@@ -246,7 +326,7 @@ func ListHandler(deps *Deps) http.HandlerFunc {
 			Pagination: pag,
 		}
 
-		renderTemplate(w, r, deps.Theme, "templates/list.html", data, http.StatusOK)
+		renderTemplate(w, r, deps, "templates/list.html", data, http.StatusOK)
 	}
 }
 
@@ -273,7 +353,7 @@ func PostHandler(deps *Deps) http.HandlerFunc {
 			Title: post.Title,
 		}
 
-		renderTemplate(w, r, deps.Theme, "templates/post.html", data, http.StatusOK)
+		renderTemplate(w, r, deps, "templates/post.html", data, http.StatusOK)
 	}
 }
 
@@ -300,7 +380,7 @@ func PageHandler(deps *Deps) http.HandlerFunc {
 			Title: page.Title,
 		}
 
-		renderTemplate(w, r, deps.Theme, "templates/page.html", data, http.StatusOK)
+		renderTemplate(w, r, deps, "templates/page.html", data, http.StatusOK)
 	}
 }
 
@@ -335,7 +415,7 @@ func TagHandler(deps *Deps) http.HandlerFunc {
 			Pagination: pag,
 		}
 
-		renderTemplate(w, r, deps.Theme, "templates/list.html", data, http.StatusOK)
+		renderTemplate(w, r, deps, "templates/list.html", data, http.StatusOK)
 	}
 }
 
@@ -349,7 +429,7 @@ func NotFoundHandler(deps *Deps) http.HandlerFunc {
 			Title: "Page Not Found",
 		}
 
-		renderTemplate(w, r, deps.Theme, "templates/404.html", data, http.StatusNotFound)
+		renderTemplate(w, r, deps, "templates/404.html", data, http.StatusNotFound)
 	}
 }
 
@@ -453,8 +533,13 @@ func setPageURLs(pag *Pagination, urlFunc func(int) string) {
 
 // renderTemplate renders the named template into a buffer, then writes
 // the response. If rendering fails the client receives a 500 error
-// without any partial content.
-func renderTemplate(w http.ResponseWriter, r *http.Request, engine *theme.Engine, name string, data *PageData, statusCode int) {
+// without any partial content. It injects the global search affordance
+// state (PageData.Search.Enabled) when a handler has not already set it.
+func renderTemplate(w http.ResponseWriter, r *http.Request, deps *Deps, name string, data *PageData, statusCode int) {
+	if data.Search == nil {
+		data.Search = &SearchData{Enabled: deps.searchEnabled}
+	}
+	engine := deps.Theme
 	var buf bytes.Buffer
 	if err := engine.Render(r.Context(), &buf, name, data); err != nil {
 		if r.Context().Err() != nil {

--- a/internal/server/handlers/search.go
+++ b/internal/server/handlers/search.go
@@ -1,0 +1,276 @@
+package handlers
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/khaines/blogflow/internal/search"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// maxSearchPage bounds the parsed page number so that computing the offset
+// (page-1)*limit cannot overflow int for any parseable input.
+const maxSearchPage = 1_000_000
+
+// SearchHandler returns the handler for GET /search. It is registered only when
+// search.enabled was true at router build time; when search is disabled the
+// route is not registered and requests fall through to normal 404 handling.
+// Go's ServeMux serves HEAD via the GET handler and returns 405 with an
+// Allow: GET header for other methods automatically.
+//
+// The handler owns validation of query rune length and page parameters; the
+// search index owns validation of index availability and query term count.
+// Response statuses follow the design's API surface:
+//
+//	200 landing form (empty/whitespace query), inline validation (below min),
+//	    results, no-results, and page-overflow pages
+//	400 query over max length or over max terms
+//	503 route registered but this generation's search index is nil
+//	500 template render failure
+func SearchHandler(deps *Deps) http.HandlerFunc {
+	tracer := otel.Tracer("github.com/khaines/blogflow/search")
+	return func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		// Per design §7.3: create a search.Query span. The raw query string is
+		// deliberately not attached as an attribute (§5.3). search.duration_ms is
+		// set at the end so it is recorded on every return path.
+		ctx, span := tracer.Start(r.Context(), "search.Query")
+		defer func() {
+			span.SetAttributes(attribute.Int64("search.duration_ms", time.Since(start).Milliseconds()))
+			span.End()
+		}()
+
+		cfg := deps.LoadConfig()
+		sc := cfg.Search
+
+		rawQuery := r.URL.Query().Get("q")
+		normalized := search.NormalizeQuery(rawQuery)
+
+		data := &SearchData{
+			Enabled: true,
+			Query:   rawQuery,
+			Page:    1,
+		}
+		span.SetAttributes(attribute.Bool("search.enabled", true))
+
+		// Empty or whitespace-only query: render the landing form (200). This is
+		// normal navigation rather than a search, so it is not counted in the
+		// search query metric.
+		if normalized == "" {
+			span.SetAttributes(attribute.Bool("search.landing", true))
+			_ = deps.renderSearch(w, r, data, http.StatusOK)
+			return
+		}
+
+		queryLen := search.RuneLen(normalized)
+		span.SetAttributes(attribute.Int("search.query_terms_count", search.CountQueryTerms(normalized)))
+
+		// Over max length: reject before tokenization (400).
+		if queryLen > sc.MaxQueryLength {
+			data.Error = "Search query is too long. Please shorten it and try again."
+			deps.finishSearch(w, r, span, data, http.StatusBadRequest, search.StatusInvalid, start)
+			return
+		}
+
+		// Below min length: inline accessible validation message (200); do not
+		// scan the index.
+		if queryLen < sc.MinQueryLength {
+			data.Error = "Please enter at least " + strconv.Itoa(sc.MinQueryLength) + " characters to search."
+			deps.finishSearch(w, r, span, data, http.StatusOK, search.StatusInvalid, start)
+			return
+		}
+
+		// Page parameter: invalid or below 1 clamps to page 1; huge values clamp
+		// to maxSearchPage so the offset cannot overflow. Pages beyond the last
+		// are not pre-clamped so pagination can expose the true last page.
+		page := parseSearchPage(r)
+		limit := sc.MaxResults
+		if limit < 1 {
+			limit = 20
+		}
+		span.SetAttributes(attribute.Int("search.page", page), attribute.Int("search.limit", limit))
+
+		snap := deps.LoadSnapshot()
+		var si *search.SearchIndex
+		if snap != nil {
+			si = snap.Search
+		}
+
+		// Route registered but this generation's search index is nil: 503.
+		if si == nil {
+			logSearchUnavailable(span, snapshotGeneration(snap))
+			data.Error = "Search is temporarily unavailable. Please try again shortly."
+			span.SetStatus(codes.Error, "search index unavailable")
+			deps.finishSearch(w, r, span, data, http.StatusServiceUnavailable, search.StatusError, start)
+			return
+		}
+		span.SetAttributes(attribute.Int("search.index_docs", si.DocCount()))
+
+		resp, err := si.Search(ctx, snap.Content, rawQuery, search.SearchOptions{
+			Limit:  limit,
+			Offset: (page - 1) * limit,
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, search.ErrQueryTooComplex):
+				data.Error = "Search query is too complex. Please use fewer distinct words."
+				deps.finishSearch(w, r, span, data, http.StatusBadRequest, search.StatusInvalid, start)
+			case errors.Is(err, search.ErrIndexUnavailable):
+				logSearchUnavailable(span, snap.Generation)
+				data.Error = "Search is temporarily unavailable. Please try again shortly."
+				span.SetStatus(codes.Error, err.Error())
+				deps.finishSearch(w, r, span, data, http.StatusServiceUnavailable, search.StatusError, start)
+			default:
+				slog.Error("search failed", "error", err, "trace_id", traceID(span))
+				span.SetStatus(codes.Error, err.Error())
+				search.RecordQuery(search.StatusError, time.Since(start))
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			}
+			return
+		}
+
+		populateSearchResults(data, resp)
+		span.SetAttributes(
+			attribute.Int("search.results_count", resp.Total),
+			attribute.Bool("search.zero_results", resp.Total == 0),
+		)
+		// Record the result-count distribution only when the response actually
+		// renders successfully, so it stays consistent with queries_total{ok}.
+		if deps.finishSearch(w, r, span, data, http.StatusOK, search.StatusOK, start) {
+			search.RecordResults(resp.Total)
+		}
+	}
+}
+
+// finishSearch renders the search page and records the query metric based on
+// the actual outcome. If the render fails (500 already written), the request is
+// recorded as an error regardless of the intended logical status, so a template
+// failure is never counted as a successful search. It returns true when the
+// render succeeded so callers can record success-only metrics consistently.
+func (d *Deps) finishSearch(w http.ResponseWriter, r *http.Request, span trace.Span, data *SearchData, httpStatus int, logicalStatus string, start time.Time) bool {
+	if err := d.renderSearch(w, r, data, httpStatus); err != nil {
+		span.SetStatus(codes.Error, "search render failed")
+		search.RecordQuery(search.StatusError, time.Since(start))
+		return false
+	}
+	search.RecordQuery(logicalStatus, time.Since(start))
+	return true
+}
+
+// renderSearch renders the search page with the given SearchData and status.
+// It returns any render error after having written a 500 response, so callers
+// can record accurate metrics.
+func (d *Deps) renderSearch(w http.ResponseWriter, r *http.Request, data *SearchData, status int) error {
+	cfg := d.LoadConfig()
+	pd := &PageData{
+		Site:   cfg.Site,
+		Feed:   cfg.Feed,
+		Title:  searchTitle(data.Query),
+		Search: data,
+	}
+	var buf bytes.Buffer
+	if err := d.Theme.Render(r.Context(), &buf, "templates/search.html", pd); err != nil {
+		if r.Context().Err() != nil {
+			slog.Debug("search render aborted: client disconnected", "error", err)
+			return err
+		}
+		slog.Error("template render failed", "template", "templates/search.html", "error", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return err
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+	_, _ = buf.WriteTo(w)
+	return nil
+}
+
+// logSearchUnavailable emits the ERROR log required by design §7.1/§2.5 when
+// the search route is registered but the index is unavailable (503).
+func logSearchUnavailable(span trace.Span, generation uint64) {
+	slog.Error("search index unavailable", "generation", generation, "trace_id", traceID(span))
+}
+
+// snapshotGeneration returns the snapshot's generation, or 0 when nil.
+func snapshotGeneration(snap *SiteSnapshot) uint64 {
+	if snap == nil {
+		return 0
+	}
+	return snap.Generation
+}
+
+// traceID returns the span's trace ID as a string for log correlation.
+func traceID(span trace.Span) string {
+	sc := span.SpanContext()
+	if !sc.HasTraceID() {
+		return ""
+	}
+	return sc.TraceID().String()
+}
+
+// populateSearchResults copies a SearchResponse into template data and computes
+// pagination URLs.
+func populateSearchResults(data *SearchData, resp search.SearchResponse) {
+	data.Executed = true
+	data.Results = resp.Results
+	data.Total = resp.Total
+	data.Page = resp.Page
+	data.TotalPages = resp.TotalPages
+	data.Truncated = resp.Truncated
+	data.HasPrev = resp.Page > 1
+	data.HasNext = resp.Page < resp.TotalPages
+	if data.HasPrev {
+		// On a page beyond the last, target the true last page so the previous
+		// link returns readers to real results instead of another empty page.
+		prev := resp.Page - 1
+		if prev > resp.TotalPages {
+			prev = resp.TotalPages
+		}
+		data.PrevURL = searchPageURL(resp.Query, prev)
+	}
+	if data.HasNext {
+		data.NextURL = searchPageURL(resp.Query, resp.Page+1)
+	}
+}
+
+// searchTitle returns the page title for a search request.
+func searchTitle(query string) string {
+	if query == "" {
+		return "Search"
+	}
+	return "Search results for \"" + query + "\""
+}
+
+// parseSearchPage reads the ?page= parameter, clamping invalid or below-1 values
+// to 1 and very large values to maxSearchPage (to prevent offset overflow).
+// Values beyond the last page are intentionally not clamped to the last page.
+func parseSearchPage(r *http.Request) int {
+	p := r.URL.Query().Get("page")
+	if p == "" {
+		return 1
+	}
+	v, err := strconv.Atoi(p)
+	if err != nil || v < 1 {
+		return 1
+	}
+	if v > maxSearchPage {
+		return maxSearchPage
+	}
+	return v
+}
+
+// searchPageURL builds a canonical /search URL for a page, preserving the query.
+func searchPageURL(query string, page int) string {
+	u := "/search?q=" + url.QueryEscape(query)
+	if page > 1 {
+		u += "&page=" + strconv.Itoa(page)
+	}
+	return u
+}

--- a/internal/server/handlers/search_test.go
+++ b/internal/server/handlers/search_test.go
@@ -1,0 +1,245 @@
+package handlers_test
+
+import (
+	"context"
+	"fmt"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	blogflow "github.com/khaines/blogflow"
+	"github.com/khaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/content"
+	"github.com/khaines/blogflow/internal/search"
+	"github.com/khaines/blogflow/internal/server/handlers"
+	"github.com/khaines/blogflow/internal/theme"
+)
+
+// mkSearchPost builds a post with an explicit rendered-HTML body for search.
+func mkSearchPost(slug, title string, tags []string, day int, body string) *content.Post {
+	p := &content.Post{
+		Slug:    slug,
+		Content: template.HTML(body), //nolint:gosec // test data
+	}
+	p.Title = title
+	p.Tags = tags
+	p.Date = time.Date(2026, 3, day, 0, 0, 0, 0, time.UTC)
+	return p
+}
+
+func searchIndex(posts ...*content.Post) *content.Index {
+	idx := &content.Index{
+		BySlug:     make(map[string]*content.Post),
+		ByTag:      make(map[string][]*content.Post),
+		ByYear:     make(map[int][]*content.Post),
+		PageBySlug: make(map[string]*content.Post),
+	}
+	idx.Posts = posts
+	for _, p := range posts {
+		idx.BySlug[p.Slug] = p
+	}
+	return idx
+}
+
+// searchDeps builds Deps backed by the real embedded default theme so tests
+// exercise the shipped search.html and partials. When buildIndex is false, the
+// snapshot is published with a nil search index to exercise the 503 path.
+func searchDeps(t *testing.T, buildIndex bool, posts ...*content.Post) *handlers.Deps {
+	t.Helper()
+	eng, err := theme.NewEngine(blogflow.Defaults)
+	if err != nil {
+		t.Fatalf("theme engine: %v", err)
+	}
+	cfg := config.Default()
+	cfg.Search.Enabled = true
+	cfg.Search.MinQueryLength = 2
+	cfg.Search.MaxResults = 2 // small page for pagination tests
+
+	idx := searchIndex(posts...)
+	deps := handlers.NewDeps(cfg, idx, eng)
+	deps.SetSearchEnabled(true)
+	if buildIndex {
+		si := search.Build(context.Background(), idx, cfg.Search, 1)
+		deps.SetSnapshot(1, idx, si)
+	} else {
+		deps.SetSnapshot(1, idx, nil) // enabled but index unavailable
+	}
+	return deps
+}
+
+func doSearch(t *testing.T, deps *handlers.Deps, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	rec := httptest.NewRecorder()
+	handlers.SearchHandler(deps)(rec, req)
+	return rec
+}
+
+func sampleCorpus() []*content.Post {
+	return []*content.Post{
+		mkSearchPost("go-internals", "Go internals", []string{"go"}, 2, "<p>A deep dive into Go internals and the runtime.</p>"),
+		mkSearchPost("overlay-fs", "Overlay filesystem", []string{"architecture"}, 3, "<p>The overlay filesystem merges layers.</p>"),
+		mkSearchPost("caching", "Caching strategies", []string{"go"}, 1, "<p>Caching improves throughput significantly.</p>"),
+	}
+}
+
+func TestSearchHandler_EmptyQueryRendersForm(t *testing.T) {
+	deps := searchDeps(t, true, sampleCorpus()...)
+	rec := doSearch(t, deps, "/search")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `role="search"`) {
+		t.Error("landing form missing role=\"search\"")
+	}
+	if !strings.Contains(body, `name="q"`) {
+		t.Error("landing form missing query input")
+	}
+	if strings.Contains(body, "search-results") {
+		t.Error("landing form should not show a results list")
+	}
+}
+
+func TestSearchHandler_BelowMinLength(t *testing.T) {
+	deps := searchDeps(t, true, sampleCorpus()...)
+	rec := doSearch(t, deps, "/search?q=a")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `role="alert"`) {
+		t.Error("below-min query should render an accessible validation alert")
+	}
+	if !strings.Contains(body, "at least 2 characters") {
+		t.Errorf("missing min-length message: %s", body)
+	}
+}
+
+func TestSearchHandler_OverMaxLength(t *testing.T) {
+	deps := searchDeps(t, true, sampleCorpus()...)
+	long := strings.Repeat("x", 200)
+	rec := doSearch(t, deps, "/search?q="+long)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `role="alert"`) {
+		t.Error("over-length query should render a validation alert")
+	}
+}
+
+func TestSearchHandler_ResultsAndAccessibility(t *testing.T) {
+	deps := searchDeps(t, true, sampleCorpus()...)
+	rec := doSearch(t, deps, "/search?q=overlay")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Overlay filesystem") {
+		t.Error("expected matching post title in results")
+	}
+	if !strings.Contains(body, `role="status"`) {
+		t.Error("result count should be exposed via role=\"status\"")
+	}
+	if !strings.Contains(body, `href="/posts/overlay-fs"`) {
+		t.Error("result should link to the post")
+	}
+}
+
+// TestSearchHandler_ScoreNotInBody verifies the maintainer-approved refinement:
+// numeric relevance scores are not shown in the default reader-visible body.
+func TestSearchHandler_ScoreNotInBody(t *testing.T) {
+	posts := sampleCorpus()
+	deps := searchDeps(t, true, posts...)
+	// Compute the top result's full-precision score independently.
+	idx := searchIndex(posts...)
+	si := search.Build(context.Background(), idx, func() config.SearchConfig {
+		c := config.Default().Search
+		c.Enabled = true
+		return c
+	}(), 1)
+	resp, err := si.Search(context.Background(), idx, "go", search.SearchOptions{Limit: 20})
+	if err != nil || len(resp.Results) == 0 {
+		t.Fatalf("setup search failed: %v", err)
+	}
+	scoreStr := fmt.Sprintf("%.6f", resp.Results[0].Score)
+
+	rec := doSearch(t, deps, "/search?q=go")
+	if strings.Contains(rec.Body.String(), scoreStr) {
+		t.Errorf("numeric score %q leaked into default result body", scoreStr)
+	}
+}
+
+func TestSearchHandler_NoResults(t *testing.T) {
+	deps := searchDeps(t, true, sampleCorpus()...)
+	rec := doSearch(t, deps, "/search?q=nonexistentterm")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "No results") {
+		t.Error("expected explicit no-results state")
+	}
+}
+
+func TestSearchHandler_MaliciousQueryEscaped(t *testing.T) {
+	deps := searchDeps(t, true, sampleCorpus()...)
+	rec := doSearch(t, deps, "/search?q=%3Cscript%3Ealert(1)%3C%2Fscript%3Ego")
+	body := rec.Body.String()
+	if strings.Contains(body, "<script>alert(1)</script>") {
+		t.Error("query echo was not escaped — potential XSS")
+	}
+	if !strings.Contains(body, "&lt;script&gt;") {
+		t.Error("expected escaped query echo")
+	}
+}
+
+func TestSearchHandler_IndexUnavailable503(t *testing.T) {
+	deps := searchDeps(t, false, sampleCorpus()...) // enabled but nil search index
+	rec := doSearch(t, deps, "/search?q=go")
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "temporarily unavailable") {
+		t.Error("expected friendly unavailable message")
+	}
+}
+
+func TestSearchHandler_PaginationLinks(t *testing.T) {
+	// 5 posts all matching "go", page size 2 -> 3 pages with nav links.
+	posts := []*content.Post{}
+	for i := 1; i <= 5; i++ {
+		posts = append(posts, mkSearchPost(fmt.Sprintf("p%d", i), fmt.Sprintf("Go post %d", i), []string{"go"}, i, "<p>go content</p>"))
+	}
+	deps := searchDeps(t, true, posts...)
+	rec := doSearch(t, deps, "/search?q=go&page=2")
+	body := rec.Body.String()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(body, `class="pagination search-pagination"`) {
+		t.Error("expected search pagination nav")
+	}
+	if !strings.Contains(body, `rel="prev"`) || !strings.Contains(body, `rel="next"`) {
+		t.Errorf("page 2 of 3 should have prev and next links: %s", body)
+	}
+}
+
+func TestSearchHandler_PageOverflowExposesLastPage(t *testing.T) {
+	posts := []*content.Post{}
+	for i := 1; i <= 3; i++ {
+		posts = append(posts, mkSearchPost(fmt.Sprintf("p%d", i), fmt.Sprintf("Go post %d", i), []string{"go"}, i, "<p>go content</p>"))
+	}
+	deps := searchDeps(t, true, posts...) // page size 2 -> 2 pages total
+	rec := doSearch(t, deps, "/search?q=go&page=9")
+	body := rec.Body.String()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	// Overflow page has no results but must expose navigation back to results.
+	if !strings.Contains(body, `rel="prev"`) {
+		t.Errorf("overflow page should expose a previous link: %s", body)
+	}
+}

--- a/internal/server/handlers/snapshot_test.go
+++ b/internal/server/handlers/snapshot_test.go
@@ -1,0 +1,148 @@
+package handlers_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	blogflow "github.com/khaines/blogflow"
+	"github.com/khaines/blogflow/internal/config"
+	"github.com/khaines/blogflow/internal/content"
+	"github.com/khaines/blogflow/internal/search"
+	"github.com/khaines/blogflow/internal/server/handlers"
+	"github.com/khaines/blogflow/internal/theme"
+)
+
+// pageDeps builds Deps with the real embedded theme and a configurable
+// router-build search-enabled value, for testing global header affordances.
+func pageDeps(t *testing.T, searchEnabled bool, posts ...*content.Post) *handlers.Deps {
+	t.Helper()
+	eng, err := theme.NewEngine(blogflow.Defaults)
+	if err != nil {
+		t.Fatalf("theme engine: %v", err)
+	}
+	cfg := config.Default()
+	cfg.Search.Enabled = searchEnabled
+	idx := searchIndex(posts...)
+	deps := handlers.NewDeps(cfg, idx, eng)
+	deps.SetSearchEnabled(searchEnabled)
+	if searchEnabled {
+		si := search.Build(context.Background(), idx, cfg.Search, 1)
+		deps.SetSnapshot(1, idx, si)
+	} else {
+		deps.SetSnapshot(1, idx, nil)
+	}
+	return deps
+}
+
+func TestGlobalSearchAffordance_ShownWhenEnabled(t *testing.T) {
+	deps := pageDeps(t, true, sampleCorpus()...)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handlers.ListHandler(deps)(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `class="site-search"`) {
+		t.Error("enabled search should render a header search form on normal pages")
+	}
+	if !strings.Contains(body, `action="/search"`) {
+		t.Error("header search form should post to /search")
+	}
+}
+
+func TestGlobalSearchAffordance_HiddenWhenDisabled(t *testing.T) {
+	deps := pageDeps(t, false, sampleCorpus()...)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handlers.ListHandler(deps)(rec, req)
+
+	body := rec.Body.String()
+	if strings.Contains(body, `class="site-search"`) {
+		t.Error("disabled search must not render a header search form")
+	}
+	if strings.Contains(body, `action="/search"`) {
+		t.Error("disabled search must not emit any link/form to /search")
+	}
+}
+
+// TestSnapshot_ReloadSwapsSearchableTerms verifies a published reload makes new
+// terms searchable and old terms disappear, using one atomic snapshot swap.
+func TestSnapshot_ReloadSwapsSearchableTerms(t *testing.T) {
+	deps := searchDeps(t, true, mkSearchPost("a", "Alpha topic", nil, 1, "<p>alpha content</p>"))
+
+	rec := doSearch(t, deps, "/search?q=alpha")
+	if !strings.Contains(rec.Body.String(), "Alpha topic") {
+		t.Fatal("initial term should be searchable")
+	}
+
+	// Publish a new generation with different content.
+	newIdx := searchIndex(mkSearchPost("b", "Beta topic", nil, 2, "<p>beta content</p>"))
+	cfg := config.Default().Search
+	cfg.Enabled = true
+	gen := deps.NextGeneration()
+	newSI := search.Build(context.Background(), newIdx, cfg, gen)
+	deps.SetSnapshot(gen, newIdx, newSI)
+
+	if got := doSearch(t, deps, "/search?q=alpha"); !strings.Contains(got.Body.String(), "No results") {
+		t.Error("old term should no longer be searchable after reload")
+	}
+	if got := doSearch(t, deps, "/search?q=beta"); !strings.Contains(got.Body.String(), "Beta topic") {
+		t.Error("new term should be searchable after reload")
+	}
+}
+
+// TestSnapshot_ConcurrentReloadAndQuery runs concurrent publishes and queries;
+// it must be free of data races (run with -race) and mixed generations.
+func TestSnapshot_ConcurrentReloadAndQuery(t *testing.T) {
+	deps := searchDeps(t, true, sampleCorpus()...)
+	cfg := config.Default().Search
+	cfg.Enabled = true
+
+	var reloaders sync.WaitGroup
+	var queriers sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Reloaders: repeatedly build and publish new generations until stopped.
+	for r := 0; r < 3; r++ {
+		reloaders.Add(1)
+		go func() {
+			defer reloaders.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				idx := searchIndex(
+					mkSearchPost("x", "Concurrent go", []string{"go"}, 1, "<p>go overlay content</p>"),
+					mkSearchPost("y", "Overlay", []string{"go"}, 2, "<p>overlay filesystem</p>"),
+				)
+				gen := deps.NextGeneration()
+				si := search.Build(context.Background(), idx, cfg, gen)
+				deps.SetSnapshot(gen, idx, si)
+			}
+		}()
+	}
+
+	// Queriers: a fixed number of queries each, then finish.
+	for q := 0; q < 4; q++ {
+		queriers.Add(1)
+		go func() {
+			defer queriers.Done()
+			for i := 0; i < 200; i++ {
+				rec := doSearch(t, deps, "/search?q=go")
+				if rec.Code != http.StatusOK {
+					t.Errorf("query status = %d", rec.Code)
+					return
+				}
+			}
+		}()
+	}
+
+	queriers.Wait() // let all queries complete under concurrent reloads
+	close(stop)     // then stop the reloaders
+	reloaders.Wait()
+}

--- a/internal/server/search_route_test.go
+++ b/internal/server/search_route_test.go
@@ -1,0 +1,117 @@
+package server
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func searchTestServer(t *testing.T, enabled bool) *Server {
+	t.Helper()
+	cfg := defaultTestConfig()
+	cfg.Search.Enabled = enabled
+	s := New(cfg, nil)
+	opts := testRouteOptions()
+	if enabled {
+		opts.SearchHandler = stubHandler("search-results")
+	}
+	s.RegisterRoutes(opts)
+	return s
+}
+
+func TestSearchRoute_RegisteredWhenEnabled(t *testing.T) {
+	s := searchTestServer(t, true)
+	req := httptest.NewRequest(http.MethodGet, "/search?q=go", nil)
+	resp := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("GET /search = %d, want 200", resp.Code)
+	}
+	if body := resp.Body.String(); body != "search-results" {
+		t.Errorf("body = %q, want search handler output", body)
+	}
+}
+
+func TestSearchRoute_NotRegisteredWhenDisabled(t *testing.T) {
+	s := searchTestServer(t, false)
+	req := httptest.NewRequest(http.MethodGet, "/search?q=go", nil)
+	resp := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("GET /search with search disabled = %d, want 404", resp.Code)
+	}
+}
+
+func TestSearchRoute_MethodNotAllowed(t *testing.T) {
+	s := searchTestServer(t, true)
+	req := httptest.NewRequest(http.MethodPost, "/search?q=go", nil)
+	resp := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST /search = %d, want 405", resp.Code)
+	}
+	// Go's ServeMux advertises GET (and the implicit HEAD it serves via GET).
+	if allow := resp.Header().Get("Allow"); !strings.Contains(allow, http.MethodGet) {
+		t.Errorf("Allow header = %q, want it to include GET", allow)
+	}
+}
+
+func TestSearchRoute_HeadServedByGet(t *testing.T) {
+	s := searchTestServer(t, true)
+	req := httptest.NewRequest(http.MethodHead, "/search?q=go", nil)
+	resp := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("HEAD /search = %d, want 200", resp.Code)
+	}
+}
+
+func TestSearchRoute_PanicsWhenEnabledWithoutHandler(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when search enabled but SearchHandler is nil")
+		}
+	}()
+	cfg := defaultTestConfig()
+	cfg.Search.Enabled = true
+	s := New(cfg, nil)
+	s.RegisterRoutes(testRouteOptions()) // no SearchHandler set
+}
+
+// TestSearchRoute_QueryNotLoggedAtInfo verifies the access log redacts the raw
+// search query for /search (design §5.3/§7.1) while still logging query strings
+// for other routes.
+func TestSearchRoute_QueryNotLoggedAtInfo(t *testing.T) {
+	var buf bytes.Buffer
+	cfg := defaultTestConfig()
+	cfg.Search.Enabled = true
+	s := New(cfg, slog.New(slog.NewTextHandler(&buf, nil)))
+	opts := testRouteOptions()
+	opts.SearchHandler = stubHandler("results")
+	s.RegisterRoutes(opts)
+
+	// Search query must not appear in the access log.
+	req := httptest.NewRequest(http.MethodGet, "/search?q=SENSITIVEQUERY", nil)
+	s.httpServer.Handler.ServeHTTP(httptest.NewRecorder(), req)
+	if logged := buf.String(); strings.Contains(logged, "SENSITIVEQUERY") {
+		t.Errorf("access log leaked the raw search query: %s", logged)
+	}
+	if logged := buf.String(); !strings.Contains(logged, "/search") {
+		t.Errorf("expected /search path in access log: %s", buf.String())
+	}
+
+	// Non-search routes still log their query string (redaction is scoped).
+	buf.Reset()
+	req2 := httptest.NewRequest(http.MethodGet, "/posts?page=2", nil)
+	s.httpServer.Handler.ServeHTTP(httptest.NewRecorder(), req2)
+	if logged := buf.String(); !strings.Contains(logged, "page=2") {
+		t.Errorf("non-search query should still be logged: %s", logged)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -101,6 +101,7 @@ type RouteOptions struct {
 	TagHandler       http.HandlerFunc
 	FeedHandler      http.HandlerFunc
 	SitemapHandler   http.HandlerFunc
+	SearchHandler    http.HandlerFunc
 	WebhookHandler   http.HandlerFunc
 	StaticFS         fs.FS
 }
@@ -149,6 +150,17 @@ func (s *Server) RegisterRoutes(opts RouteOptions) {
 
 	// Sitemap
 	s.mux.HandleFunc("GET /sitemap.xml", opts.SitemapHandler)
+
+	// Full-text search: registered only when enabled at router-build time.
+	// When disabled, /search is not registered and returns the normal 404,
+	// and templates omit global search affordances. Toggling search.enabled
+	// requires a restart/router rebuild to take effect.
+	if s.config.Search.Enabled {
+		if opts.SearchHandler == nil {
+			panic("server: RegisterRoutes requires SearchHandler when search is enabled")
+		}
+		s.mux.HandleFunc("GET /search", opts.SearchHandler)
+	}
 
 	// Health checks. When PrivateHealth is set these are served only on the
 	// internal ops port (see New) and are removed from the public
@@ -329,9 +341,16 @@ func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
 		start := time.Now()
 		wrapped := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
 		next.ServeHTTP(wrapped, r)
+		// Log path with the query string, except for /search: reader-entered
+		// search terms must not be persisted in access logs at INFO level
+		// (full-text-search design §5.3 / §7.1).
+		loggedPath := r.URL.RequestURI()
+		if r.URL.Path == "/search" {
+			loggedPath = r.URL.Path
+		}
 		s.logger.Info("request",
 			"method", r.Method,
-			"path", r.URL.RequestURI(),
+			"path", loggedPath,
 			"status", wrapped.statusCode,
 			"duration", time.Since(start),
 			"remote", r.RemoteAddr,


### PR DESCRIPTION
## Summary

Implements optional, **server-rendered full-text search** (no client-side JavaScript) per the [design document](https://github.com/khaines/blogflow/blob/main/docs/engineering/design/001-full-text-search.md) and issue #129. Search is opt-in via `search.enabled: true` and disabled by default.

### Changes
- **`internal/search`** — a new package with a Unicode-normalized tokenizer (NFC + lower-case, letter/digit token boundaries), a lightweight custom in-memory inverted index, deterministic **weighted TF-IDF** ranking (title 3×, tag 2×, body 1×; `idf = ln(1 + (N+1)/(df+1))`), on-demand plain-text excerpts, and search-specific Prometheus metrics + OpenTelemetry spans.
- **Bounded, race-safe index** — document-granular admission stops before exceeding `max_docs` / `max_tokens` / `max_index_bytes` (never partially indexes a doc) and publishes a `truncated` flag. Content + search are bundled in one immutable `SiteSnapshot` published via a single atomic store, so a query never mixes generations; excerpts are re-derived from the same-generation content index.
- **`GET /search?q=&page=`** handler covering every status in the design (200 form/results/no-results/overflow, 400 too-long/too-complex, 404 when disabled, 405 + `Allow`, 503 when the index is unavailable, 500 render failure). Registered only when `search.enabled` is true at router-build time.
- **Default theme** — `search.html`, `partials/search-result.html`, `partials/search-pagination.html`, a conditional header search box, and CSS. Accessible by contract: `role="search"`, labelled input, `role="status"` result count, explicit no-results state, real `<a>` pagination links. Numeric relevance scores are available to custom themes but hidden from the default reader-visible body (design decision #8).
- **Config** — opt-in `SearchConfig` with validation; documented example in `defaults/config/defaults.yaml`.
- **Docs** — theme override guidance and the `SearchData` template context in `docs/theme-development.md`.

### Acceptance Criteria
- [x] Search by title, tags, and body content
- [x] Results show title, excerpt, date; relevance score controls ordering and is exposed to templates (hidden from default body)
- [x] Handles Unicode content (NFC-normalized tokenizer; CJK kept whole, bigrams deferred)
- [x] Configurable via `search.enabled: true`
- [x] Accessible, keyboard-navigable results
- [x] Server-side, no JavaScript

### Test Coverage
- Unit: tokenizer/normalization, **golden TF-IDF ranking fixtures** (exact scores from the design), TF capping, tie-breaks, caps/truncation, logical-byte estimator, excerpts (incl. Unicode), config validation.
- Integration (real embedded templates): handler status codes, HEAD/405/`Allow`, route enablement (disabled → 404), global affordance toggle, XSS escaping, pagination/overflow, and a concurrent reload/query test under `-race`.
- Benchmarks for tokenize/build/search at 100/1k/10k corpora plus a logical-memory report.

### Build & Test Results
- `go build ./...`: ✅  `go vet ./...`: ✅
- `go test -race ./...`: ✅ (all packages; one unrelated pre-existing fsnotify timing flake in `internal/gitops` passes on rerun)
- `golangci-lint run ./...`: ✅ 0 issues
- Manual end-to-end smoke test with the real binary: results render, validation/405/HEAD correct, header search box present, `<script>` echo escaped.

### Design Document
- [`docs/engineering/design/001-full-text-search.md`](https://github.com/khaines/blogflow/blob/main/docs/engineering/design/001-full-text-search.md)

Refs #129
