### PR TITLE
feat(config): rename metrics_port to ops_port with deprecated alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### Configuration
 
-* [CHANGE] Config: `server.metrics_port` (`BLOGFLOW_SERVER_METRICS_PORT`) is renamed to `server.ops_port` (`BLOGFLOW_SERVER_OPS_PORT`) to reflect its dual role (metrics + health/readiness when `private_health` is set). `metrics_port` remains a backward-compatible alias that logs a deprecation warning at startup; setting both `ops_port` and `metrics_port` to different values is a validation error. #284
+* [CHANGE] Config: `server.metrics_port` (`BLOGFLOW_SERVER_METRICS_PORT`) is renamed to `server.ops_port` (`BLOGFLOW_SERVER_OPS_PORT`) to reflect its dual role (metrics + health/readiness when `private_health` is set). `metrics_port` remains a backward-compatible alias that logs a deprecation warning at startup and is **scheduled for removal in v1.0.0**; setting both `ops_port` and `metrics_port` to different values is a validation error. The internal ops-listener API was renamed to match (`Server.StartOps`/`Server.OpsServer`, `opsServer` field — `internal` package, no external impact). #284 #286
 * [ENHANCEMENT] config: BLOGFLOW_SYNC_WEBHOOK_ALLOWED_IPS env var now overrides sync.webhook.allowed_ips (comma-separated). #249
 * [CHANGE] Webhook: the IP allowlist is now configured via `allowed_ips` (`[]string`, CIDR-aware). The earlier `ip_allowlist: true` boolean that shipped in the embedded default config (`defaults/config/defaults.yaml`) was removed; with strict config parsing (`KnownFields(true)`), a `site.yaml` that still sets `ip_allowlist` will fail to load and must be migrated to `allowed_ips`. #237
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Configuration
 
+* [CHANGE] Config: `server.metrics_port` (`BLOGFLOW_SERVER_METRICS_PORT`) is renamed to `server.ops_port` (`BLOGFLOW_SERVER_OPS_PORT`) to reflect its dual role (metrics + health/readiness when `private_health` is set). `metrics_port` remains a backward-compatible alias that logs a deprecation warning at startup; setting both `ops_port` and `metrics_port` to different values is a validation error. #284
 * [ENHANCEMENT] config: BLOGFLOW_SYNC_WEBHOOK_ALLOWED_IPS env var now overrides sync.webhook.allowed_ips (comma-separated). #249
 * [CHANGE] Webhook: the IP allowlist is now configured via `allowed_ips` (`[]string`, CIDR-aware). The earlier `ip_allowlist: true` boolean that shipped in the embedded default config (`defaults/config/defaults.yaml`) was removed; with strict config parsing (`KnownFields(true)`), a `site.yaml` that still sets `ip_allowlist` will fail to load and must be migrated to `allowed_ips`. #237
 

