### PR TITLE
chore(release): prepare v0.5.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+## 0.5.0 / 2026-07-30
+
 ### BlogFlow
 
 * [FEATURE] search: optional server-rendered full-text search (no JavaScript). Enable with `search.enabled: true`; adds `GET /search?q=&page=` with a Unicode-normalized tokenizer, a bounded in-memory inverted index (`max_docs`/`max_tokens`/`max_index_bytes` caps), deterministic weighted TF-IDF ranking, plain-text excerpts, accessible default-theme templates (`search.html` + `search-result`/`search-pagination` partials, conditional header search box), and `blogflow_search_*` metrics. Content and search publish atomically in one snapshot generation. #280
@@ -29,6 +31,10 @@
 ### Testing
 
 * [ENHANCEMENT] Add test coverage for gap-analysis items #217–#235: CSP headers on non-HTML responses, symlink-escape detection, IP allowlist (bare IP + CIDR), webhook secret-length bounds, environment-override validation, and overlay-FS behaviors. #237
+
+### Dependencies
+
+* [BUGFIX] Deps: bump `google.golang.org/grpc` from `v1.81.1` to `v1.83.0` to resolve `GHSA-hrxh-6v49-42gf` and unblock the Publish Trivy gate. #287
 
 ## 0.4.1 / 2026-05-18
 

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.83.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.83.0 h1:JeNZEKJFbQxArAMl+hiytHauacDNqJUllNfmIMmpqnQ=
+google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Summary: promote unreleased entries into 0.5.0 / 2026-07-30 and add missing grpc security changelog entry for #287. Tagging is deferred until merge. Post-merge: git checkout main; git pull --ff-only; git tag -a v0.5.0 -m 'Release v0.5.0'; git push origin v0.5.0