--- a/cmd/blogflow/healthcheck.go
+++ b/cmd/blogflow/healthcheck.go
@@ -19,10 +19,15 @@ const (
 // It honors the server's runtime configuration so the built-in Docker
 // HEALTHCHECK keeps working when health & readiness are moved to the internal
 // ops port via private_health: with BLOGFLOW_SERVER_PRIVATE_HEALTH enabled,
-// /healthz is served only on BLOGFLOW_SERVER_METRICS_PORT. Otherwise it follows
+// /healthz is served only on the ops port (BLOGFLOW_SERVER_OPS_PORT, or the
+// deprecated BLOGFLOW_SERVER_METRICS_PORT alias). Otherwise it follows
 // BLOGFLOW_SERVER_PORT, falling back to the compiled-in default.
 func healthcheckDefaultPort() int {
 	if private, _ := strconv.ParseBool(os.Getenv("BLOGFLOW_SERVER_PRIVATE_HEALTH")); private {
+		// Prefer the canonical ops port; fall back to the deprecated metrics_port alias.
+		if n, err := strconv.Atoi(os.Getenv("BLOGFLOW_SERVER_OPS_PORT")); err == nil && n > 0 {
+			return n
+		}
 		if n, err := strconv.Atoi(os.Getenv("BLOGFLOW_SERVER_METRICS_PORT")); err == nil && n > 0 {
 			return n
 		}

--- a/cmd/blogflow/healthcheck_test.go
+++ b/cmd/blogflow/healthcheck_test.go
@@ -36,20 +36,24 @@ func TestHealthcheckDefaultPort(t *testing.T) {
 	tests := []struct {
 		name    string
 		private string
+		ops     string
 		metrics string
 		port    string
 		want    int
 	}{
-		{"defaults", "", "", "", defaultPort},
-		{"private health uses metrics port", "true", "8081", "", 8081},
-		{"private health without metrics port falls back to server port", "true", "", "9000", 9000},
-		{"private health without any port falls back to default", "true", "", "", defaultPort},
-		{"custom server port", "", "", "9090", 9090},
-		{"private false ignores metrics port", "false", "8081", "", defaultPort},
+		{"defaults", "", "", "", "", defaultPort},
+		{"private health uses ops port", "true", "8081", "", "", 8081},
+		{"private health prefers ops over metrics alias", "true", "8081", "9090", "", 8081},
+		{"private health falls back to metrics alias", "true", "", "9090", "", 9090},
+		{"private health without ops/metrics falls back to server port", "true", "", "", "9000", 9000},
+		{"private health without any port falls back to default", "true", "", "", "", defaultPort},
+		{"custom server port", "", "", "", "9090", 9090},
+		{"private false ignores ops and metrics", "false", "8081", "9090", "", defaultPort},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("BLOGFLOW_SERVER_PRIVATE_HEALTH", tt.private)
+			t.Setenv("BLOGFLOW_SERVER_OPS_PORT", tt.ops)
 			t.Setenv("BLOGFLOW_SERVER_METRICS_PORT", tt.metrics)
 			t.Setenv("BLOGFLOW_SERVER_PORT", tt.port)
 			if got := healthcheckDefaultPort(); got != tt.want {

--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -294,18 +294,18 @@ func main() {
 		errCh <- srv.Start()
 	}()
 
-	// Start metrics server on dedicated port (no-op when MetricsPort == 0).
+	// Start ops server on its dedicated port (no-op when no ops port is configured).
 	metricsErrCh := make(chan error, 1)
 	go func() {
 		metricsErrCh <- srv.StartMetrics()
 	}()
 
-	// metricsStartCh mirrors metricsErrCh only when a separate metrics
+	// metricsStartCh mirrors metricsErrCh only when a separate ops
 	// port is configured.  A nil channel is never selected, so the
-	// readiness select below naturally ignores it when MetricsPort == 0
+	// readiness select below naturally ignores it when no ops port is set
 	// (where StartMetrics returns nil immediately).
 	var metricsStartCh <-chan error
-	if cfg.Server.MetricsPort > 0 {
+	if cfg.Server.EffectiveOpsPort() > 0 {
 		metricsStartCh = metricsErrCh
 	}
 

--- a/cmd/blogflow/main.go
+++ b/cmd/blogflow/main.go
@@ -280,7 +280,7 @@ func main() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		// Shutdown shuts down both the main and metrics servers.
+		// Shutdown shuts down both the main and ops servers.
 		if err := srv.Shutdown(ctx); err != nil {
 			logger.Error("shutdown error", "error", err)
 		}
@@ -295,18 +295,18 @@ func main() {
 	}()
 
 	// Start ops server on its dedicated port (no-op when no ops port is configured).
-	metricsErrCh := make(chan error, 1)
+	opsErrCh := make(chan error, 1)
 	go func() {
-		metricsErrCh <- srv.StartMetrics()
+		opsErrCh <- srv.StartOps()
 	}()
 
-	// metricsStartCh mirrors metricsErrCh only when a separate ops
+	// opsStartCh mirrors opsErrCh only when a separate ops
 	// port is configured.  A nil channel is never selected, so the
 	// readiness select below naturally ignores it when no ops port is set
-	// (where StartMetrics returns nil immediately).
-	var metricsStartCh <-chan error
+	// (where StartOps returns nil immediately).
+	var opsStartCh <-chan error
 	if cfg.Server.EffectiveOpsPort() > 0 {
-		metricsStartCh = metricsErrCh
+		opsStartCh = opsErrCh
 	}
 
 	// Wait for listener to bind or an immediate failure
@@ -314,8 +314,8 @@ func main() {
 	case err := <-errCh:
 		logger.Error("server failed to start", "error", err)
 		os.Exit(1)
-	case err := <-metricsStartCh:
-		logger.Error("metrics server failed to start", "error", err)
+	case err := <-opsStartCh:
+		logger.Error("ops server failed to start", "error", err)
 		os.Exit(1)
 	case <-srv.Ready():
 		srv.SetReady(true)
@@ -326,10 +326,10 @@ func main() {
 	}
 
 	// Wait for both servers to finish (shutdown or error).
-	// Using a select ensures that a metrics-server failure (e.g. port
+	// Using a select ensures that an ops-server failure (e.g. port
 	// conflict) is detected immediately rather than going unnoticed until
 	// the main server shuts down.
-	for errCh != nil || metricsErrCh != nil {
+	for errCh != nil || opsErrCh != nil {
 		select {
 		case err := <-errCh:
 			errCh = nil
@@ -337,10 +337,10 @@ func main() {
 				logger.Error("server error", "error", err)
 				os.Exit(1)
 			}
-		case err := <-metricsErrCh:
-			metricsErrCh = nil
+		case err := <-opsErrCh:
+			opsErrCh = nil
 			if err != nil {
-				logger.Error("metrics server error", "error", err)
+				logger.Error("ops server error", "error", err)
 				os.Exit(1)
 			}
 		}

--- a/deploy/azure/modules/container-app.bicep
+++ b/deploy/azure/modules/container-app.bicep
@@ -308,7 +308,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
             // management keeps working while the public internet cannot reach
             // or flood /healthz and /readyz.
             {
-              name: 'BLOGFLOW_SERVER_METRICS_PORT'
+              name: 'BLOGFLOW_SERVER_OPS_PORT'
               value: '8081'
             }
             {

--- a/deploy/helm/blogflow/templates/_helpers.tpl
+++ b/deploy/helm/blogflow/templates/_helpers.tpl
@@ -78,3 +78,17 @@ Validate sync configuration at render time.
   {{- fail "sync.strategy is 'sidecar' but sync.sidecar.repo is not set" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Effective ops/observability port: prefer service.opsPort, fall back to the
+deprecated service.metricsPort alias. Returns 0 when neither is set.
+*/}}
+{{- define "blogflow.opsPort" -}}
+{{- if and .Values.service.opsPort (gt (int .Values.service.opsPort) 0) -}}
+{{- int .Values.service.opsPort -}}
+{{- else if and .Values.service.metricsPort (gt (int .Values.service.metricsPort) 0) -}}
+{{- int .Values.service.metricsPort -}}
+{{- else -}}
+0
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/blogflow/templates/configmap.yaml
+++ b/deploy/helm/blogflow/templates/configmap.yaml
@@ -7,7 +7,9 @@ metadata:
 data:
   site.yaml: |
     {{- $config := deepCopy .Values.siteConfig -}}
-    {{- if and .Values.service.metricsPort (gt (int .Values.service.metricsPort) 0) -}}
+    {{- if and .Values.service.opsPort (gt (int .Values.service.opsPort) 0) -}}
+      {{- $_ := set $config.server "ops_port" (int .Values.service.opsPort) -}}
+    {{- else if and .Values.service.metricsPort (gt (int .Values.service.metricsPort) 0) -}}
       {{- $_ := set $config.server "metrics_port" (int .Values.service.metricsPort) -}}
     {{- end }}
     {{- $config | toYaml | nindent 4 }}

--- a/deploy/helm/blogflow/templates/configmap.yaml
+++ b/deploy/helm/blogflow/templates/configmap.yaml
@@ -8,8 +8,10 @@ data:
   site.yaml: |
     {{- $config := deepCopy .Values.siteConfig -}}
     {{- if and .Values.service.opsPort (gt (int .Values.service.opsPort) 0) -}}
+      {{- $_ := unset $config.server "metrics_port" -}}
       {{- $_ := set $config.server "ops_port" (int .Values.service.opsPort) -}}
     {{- else if and .Values.service.metricsPort (gt (int .Values.service.metricsPort) 0) -}}
+      {{- $_ := unset $config.server "ops_port" -}}
       {{- $_ := set $config.server "metrics_port" (int .Values.service.metricsPort) -}}
     {{- end }}
     {{- $config | toYaml | nindent 4 }}

--- a/deploy/helm/blogflow/templates/deployment.yaml
+++ b/deploy/helm/blogflow/templates/deployment.yaml
@@ -38,9 +38,10 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-            {{- if and .Values.service.metricsPort (gt (int .Values.service.metricsPort) 0) }}
+            {{- $opsPort := int (include "blogflow.opsPort" .) }}
+            {{- if gt $opsPort 0 }}
             - name: metrics
-              containerPort: {{ .Values.service.metricsPort }}
+              containerPort: {{ $opsPort }}
               protocol: TCP
             {{- end }}
           securityContext:

--- a/deploy/helm/blogflow/templates/service.yaml
+++ b/deploy/helm/blogflow/templates/service.yaml
@@ -11,8 +11,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    {{- if and .Values.service.metricsPort (gt (int .Values.service.metricsPort) 0) }}
-    - port: {{ .Values.service.metricsPort }}
+    {{- $opsPort := int (include "blogflow.opsPort" .) }}
+    {{- if gt $opsPort 0 }}
+    {{- /* Named "metrics" for backward compatibility with existing ServiceMonitor
+           selectors; the number comes from service.opsPort (or the deprecated
+           service.metricsPort alias). */}}
+    - port: {{ $opsPort }}
       targetPort: metrics
       protocol: TCP
       name: metrics

--- a/deploy/helm/blogflow/values.yaml
+++ b/deploy/helm/blogflow/values.yaml
@@ -74,7 +74,9 @@ siteConfig:
     name: default
   server:
     port: 8080
-    # -- Dedicated metrics port (0 = serve metrics on main port)
+    # -- Dedicated ops/observability port (0 = serve on main port)
+    # ops_port: 9090
+    # -- metrics_port is a deprecated alias for ops_port
     # metrics_port: 9090
     read_timeout: 5s
     write_timeout: 10s
@@ -103,7 +105,9 @@ service:
   port: 8080
   # -- Dedicated ops/observability port (0 = disabled, ops endpoints served on main port)
   opsPort: 0
-  # -- DEPRECATED alias for opsPort (kept for backward compatibility; prefer opsPort)
+  # -- DEPRECATED alias for opsPort (kept for backward compatibility; prefer opsPort).
+  # -- If both opsPort and metricsPort are non-zero, opsPort takes precedence and
+  # -- metricsPort is ignored here (the raw BlogFlow config instead rejects the conflict).
   metricsPort: 0
 
 ingress:

--- a/deploy/helm/blogflow/values.yaml
+++ b/deploy/helm/blogflow/values.yaml
@@ -101,7 +101,9 @@ service:
   type: ClusterIP
   # -- Service port
   port: 8080
-  # -- Dedicated metrics port (0 = disabled, metrics served on main port)
+  # -- Dedicated ops/observability port (0 = disabled, ops endpoints served on main port)
+  opsPort: 0
+  # -- DEPRECATED alias for opsPort (kept for backward compatibility; prefer opsPort)
   metricsPort: 0
 
 ingress:

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -946,18 +946,20 @@ readinessProbe:
   failureThreshold: 12  # allow 60s for initial clone
 ```
 
-### Metrics / Ops Port
+### Ops Port
 
-When `server.metrics_port` is configured, the health and readiness endpoints (`/healthz`, `/readyz`, `/readyz/content`) are served on **both** the main port and the metrics port, and `/metrics` moves to the metrics port only. (As of #283 `/readyz` and `/readyz/content` are also on the metrics port — previously only `/healthz` was.)
+When `server.ops_port` is configured, the health and readiness endpoints (`/healthz`, `/readyz`, `/readyz/content`) are served on **both** the main port and the ops port, and `/metrics` moves to the ops port only.
+
+> `server.metrics_port` (`BLOGFLOW_SERVER_METRICS_PORT`) is a **deprecated alias** for `ops_port`, retained for backward compatibility — it still works but logs a deprecation warning at startup. Prefer `ops_port` / `BLOGFLOW_SERVER_OPS_PORT`. Setting both to different values is a validation error.
 
 | Port | `/healthz` | `/readyz` | `/readyz/content` | `/metrics` |
 |------|-----------|-----------|-------------------|------------|
-| Main (8080) | ✅ | ✅ | ✅ | ❌ (when metrics_port set) |
-| Metrics/ops (9090) | ✅ | ✅ | ✅ | ✅ |
+| Main (8080) | ✅ | ✅ | ✅ | ❌ (when ops_port set) |
+| Ops (9090) | ✅ | ✅ | ✅ | ✅ |
 
 ### Private Health — isolate probes from public traffic
 
-Set `server.private_health: true` (requires `server.metrics_port`) to **remove** `/healthz`, `/readyz` and `/readyz/content` from the public port and serve them **only** on the internal metrics/ops port. On the public port these paths return a cheap `404` *before* any tracing or access logging runs, so floods to them cost almost nothing.
+Set `server.private_health: true` (requires `server.ops_port`) to **remove** `/healthz`, `/readyz` and `/readyz/content` from the public port and serve them **only** on the internal ops port. On the public port these paths return a cheap `404` *before* any tracing or access logging runs, so floods to them cost almost nothing.
 
 This protects against denial-of-service floods and readiness-state probing on the public listener while keeping lifecycle management intact: Kubernetes and Azure Container Apps execute probes against the container port **directly** — that traffic never traverses public ingress — so simply point your probes at the ops port.
 
@@ -978,7 +980,7 @@ livenessProbe:
     port: 8081
 ```
 
-> With `private_health` enabled **via environment variables** (`BLOGFLOW_SERVER_PRIVATE_HEALTH` + `BLOGFLOW_SERVER_METRICS_PORT`), the built-in `healthcheck` subcommand automatically targets the ops port, so the Docker `HEALTHCHECK` keeps working with no override. The healthcheck process does **not** read `site.yaml`, so if you configure `private_health`/`metrics_port` through the config file instead, pass the ops port explicitly: `["/app", "healthcheck", "--port", "8081"]`.
+> With `private_health` enabled **via environment variables** (`BLOGFLOW_SERVER_PRIVATE_HEALTH` + `BLOGFLOW_SERVER_OPS_PORT`, or the deprecated `BLOGFLOW_SERVER_METRICS_PORT`), the built-in `healthcheck` subcommand automatically targets the ops port, so the Docker `HEALTHCHECK` keeps working with no override. The healthcheck process does **not** read `site.yaml`, so if you configure `private_health`/`ops_port` through the config file instead, pass the ops port explicitly: `["/app", "healthcheck", "--port", "8081"]`.
 >
 > **Residual note:** moving the endpoints off the public port (and cheap-404ing floods) removes per-request tracing/logging cost, but volumetric floods still open TCP connections and count toward the platform's HTTP autoscaler. For full volumetric protection, front the app with a WAF/rate limiter (e.g. Azure Front Door) or a custom scale rule.
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -951,6 +951,8 @@ readinessProbe:
 When `server.ops_port` is configured, the health and readiness endpoints (`/healthz`, `/readyz`, `/readyz/content`) are served on **both** the main port and the ops port, and `/metrics` moves to the ops port only.
 
 > `server.metrics_port` (`BLOGFLOW_SERVER_METRICS_PORT`) is a **deprecated alias** for `ops_port`, retained for backward compatibility — it still works but logs a deprecation warning at startup. Prefer `ops_port` / `BLOGFLOW_SERVER_OPS_PORT`. Setting both to different values is a validation error.
+>
+> **Migration & timeline:** `metrics_port` is deprecated and **scheduled for removal in v1.0.0**. Before upgrading to v1.0.0, rename `metrics_port` → `ops_port` (env `BLOGFLOW_SERVER_METRICS_PORT` → `BLOGFLOW_SERVER_OPS_PORT`; Helm `service.metricsPort` → `service.opsPort`). Because config parsing is strict (`KnownFields(true)`), a `site.yaml` that still contains `metrics_port` after the alias is removed will fail to load.
 
 | Port | `/healthz` | `/readyz` | `/readyz/content` | `/metrics` |
 |------|-----------|-----------|-------------------|------------|

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -998,7 +998,7 @@ Prometheus metrics are always available. No extra configuration is needed.
 
 | Feature | Details |
 |---------|---------|
-| Endpoint | `/metrics` on the main port, or on a dedicated `metrics_port` |
+| Endpoint | `/metrics` on the main port, or on a dedicated `ops_port` |
 | RED metrics | Request rate, error rate, and duration (p50/p95/p99) per path |
 | Content analytics | Views per content item: `blogflow_content_views_total{type, slug}` |
 | Overlay FS metrics | Layer hit rate, cache hit ratio, resolve duration, negative-cache size |
@@ -1010,8 +1010,10 @@ To move metrics off the main port:
 ```yaml
 server:
   port: 8080
-  metrics_port: 9090   # /metrics served here only
+  ops_port: 9090   # /metrics (and health/readiness) served here
 ```
+
+> `metrics_port` remains a deprecated alias for `ops_port`.
 
 #### Content analytics
 

--- a/docs/engineering/design/configuration-system.md
+++ b/docs/engineering/design/configuration-system.md
@@ -242,7 +242,9 @@ type ThemeConfig struct {
 
 type ServerConfig struct {
     Port              int           `yaml:"port"               validate:"required,min=1,max=65535"`
-    MetricsPort       int           `yaml:"metrics_port"       validate:"omitempty,min=0,max=65535"`   // 0 = disabled (metrics on main port); 1-65535 = separate listener
+    OpsPort           int           `yaml:"ops_port"           validate:"omitempty,min=0,max=65535"`   // 0 = disabled (ops endpoints on main port); 1-65535 = separate ops listener
+    MetricsPort       int           `yaml:"metrics_port"       validate:"omitempty,min=0,max=65535"`   // DEPRECATED alias for ops_port (backward compatibility)
+    PrivateHealth     bool          `yaml:"private_health"     validate:"omitempty"`                   // serve health/readiness only on the ops port
     ReadTimeout       time.Duration `yaml:"read_timeout"       validate:"required,min=1s,max=60s"`
     WriteTimeout      time.Duration `yaml:"write_timeout"      validate:"required,min=1s,max=300s"`
     IdleTimeout       time.Duration `yaml:"idle_timeout"       validate:"required,min=1s,max=600s"`
@@ -500,7 +502,8 @@ Environment variables use a `BLOGFLOW_` prefix with underscore-separated paths f
 | `server.idle_timeout` | `BLOGFLOW_SERVER_IDLE_TIMEOUT` | `BLOGFLOW_SERVER_IDLE_TIMEOUT=120s` |
 | `server.tls_terminated` | `BLOGFLOW_SERVER_TLS_TERMINATED` | `BLOGFLOW_SERVER_TLS_TERMINATED=true` |
 | `server.hsts_max_age` | `BLOGFLOW_SERVER_HSTS_MAX_AGE` | `BLOGFLOW_SERVER_HSTS_MAX_AGE=31536000` |
-| `server.metrics_port` | `BLOGFLOW_SERVER_METRICS_PORT` | `BLOGFLOW_SERVER_METRICS_PORT=9091` |
+| `server.ops_port` | `BLOGFLOW_SERVER_OPS_PORT` | `BLOGFLOW_SERVER_OPS_PORT=9091` |
+| `server.metrics_port` (deprecated alias) | `BLOGFLOW_SERVER_METRICS_PORT` | `BLOGFLOW_SERVER_METRICS_PORT=9091` |
 | `cache.enabled` | `BLOGFLOW_CACHE_ENABLED` | `BLOGFLOW_CACHE_ENABLED=false` |
 | `sync.strategy` | `BLOGFLOW_SYNC_STRATEGY` | `BLOGFLOW_SYNC_STRATEGY=webhook` |
 | `sync.repo` | `BLOGFLOW_SYNC_REPO` | `BLOGFLOW_SYNC_REPO="git@github.com:org/content.git"` |

--- a/examples/config/site.yaml
+++ b/examples/config/site.yaml
@@ -53,16 +53,19 @@ theme:
 # ---------------------------------------------------------------------------
 server:
   port: 8080                  # Listen port (1–65535). Override: BLOGFLOW_SERVER_PORT
-  # metrics_port: 9090        # Dedicated metrics/ops port (1–65535, must differ from port).
-                              # When set, /metrics is served on this port only — the
-                              # main port has no /metrics endpoint.  /healthz, /readyz and
-                              # /readyz/content are also served here (in addition to the
-                              # main port, unless private_health is enabled below).
-                              # Set to 0 (default) to serve metrics on the main port.
+  # ops_port: 9090            # Dedicated ops/observability port (1–65535, must differ from port).
+                              # When set, /metrics, /healthz, /readyz and /readyz/content are
+                              # served here; /metrics is removed from the main port. Health &
+                              # readiness stay on the main port too, unless private_health is
+                              # enabled below.
+                              # Set to 0 (default) to serve everything on the main port.
+                              # Override: BLOGFLOW_SERVER_OPS_PORT
+  # metrics_port: 9090        # DEPRECATED alias for ops_port (backward compatibility only).
+                              # Prefer ops_port; setting this logs a deprecation warning.
                               # Override: BLOGFLOW_SERVER_METRICS_PORT
   # private_health: false     # When true, /healthz, /readyz and /readyz/content are
-                              # removed from the public port and served ONLY on
-                              # metrics_port (which must be set). Orchestrator probes
+                              # removed from the public port and served ONLY on the
+                              # ops_port (which must be set). Orchestrator probes
                               # (Kubernetes, Azure Container Apps) reach that port
                               # directly, so liveness/readiness keep working while the
                               # public internet cannot reach or flood these endpoints.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,7 +71,8 @@ type ServerConfig struct {
 	// MetricsPort is the deprecated alias for OpsPort, retained for backward
 	// compatibility. Prefer OpsPort/ops_port. When OpsPort is unset and
 	// MetricsPort is set, MetricsPort is used and a deprecation warning is
-	// logged at load time. Env: BLOGFLOW_SERVER_METRICS_PORT (deprecated).
+	// logged at load time. Scheduled for removal in v1.0.0.
+	// Env: BLOGFLOW_SERVER_METRICS_PORT (deprecated).
 	MetricsPort int `yaml:"metrics_port"`
 	// PrivateHealth, when true, removes the /healthz, /readyz and
 	// /readyz/content endpoints from the public listener and serves them only

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,13 +63,22 @@ type ThemeConfig struct {
 
 // ServerConfig holds HTTP server settings.
 type ServerConfig struct {
-	Port        int `yaml:"port"`
+	Port int `yaml:"port"`
+	// OpsPort is the internal ops/observability listener. When > 0 it serves
+	// /metrics, /healthz, /readyz and /readyz/content on a dedicated port,
+	// separate from the public content port. Env: BLOGFLOW_SERVER_OPS_PORT.
+	OpsPort int `yaml:"ops_port"`
+	// MetricsPort is the deprecated alias for OpsPort, retained for backward
+	// compatibility. Prefer OpsPort/ops_port. When OpsPort is unset and
+	// MetricsPort is set, MetricsPort is used and a deprecation warning is
+	// logged at load time. Env: BLOGFLOW_SERVER_METRICS_PORT (deprecated).
 	MetricsPort int `yaml:"metrics_port"`
 	// PrivateHealth, when true, removes the /healthz, /readyz and
 	// /readyz/content endpoints from the public listener and serves them only
-	// on the internal MetricsPort listener. Requires MetricsPort > 0. Use this
-	// so orchestrator probes (which reach the container port directly) keep
-	// working while the public internet cannot reach or flood these endpoints.
+	// on the internal ops-port listener. Requires the ops port (OpsPort, or the
+	// deprecated MetricsPort alias) to be set. Use this so orchestrator probes
+	// (which reach the container port directly) keep working while the public
+	// internet cannot reach or flood these endpoints.
 	PrivateHealth     bool          `yaml:"private_health"`
 	ReadTimeout       time.Duration `yaml:"read_timeout"`
 	WriteTimeout      time.Duration `yaml:"write_timeout"`
@@ -77,6 +86,17 @@ type ServerConfig struct {
 	TLSTerminated     bool          `yaml:"tls_terminated"`
 	HSTSMaxAge        int           `yaml:"hsts_max_age"`
 	TrustedProxyCIDRs []string      `yaml:"trusted_proxy_cidrs"`
+}
+
+// EffectiveOpsPort returns the resolved internal ops/observability port,
+// preferring OpsPort and falling back to the deprecated MetricsPort alias.
+// A return value of 0 means no dedicated ops port is configured (ops
+// endpoints are served on the main port).
+func (s ServerConfig) EffectiveOpsPort() int {
+	if s.OpsPort != 0 {
+		return s.OpsPort
+	}
+	return s.MetricsPort
 }
 
 // CacheConfig holds rendered content cache settings.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1091,6 +1091,121 @@ func TestValidate_PrivateHealth_Valid(t *testing.T) {
 	}
 }
 
+func TestEffectiveOpsPort(t *testing.T) {
+	tests := []struct {
+		name    string
+		ops     int
+		metrics int
+		want    int
+	}{
+		{"neither set", 0, 0, 0},
+		{"ops only", 8081, 0, 8081},
+		{"metrics alias only", 0, 9090, 9090},
+		{"ops takes precedence over metrics alias", 8081, 9090, 8081},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := ServerConfig{OpsPort: tt.ops, MetricsPort: tt.metrics}
+			if got := s.EffectiveOpsPort(); got != tt.want {
+				t.Errorf("EffectiveOpsPort() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidate_OpsPort_Valid(t *testing.T) {
+	cfg := Default()
+	cfg.Server.OpsPort = 8081
+	if err := Validate(cfg); err != nil {
+		t.Errorf("unexpected validation error for valid ops_port: %v", err)
+	}
+}
+
+func TestValidate_OpsPort_OutOfRange(t *testing.T) {
+	cfg := Default()
+	cfg.Server.OpsPort = 70000
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected validation error for out-of-range ops_port")
+	}
+	cfgErr, ok := err.(*ConfigError)
+	if !ok {
+		t.Fatalf("expected *ConfigError, got %T", err)
+	}
+	found := false
+	for _, fe := range cfgErr.Errors {
+		if fe.Field == "server.ops_port" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected server.ops_port field error")
+	}
+}
+
+func TestValidate_OpsPort_SameAsPort(t *testing.T) {
+	cfg := Default()
+	cfg.Server.OpsPort = cfg.Server.Port
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected validation error when ops_port == port")
+	}
+	cfgErr, ok := err.(*ConfigError)
+	if !ok {
+		t.Fatalf("expected *ConfigError, got %T", err)
+	}
+	found := false
+	for _, fe := range cfgErr.Errors {
+		if fe.Field == "server.ops_port" && strings.Contains(fe.Message, "different") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected server.ops_port field error about being different from port")
+	}
+}
+
+func TestValidate_OpsPort_ConflictsWithMetricsAlias(t *testing.T) {
+	cfg := Default()
+	cfg.Server.OpsPort = 8081
+	cfg.Server.MetricsPort = 9090 // different value — ambiguous
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected validation error when ops_port and metrics_port conflict")
+	}
+	cfgErr, ok := err.(*ConfigError)
+	if !ok {
+		t.Fatalf("expected *ConfigError, got %T", err)
+	}
+	found := false
+	for _, fe := range cfgErr.Errors {
+		if fe.Field == "server.metrics_port" && strings.Contains(fe.Message, "conflicts") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected server.metrics_port conflict error")
+	}
+}
+
+func TestValidate_OpsPort_EqualToMetricsAlias_OK(t *testing.T) {
+	cfg := Default()
+	cfg.Server.OpsPort = 8081
+	cfg.Server.MetricsPort = 8081 // same value — not a conflict
+	if err := Validate(cfg); err != nil {
+		t.Errorf("unexpected validation error when ops_port == metrics_port: %v", err)
+	}
+}
+
+func TestValidate_PrivateHealth_Valid_WithOpsPort(t *testing.T) {
+	cfg := Default()
+	cfg.Server.PrivateHealth = true
+	cfg.Server.OpsPort = 8081
+	if err := Validate(cfg); err != nil {
+		t.Errorf("unexpected validation error for private_health with ops_port: %v", err)
+	}
+}
+
 func TestValidate_Homepage(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/config/env_override_test.go
+++ b/internal/config/env_override_test.go
@@ -34,6 +34,34 @@ func TestEnvOverrideInvalidMetricsPort(t *testing.T) {
 	}
 }
 
+func TestEnvOverrideOpsPort(t *testing.T) {
+	t.Setenv("BLOGFLOW_SERVER_OPS_PORT", "9091")
+	fsys := fstest.MapFS{}
+	loader := NewLoader(fsys)
+	cfg, err := loader.Load()
+	if err != nil {
+		t.Fatalf("unexpected error for valid ops port: %v", err)
+	}
+	if cfg.Server.OpsPort != 9091 {
+		t.Errorf("server.ops_port = %d, want 9091", cfg.Server.OpsPort)
+	}
+	if cfg.Server.EffectiveOpsPort() != 9091 {
+		t.Errorf("EffectiveOpsPort() = %d, want 9091", cfg.Server.EffectiveOpsPort())
+	}
+}
+
+func TestEnvOverrideInvalidOpsPort(t *testing.T) {
+	t.Setenv("BLOGFLOW_SERVER_OPS_PORT", "invalid")
+	fsys := fstest.MapFS{}
+	loader := NewLoader(fsys)
+	_, err := loader.Load()
+	if err == nil {
+		t.Error("expected error for invalid ops port, got nil")
+	} else {
+		t.Logf("got expected error: %v", err)
+	}
+}
+
 func TestEnvOverrideValidServerPort(t *testing.T) {
 	t.Setenv("BLOGFLOW_SERVER_PORT", "9090")
 	fsys := fstest.MapFS{}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -185,6 +185,12 @@ func (l *Loader) Load() (*Config, error) {
 		)
 	}
 
+	if cfg.Server.MetricsPort != 0 {
+		l.logger.Warn("server.metrics_port is deprecated; use server.ops_port (env BLOGFLOW_SERVER_OPS_PORT). The metrics_port alias will be removed in a future release.",
+			"metrics_port", cfg.Server.MetricsPort,
+		)
+	}
+
 	if err := Validate(cfg); err != nil {
 		l.logger.Warn("config validation failed", "error", err)
 		return nil, err
@@ -429,6 +435,14 @@ var envMap = map[string]func(*Config, string, *slog.Logger) error{
 		c.Server.HSTSMaxAge = n
 		return nil
 	},
+	"BLOGFLOW_SERVER_OPS_PORT": func(c *Config, v string, _ *slog.Logger) error {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("cannot parse env var BLOGFLOW_SERVER_OPS_PORT as int: %w", err)
+		}
+		c.Server.OpsPort = n
+		return nil
+	},
 	"BLOGFLOW_SERVER_METRICS_PORT": func(c *Config, v string, _ *slog.Logger) error {
 		n, err := strconv.Atoi(v)
 		if err != nil {
@@ -514,32 +528,47 @@ func Validate(cfg *Config) error {
 		})
 	}
 
-	// Server.MetricsPort: 0 = disabled (metrics on main port); 1-65535 = separate listener
-	if cfg.Server.MetricsPort != 0 {
-		if cfg.Server.MetricsPort < 1 || cfg.Server.MetricsPort > 65535 {
+	// Server.OpsPort (with the deprecated server.metrics_port alias):
+	// 0 = disabled (ops endpoints on main port); 1-65535 = separate listener.
+	opsPort := cfg.Server.EffectiveOpsPort()
+	opsField := "server.ops_port"
+	if cfg.Server.OpsPort == 0 && cfg.Server.MetricsPort != 0 {
+		opsField = "server.metrics_port"
+	}
+	if opsPort != 0 {
+		if opsPort < 1 || opsPort > 65535 {
 			errs = append(errs, FieldError{
-				Field:   "server.metrics_port",
-				Value:   cfg.Server.MetricsPort,
+				Field:   opsField,
+				Value:   opsPort,
 				Message: "must be between 1 and 65535",
 			})
 		}
-		if cfg.Server.MetricsPort == cfg.Server.Port {
+		if opsPort == cfg.Server.Port {
 			errs = append(errs, FieldError{
-				Field:   "server.metrics_port",
-				Value:   cfg.Server.MetricsPort,
+				Field:   opsField,
+				Value:   opsPort,
 				Message: "must be different from server.port",
 			})
 		}
 	}
+	// Reject setting both the canonical ops_port and the deprecated alias to
+	// conflicting values — the configuration would be ambiguous.
+	if cfg.Server.OpsPort != 0 && cfg.Server.MetricsPort != 0 && cfg.Server.OpsPort != cfg.Server.MetricsPort {
+		errs = append(errs, FieldError{
+			Field:   "server.metrics_port",
+			Value:   cfg.Server.MetricsPort,
+			Message: "conflicts with server.ops_port; set only one (metrics_port is a deprecated alias for ops_port)",
+		})
+	}
 
-	// Server.PrivateHealth requires a separate metrics/ops port: health and
-	// readiness are removed from the public port, so they must have somewhere
-	// (the internal MetricsPort listener) for orchestrator probes to reach them.
-	if cfg.Server.PrivateHealth && cfg.Server.MetricsPort == 0 {
+	// Server.PrivateHealth requires a separate ops port: health and readiness
+	// are removed from the public port, so they must have somewhere (the ops
+	// listener) for orchestrator probes to reach them.
+	if cfg.Server.PrivateHealth && opsPort == 0 {
 		errs = append(errs, FieldError{
 			Field:   "server.private_health",
 			Value:   cfg.Server.PrivateHealth,
-			Message: "requires server.metrics_port to be set (health & readiness are moved off the public port)",
+			Message: "requires server.ops_port (or the deprecated server.metrics_port) to be set (health & readiness are moved off the public port)",
 		})
 	}
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -189,7 +189,7 @@ func (l *Loader) Load() (*Config, error) {
 	// unset). If ops_port is set, metrics_port is either redundant (same value)
 	// or a conflict caught by Validate — no deprecation nudge is needed.
 	if cfg.Server.MetricsPort != 0 && cfg.Server.OpsPort == 0 {
-		l.logger.Warn("server.metrics_port is deprecated; use server.ops_port (env BLOGFLOW_SERVER_OPS_PORT). The metrics_port alias will be removed in a future release.",
+		l.logger.Warn("server.metrics_port is deprecated; use server.ops_port (env BLOGFLOW_SERVER_OPS_PORT). The metrics_port alias is scheduled for removal in v1.0.0.",
 			"metrics_port", cfg.Server.MetricsPort,
 		)
 	}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -185,7 +185,10 @@ func (l *Loader) Load() (*Config, error) {
 		)
 	}
 
-	if cfg.Server.MetricsPort != 0 {
+	// Warn only when the deprecated alias is the effective source (ops_port
+	// unset). If ops_port is set, metrics_port is either redundant (same value)
+	// or a conflict caught by Validate — no deprecation nudge is needed.
+	if cfg.Server.MetricsPort != 0 && cfg.Server.OpsPort == 0 {
 		l.logger.Warn("server.metrics_port is deprecated; use server.ops_port (env BLOGFLOW_SERVER_OPS_PORT). The metrics_port alias will be removed in a future release.",
 			"metrics_port", cfg.Server.MetricsPort,
 		)

--- a/internal/config/loader_logging_test.go
+++ b/internal/config/loader_logging_test.go
@@ -189,3 +189,40 @@ func TestLoad_NoDeprecationWarningForOpsPort(t *testing.T) {
 		t.Errorf("did not expect deprecation warning when using ops_port, got:\n%s", out)
 	}
 }
+
+func TestLoad_LogsMetricsPortDeprecation_FromEnv(t *testing.T) {
+	var buf bytes.Buffer
+	logger := testLogger(&buf)
+
+	t.Setenv("BLOGFLOW_SERVER_METRICS_PORT", "9090")
+	fsys := fstest.MapFS{}
+	loader := NewLoader(fsys, WithLogger(logger))
+	if _, err := loader.Load(); err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "metrics_port is deprecated") {
+		t.Errorf("expected metrics_port deprecation warning from env, got:\n%s", out)
+	}
+}
+
+func TestLoad_NoDeprecationWarningWhenOpsPortAlsoSet(t *testing.T) {
+	var buf bytes.Buffer
+	logger := testLogger(&buf)
+
+	// Same value for both — a valid belt-and-suspenders migration state; the
+	// user is already on the canonical ops_port, so no deprecation nudge.
+	fsys := fstest.MapFS{
+		"site.yaml": &fstest.MapFile{Data: []byte("server:\n  ops_port: 8081\n  metrics_port: 8081\n")},
+	}
+	loader := NewLoader(fsys, WithLogger(logger))
+	if _, err := loader.Load(); err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "metrics_port is deprecated") {
+		t.Errorf("did not expect deprecation warning when ops_port is set, got:\n%s", out)
+	}
+}

--- a/internal/config/loader_logging_test.go
+++ b/internal/config/loader_logging_test.go
@@ -153,3 +153,39 @@ func TestLoad_NilLoggerDoesNotPanic(t *testing.T) {
 		t.Fatalf("Load() error: %v", err)
 	}
 }
+
+func TestLoad_LogsMetricsPortDeprecation(t *testing.T) {
+	var buf bytes.Buffer
+	logger := testLogger(&buf)
+
+	fsys := fstest.MapFS{
+		"site.yaml": &fstest.MapFile{Data: []byte("server:\n  metrics_port: 9090\n")},
+	}
+	loader := NewLoader(fsys, WithLogger(logger))
+	if _, err := loader.Load(); err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "metrics_port is deprecated") {
+		t.Errorf("expected metrics_port deprecation warning, got:\n%s", out)
+	}
+}
+
+func TestLoad_NoDeprecationWarningForOpsPort(t *testing.T) {
+	var buf bytes.Buffer
+	logger := testLogger(&buf)
+
+	fsys := fstest.MapFS{
+		"site.yaml": &fstest.MapFile{Data: []byte("server:\n  ops_port: 8081\n")},
+	}
+	loader := NewLoader(fsys, WithLogger(logger))
+	if _, err := loader.Load(); err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "metrics_port is deprecated") {
+		t.Errorf("did not expect deprecation warning when using ops_port, got:\n%s", out)
+	}
+}

--- a/internal/server/csp_coverage_test.go
+++ b/internal/server/csp_coverage_test.go
@@ -121,18 +121,18 @@ func TestCSPOnSeparateMetricsPort(t *testing.T) {
 	}
 }
 
-// TestCSPViaMiddlewareOnMetricsServer verifies that the dedicated metrics
+// TestCSPViaMiddlewareOnOpsServer verifies that the dedicated ops
 // port also carries security headers (CSP, X-Frame-Options, etc.) via the
 // same middleware chain as the main server.
-func TestCSPViaMiddlewareOnMetricsServer(t *testing.T) {
+func TestCSPViaMiddlewareOnOpsServer(t *testing.T) {
 	t.Parallel()
 	cfg := defaultTestConfig()
 	cfg.Server.MetricsPort = 9090
 	s := New(cfg, nil)
 
-	ms := s.MetricsServer()
+	ms := s.OpsServer()
 	if ms == nil {
-		t.Fatal("MetricsServer() should not be nil when MetricsPort > 0")
+		t.Fatal("OpsServer() should not be nil when MetricsPort > 0")
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -72,14 +72,14 @@ func New(cfg *config.Config, logger *slog.Logger) *Server {
 		IdleTimeout:       cfg.Server.IdleTimeout,
 	}
 
-	if cfg.Server.EffectiveOpsPort() > 0 {
+	if opsPort := cfg.Server.EffectiveOpsPort(); opsPort > 0 {
 		metricsMux := http.NewServeMux()
 		metricsMux.Handle("GET /metrics", MetricsHandler())
 		metricsMux.HandleFunc("GET /healthz", s.healthHandler)
 		metricsMux.HandleFunc("GET /readyz", s.readyHandler)
 		metricsMux.HandleFunc("GET /readyz/content", s.contentReadyHandler)
 		s.metricsServer = &http.Server{
-			Addr:              fmt.Sprintf(":%d", cfg.Server.EffectiveOpsPort()),
+			Addr:              fmt.Sprintf(":%d", opsPort),
 			Handler:           s.middleware(metricsMux),
 			ReadTimeout:       cfg.Server.ReadTimeout,
 			ReadHeaderTimeout: 5 * time.Second,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,7 +30,7 @@ type ContentChecker interface {
 // Server is the BlogFlow HTTP server.
 type Server struct {
 	httpServer     *http.Server
-	metricsServer  *http.Server // ops/observability listener; nil when no ops port is configured
+	opsServer      *http.Server // ops/observability listener; nil when no ops port is configured
 	mux            *http.ServeMux
 	config         *config.Config
 	logger         *slog.Logger
@@ -73,14 +73,14 @@ func New(cfg *config.Config, logger *slog.Logger) *Server {
 	}
 
 	if opsPort := cfg.Server.EffectiveOpsPort(); opsPort > 0 {
-		metricsMux := http.NewServeMux()
-		metricsMux.Handle("GET /metrics", MetricsHandler())
-		metricsMux.HandleFunc("GET /healthz", s.healthHandler)
-		metricsMux.HandleFunc("GET /readyz", s.readyHandler)
-		metricsMux.HandleFunc("GET /readyz/content", s.contentReadyHandler)
-		s.metricsServer = &http.Server{
+		opsMux := http.NewServeMux()
+		opsMux.Handle("GET /metrics", MetricsHandler())
+		opsMux.HandleFunc("GET /healthz", s.healthHandler)
+		opsMux.HandleFunc("GET /readyz", s.readyHandler)
+		opsMux.HandleFunc("GET /readyz/content", s.contentReadyHandler)
+		s.opsServer = &http.Server{
 			Addr:              fmt.Sprintf(":%d", opsPort),
-			Handler:           s.middleware(metricsMux),
+			Handler:           s.middleware(opsMux),
 			ReadTimeout:       cfg.Server.ReadTimeout,
 			ReadHeaderTimeout: 5 * time.Second,
 			WriteTimeout:      cfg.Server.WriteTimeout,
@@ -151,7 +151,7 @@ func (s *Server) RegisterRoutes(opts RouteOptions) {
 	s.mux.HandleFunc("GET /sitemap.xml", opts.SitemapHandler)
 
 	// Health checks. When PrivateHealth is set these are served only on the
-	// internal metrics/ops port (see New) and are removed from the public
+	// internal ops port (see New) and are removed from the public
 	// listener so they cannot be reached or flooded from the internet.
 	if !s.config.Server.PrivateHealth {
 		s.mux.HandleFunc("GET /healthz", s.healthHandler)
@@ -218,19 +218,19 @@ func (s *Server) Serve(ln net.Listener) error {
 }
 
 // Shutdown gracefully stops the server with the given context deadline.
-// If a separate metrics server is running, both servers are shut down
+// If a separate ops server is running, both servers are shut down
 // concurrently so that one cannot consume the other's timeout budget.
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.logger.Info("server shutting down")
 
-	var metricsErr error
+	var opsErr error
 	var wg sync.WaitGroup
-	if s.metricsServer != nil {
+	if s.opsServer != nil {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if err := s.metricsServer.Shutdown(ctx); err != nil {
-				metricsErr = fmt.Errorf("metrics server: %w", err)
+			if err := s.opsServer.Shutdown(ctx); err != nil {
+				opsErr = fmt.Errorf("ops server: %w", err)
 			}
 		}()
 	}
@@ -240,32 +240,32 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		mainErr = fmt.Errorf("main server: %w", err)
 	}
 	wg.Wait()
-	return errors.Join(mainErr, metricsErr)
+	return errors.Join(mainErr, opsErr)
 }
 
-// StartMetrics starts the metrics server on its dedicated port.
-// Returns nil immediately if no separate metrics port is configured.
-// Blocks until the metrics server stops.
-func (s *Server) StartMetrics() error {
-	if s.metricsServer == nil {
+// StartOps starts the ops server on its dedicated port.
+// Returns nil immediately if no separate ops port is configured.
+// Blocks until the ops server stops.
+func (s *Server) StartOps() error {
+	if s.opsServer == nil {
 		return nil
 	}
-	addr := s.metricsServer.Addr
+	addr := s.opsServer.Addr
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
-		return fmt.Errorf("metrics server: %w", err)
+		return fmt.Errorf("ops server: %w", err)
 	}
-	s.logger.Info("metrics server listening", "addr", ln.Addr().String())
-	if err := s.metricsServer.Serve(ln); err != nil && err != http.ErrServerClosed {
-		return fmt.Errorf("metrics server: %w", err)
+	s.logger.Info("ops server listening", "addr", ln.Addr().String())
+	if err := s.opsServer.Serve(ln); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("ops server: %w", err)
 	}
 	return nil
 }
 
-// MetricsServer returns the dedicated metrics *http.Server, or nil
-// if metrics are served on the main port.
-func (s *Server) MetricsServer() *http.Server {
-	return s.metricsServer
+// OpsServer returns the dedicated ops *http.Server, or nil
+// if ops endpoints are served on the main port.
+func (s *Server) OpsServer() *http.Server {
+	return s.opsServer
 }
 
 // IPResolver returns the server's ClientIPResolver, which resolves the

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,7 +30,7 @@ type ContentChecker interface {
 // Server is the BlogFlow HTTP server.
 type Server struct {
 	httpServer     *http.Server
-	metricsServer  *http.Server // nil when MetricsPort == 0
+	metricsServer  *http.Server // ops/observability listener; nil when no ops port is configured
 	mux            *http.ServeMux
 	config         *config.Config
 	logger         *slog.Logger
@@ -72,14 +72,14 @@ func New(cfg *config.Config, logger *slog.Logger) *Server {
 		IdleTimeout:       cfg.Server.IdleTimeout,
 	}
 
-	if cfg.Server.MetricsPort > 0 {
+	if cfg.Server.EffectiveOpsPort() > 0 {
 		metricsMux := http.NewServeMux()
 		metricsMux.Handle("GET /metrics", MetricsHandler())
 		metricsMux.HandleFunc("GET /healthz", s.healthHandler)
 		metricsMux.HandleFunc("GET /readyz", s.readyHandler)
 		metricsMux.HandleFunc("GET /readyz/content", s.contentReadyHandler)
 		s.metricsServer = &http.Server{
-			Addr:              fmt.Sprintf(":%d", cfg.Server.MetricsPort),
+			Addr:              fmt.Sprintf(":%d", cfg.Server.EffectiveOpsPort()),
 			Handler:           s.middleware(metricsMux),
 			ReadTimeout:       cfg.Server.ReadTimeout,
 			ReadHeaderTimeout: 5 * time.Second,
@@ -159,8 +159,8 @@ func (s *Server) RegisterRoutes(opts RouteOptions) {
 		s.mux.HandleFunc("GET /readyz/content", s.contentReadyHandler)
 	}
 
-	// Prometheus metrics: on main mux only when no separate metrics port is configured
-	if s.config.Server.MetricsPort == 0 {
+	// Prometheus metrics: on main mux only when no separate ops port is configured
+	if s.config.Server.EffectiveOpsPort() == 0 {
 		s.mux.Handle("GET /metrics", MetricsHandler())
 	}
 
@@ -280,7 +280,7 @@ func (s *Server) IPResolver() *ClientIPResolver {
 // tracing, logging or other middleware runs. This keeps floods to these paths
 // cheap (no span or access-log line per request) and ensures readiness state
 // is never exposed publicly. Orchestrator probes must target the internal
-// MetricsPort listener instead. When PrivateHealth is disabled it is a no-op.
+// ops-port listener instead. When PrivateHealth is disabled it is a no-op.
 //
 // The request path is normalized with path.Clean so slash variants such as
 // "/healthz/" or "//healthz" are intercepted cheaply rather than falling

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -990,6 +990,40 @@ func TestReadyzOnMetricsPort(t *testing.T) {
 	}
 }
 
+func TestHealthzOnOpsPort(t *testing.T) {
+	cfg := defaultTestConfig()
+	cfg.Server.OpsPort = 19095 // canonical ops port, no metrics_port alias
+
+	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	s.RegisterRoutes(testRouteOptions())
+	s.SetReady(true)
+
+	if s.metricsServer == nil {
+		t.Fatal("expected ops listener to be configured when ops_port is set")
+	}
+	if got := s.metricsServer.Addr; got != ":19095" {
+		t.Errorf("ops listener Addr = %q, want %q", got, ":19095")
+	}
+
+	// The ops listener serves metrics + health + readiness.
+	for _, p := range []string{"/healthz", "/readyz", "/metrics"} {
+		req := httptest.NewRequest(http.MethodGet, p, nil)
+		rec := httptest.NewRecorder()
+		s.metricsServer.Handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("ops %s: status = %d, want %d", p, rec.Code, http.StatusOK)
+		}
+	}
+
+	// When a separate ops port is configured, /metrics is not on the main mux.
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("main /metrics: status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
 func TestMetricsServer_NilWhenPortZero(t *testing.T) {
 	cfg := defaultTestConfig()
 	cfg.Server.MetricsPort = 0

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -765,11 +765,11 @@ func TestMetricsOnSeparatePort(t *testing.T) {
 	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	s.RegisterRoutes(testRouteOptions())
 
-	if s.MetricsServer() == nil {
-		t.Fatal("MetricsServer() should not be nil when MetricsPort > 0")
+	if s.OpsServer() == nil {
+		t.Fatal("OpsServer() should not be nil when MetricsPort > 0")
 	}
 
-	// Start the metrics server on a random port
+	// Start the ops server on a random port
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to listen: %v", err)
@@ -777,7 +777,7 @@ func TestMetricsOnSeparatePort(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- s.metricsServer.Serve(ln)
+		errCh <- s.opsServer.Serve(ln)
 	}()
 
 	// Make a request through the main server first so blogflow_http_requests_total
@@ -806,14 +806,14 @@ func TestMetricsOnSeparatePort(t *testing.T) {
 		t.Error("/metrics body missing expected BlogFlow metric blogflow_http_requests_total")
 	}
 
-	// Shut down metrics server
+	// Shut down ops server
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	if err := s.metricsServer.Shutdown(ctx); err != nil {
-		t.Fatalf("metrics server shutdown error: %v", err)
+	if err := s.opsServer.Shutdown(ctx); err != nil {
+		t.Fatalf("ops server shutdown error: %v", err)
 	}
 	if err := <-errCh; err != nil && err != http.ErrServerClosed {
-		t.Fatalf("metrics server returned unexpected error: %v", err)
+		t.Fatalf("ops server returned unexpected error: %v", err)
 	}
 }
 
@@ -824,7 +824,7 @@ func TestHealthzOnMetricsPort(t *testing.T) {
 	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	s.RegisterRoutes(testRouteOptions())
 
-	// Start metrics server on a random port
+	// Start ops server on a random port
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to listen: %v", err)
@@ -832,7 +832,7 @@ func TestHealthzOnMetricsPort(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- s.metricsServer.Serve(ln)
+		errCh <- s.opsServer.Serve(ln)
 	}()
 
 	// /healthz should be available on the metrics port
@@ -863,11 +863,11 @@ func TestHealthzOnMetricsPort(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	if err := s.metricsServer.Shutdown(ctx); err != nil {
-		t.Fatalf("metrics server shutdown error: %v", err)
+	if err := s.opsServer.Shutdown(ctx); err != nil {
+		t.Fatalf("ops server shutdown error: %v", err)
 	}
 	if err := <-errCh; err != nil && err != http.ErrServerClosed {
-		t.Fatalf("metrics server returned unexpected error: %v", err)
+		t.Fatalf("ops server returned unexpected error: %v", err)
 	}
 }
 
@@ -939,7 +939,7 @@ func TestPrivateHealth(t *testing.T) {
 	for _, c := range checks {
 		req := httptest.NewRequest(http.MethodGet, c.path, nil)
 		rec := httptest.NewRecorder()
-		s.metricsServer.Handler.ServeHTTP(rec, req)
+		s.opsServer.Handler.ServeHTTP(rec, req)
 		if rec.Code != c.want {
 			t.Errorf("ops %s: status = %d, want %d", c.path, rec.Code, c.want)
 		}
@@ -975,7 +975,7 @@ func TestReadyzOnMetricsPort(t *testing.T) {
 	for _, c := range cases {
 		req := httptest.NewRequest(http.MethodGet, c.path, nil)
 		rec := httptest.NewRecorder()
-		s.metricsServer.Handler.ServeHTTP(rec, req)
+		s.opsServer.Handler.ServeHTTP(rec, req)
 		if rec.Code != c.want {
 			t.Errorf("metrics %s: status = %d, want %d", c.path, rec.Code, c.want)
 		}
@@ -998,10 +998,10 @@ func TestHealthzOnOpsPort(t *testing.T) {
 	s.RegisterRoutes(testRouteOptions())
 	s.SetReady(true)
 
-	if s.metricsServer == nil {
+	if s.opsServer == nil {
 		t.Fatal("expected ops listener to be configured when ops_port is set")
 	}
-	if got := s.metricsServer.Addr; got != ":19095" {
+	if got := s.opsServer.Addr; got != ":19095" {
 		t.Errorf("ops listener Addr = %q, want %q", got, ":19095")
 	}
 
@@ -1009,7 +1009,7 @@ func TestHealthzOnOpsPort(t *testing.T) {
 	for _, p := range []string{"/healthz", "/readyz", "/metrics"} {
 		req := httptest.NewRequest(http.MethodGet, p, nil)
 		rec := httptest.NewRecorder()
-		s.metricsServer.Handler.ServeHTTP(rec, req)
+		s.opsServer.Handler.ServeHTTP(rec, req)
 		if rec.Code != http.StatusOK {
 			t.Errorf("ops %s: status = %d, want %d", p, rec.Code, http.StatusOK)
 		}
@@ -1024,25 +1024,25 @@ func TestHealthzOnOpsPort(t *testing.T) {
 	}
 }
 
-func TestMetricsServer_NilWhenPortZero(t *testing.T) {
+func TestOpsServer_NilWhenPortZero(t *testing.T) {
 	cfg := defaultTestConfig()
 	cfg.Server.MetricsPort = 0
 
 	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
-	if s.MetricsServer() != nil {
-		t.Error("MetricsServer() should be nil when MetricsPort is 0")
+	if s.OpsServer() != nil {
+		t.Error("OpsServer() should be nil when MetricsPort is 0")
 	}
 }
 
-func TestStartMetrics_NilWhenPortZero(t *testing.T) {
+func TestStartOps_NilWhenPortZero(t *testing.T) {
 	cfg := defaultTestConfig()
 	cfg.Server.MetricsPort = 0
 
 	s := New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
-	// StartMetrics should return nil immediately when no metrics server
-	if err := s.StartMetrics(); err != nil {
-		t.Errorf("StartMetrics() = %v, want nil", err)
+	// StartOps should return nil immediately when no ops server
+	if err := s.StartOps(); err != nil {
+		t.Errorf("StartOps() = %v, want nil", err)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #284. Renames `server.metrics_port` to **`server.ops_port`** to reflect its dual role — it serves `/metrics`, `/healthz`, `/readyz`, and `/readyz/content`, and is the port orchestrator probes target when `private_health` is enabled. `metrics_port` remains a **backward-compatible, deprecated alias**.

Surfaced as non-blocking naming tech-debt by the review council on #283.

## Changes

**Config (`internal/config`)**
- New canonical `ServerConfig.OpsPort` (`yaml:"ops_port"`, env `BLOGFLOW_SERVER_OPS_PORT`).
- `MetricsPort` / `metrics_port` / `BLOGFLOW_SERVER_METRICS_PORT` kept as a deprecated alias.
- `EffectiveOpsPort()` accessor resolves `OpsPort` first, falling back to the alias.
- Deprecation **warning logged at load** when `metrics_port` is set.
- Validation: range + must-differ-from-port applied to the effective port (error field reflects whichever key was set); **conflict error** if `ops_port` and `metrics_port` are set to different values; `private_health` requires the effective ops port.

**Runtime**
- `server.go`, `main.go`, `cmd/blogflow/healthcheck.go` all resolve the ops port via `EffectiveOpsPort()` / the `OPS_PORT` env (metrics as fallback).

**Infra & docs**
- Azure bicep: `BLOGFLOW_SERVER_OPS_PORT`.
- Helm: new `service.opsPort` (writes `ops_port`); `service.metricsPort` still works (writes `metrics_port`). Rendering verified for both paths.
- Example config, deployment guide, config design doc, and CHANGELOG updated.

## Backward compatibility

- Existing deployments setting `metrics_port` / `BLOGFLOW_SERVER_METRICS_PORT` / `service.metricsPort` keep working unchanged (with a deprecation warning). No behavior change.
- Setting both `ops_port` and `metrics_port` to **different** values is rejected (ambiguous); identical values are accepted.

## Note (intentionally out of scope)

Internal server method/field names (`StartMetrics()`, `MetricsServer()`, `metricsServer`) are left as-is to keep this change focused on the user-facing config surface. They can be renamed in a follow-up if desired.

## Acceptance criteria

- [x] `ops_port` / `BLOGFLOW_SERVER_OPS_PORT` is the canonical name
- [x] `metrics_port` alias honored with a deprecation notice
- [x] Strict config parsing (`KnownFields(true)`) accepts both keys
- [x] Docs consistently use "ops port"

## Test & validation

- `go build ./...`, `go vet ./...`, `golangci-lint run` — clean.
- `go test ./internal/config/... ./internal/server/... ./cmd/blogflow/...` — pass. New tests: `EffectiveOpsPort` resolution, `ops_port` validation (range/same-as-port/conflict/equal-alias), env override + invalid, deprecation-warning logging, `TestHealthzOnOpsPort`, healthcheck ops-port targeting. Existing `metrics_port` tests remain green (alias fallback).
- `az bicep build` — OK. `helm template` — renders `ops_port` (opsPort) and `metrics_port` (metricsPort) correctly.

---

**Update — folded in #286 (no further deferrals):** This PR now also completes #286: the internal ops-listener rename (`metricsServer`→`opsServer`, `StartMetrics`→`StartOps`, `MetricsServer`→`OpsServer`; `internal` pkg, no external impact) and the `metrics_port` alias **removal timeline** (scheduled for v1.0.0, with migration steps in the deployment guide). The `/metrics` endpoint handler + Prometheus request-metrics middleware keep their names (genuinely metrics).

Closes #286.
